### PR TITLE
Add manual configuration for CoreOS images.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 # After unpacking, there should be one service account key file for every GCP
 # project referenced in the "deploy" section. These keys authenticate the
 # gcloud deploy operations.
-- travis/decrypt.sh "$encrypted_af2ac69618ed_iv" "$encrypted_af2ac69618ed_key"
+- travis/decrypt.sh "$encrypted_af2ac69618ed_key" "$encrypted_af2ac69618ed_iv"
   keys/service-accounts.tar.enc /tmp/service-accounts.tar /tmp
 
 # These directories will be cached on successful "script" builds, and restored,

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 # After unpacking, there should be one service account key file for every GCP
 # project referenced in the "deploy" section. These keys authenticate the
 # gcloud deploy operations.
-- travis/decrypt.sh $encrypted_af2ac69618ed_iv $encrypted_af2ac69618ed_key
+- travis/decrypt.sh "$encrypted_af2ac69618ed_iv" "$encrypted_af2ac69618ed_key"
   keys/service-accounts.tar.enc /tmp/service-accounts.tar /tmp
 
 # These directories will be cached on successful "script" builds, and restored,

--- a/manual/coreos-manual/README.md
+++ b/manual/coreos-manual/README.md
@@ -1,9 +1,10 @@
 ## Customize CoreOS images
 
 The `customize_coreos_pxe_image.sh` script will download the latest stable
-CoreOS images and generate a customized version by adding the provide cloud
+CoreOS images and generate a customized version by adding the provided cloud
 config file to /usr/share/oem/cloud-config.yml
 
+You must specify absolute paths.
 ```
 $ ./customize_coreos_pxe_image.sh \
     $PWD/cloud-config-mlab1-lga0t.yml \

--- a/manual/coreos-manual/README.md
+++ b/manual/coreos-manual/README.md
@@ -1,0 +1,23 @@
+## Customize CoreOS images
+
+The `customize_coreos_pxe_image.sh` script will download the latest stable
+CoreOS images and generate a customized version by adding the provide cloud
+config file to /usr/share/oem/cloud-config.yml
+
+```
+$ ./customize_coreos_pxe_image.sh \
+    $PWD/cloud-config-mlab1-lga0t.yml \
+    $PWD/coreos_mlab1.lga0t.measurement-lab.org_pxe_image.cpio.gz
+```
+
+After generating these images, upload the new cpio files and the vmlinuz image
+to gs://epoxy-mlab-staging/coreos-manual/.
+
+NOTE: The CoreOS kernel and cpio image must be updated at the same time.
+Mismatched version will fail to boot or behave incorrectly.
+
+```
+  coreos_mlab1.lga0t.measurement-lab.org_pxe_image.cpio.gz
+  coreos_mlab2.lga0t.measurement-lab.org_pxe_image.cpio.gz
+  coreos_production_pxe.vmlinuz
+```

--- a/manual/coreos-manual/cloud-config-mlab1-lga0t.yml
+++ b/manual/coreos-manual/cloud-config-mlab1-lga0t.yml
@@ -1,0 +1,39 @@
+#cloud-config
+
+coreos:
+  units:
+    - name: systemd-networkd.service
+      command: stop
+    # TODO: Replace with a unit that reads epoxy.ip= from /proc/cmdline.
+    - name: 00-eth0.network
+      runtime: true
+      content: |
+        [Match]
+        Name=eth0
+
+        [Network]
+        Address=4.14.159.73/26
+        Gateway=4.14.159.65
+        DNS=8.8.8.8
+        DNS=8.8.4.4
+    - name: down-interfaces.service
+      command: start
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/ip link set eth0 down
+        ExecStart=/usr/bin/ip addr flush dev eth0
+    - name: systemd-networkd.service
+      command: restart
+
+ssh_authorized_keys:
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvIKeMHcEO1xnTmEdMY6E9Y4pBdGBCDXZnuQC5ZPjNQr9IG3ytw0OxwyCObAzSr+WOymYv6Cwm4Ckz2jc/bWygzWJH+DMdldZe7HVQu4YxuegqahIkB0D1OzaZGNctBgTp9bmpWGxyek7U8ff7GTiFqhcms4Oer4rdd0gqUhmv3LnRWQqrIDblrBosHBED/zXgjbOj3beWCA3xHDCaui/gkbmp0J2jzCnlsc7eSI0d6Jro2UhbiS2ssxVQsLViLh5okJJeb2JyzbLbcpselUg9DSwSk0pFH/wHL0usjvBisF/fEP8eQ1svq6N6gncvPlgoJaSvtACmDvIFkU4baA2v pboothe@pboothe3.nyc.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6z89QMvbWXy3Xv1AVF6D7DNlYLz9GEvpsLrvk5Mlq2Yq/N+EB64gYTEx1U5fu6CtL+Upu6G+eFfLqJ4n/UDIPOi09UxSUy0vee7W6iyO1Wl/gKiQlOex6dDK4H7NSHzBMZW6RhDkCHyxeG4+m6jv3RNYpSJ2V8qNSs18HjFCdG3o5UDNJDzNVsM3d/hFiD+b6iq7WLi2q4Rdh1lTqMS/1P5IyOFkasgEYmmaEIkSkYhtgDbLJIajiTsjDeWRh4ZUra+yKBYJToiE5oAsA0X1uppafNFzp5XXrmHc7reGACHPSZtJgIAAYgCVciD5AFnTthbH0WBw1XPQe6y8dEByh LavalleF@Techs-Air.naf.chambana.net"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDE0mkNqSerk77U6xy0/FpU+G7WdXboAvXPbK3xh5f1WCegNykjkCcgb+WVZeFudEKdMG2v3RisdKNWsRBAfAs5WLiszqQwSTDqBsjljq7vpE3BcqRIof2Tgf3fpyQ88A+KZIlCUBY8Z8NPUKXAgdhAwOmzM+IQDtX3XMQ67fPP3d5DraA0aaV5GCEZoxV+/V2X/JwhxsnaYuSvix4ow0l5pC5VxOSMatqcSLC37E7XMBY7o88C4RNuFQlwEjbwKRRFuBoZrCkjXK1F9AZDv8nzqnNO1MPf4vXkcNqL2k0PGulTDt+EIkschxirPqAU13WcBZzwdj+5LTbht7ttcAq9 mattmathis@mattmathis.mtv.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLUo2J3O0nMwlEZ7kDgYx6rHkpa1t6Z/GUQzzvOiJHgfWnQTzy0FxOMB0hDIlb+oXKbz+6URkXIlszBnhPSVVyjSDuw3LBD0WcV5N+g63u37fk+/4Ze9GFPzwBFX6NGw16KleI1pIX8s3gas6asLfJWXRgSDCXiN8ymFK88Lj0vPQBA+Lo8Gza7IGZbb2waGKUrZmrrMCk43DU5ZyRl8O6fKU4Mcs0CkYXOPvGt6WB/2Gaj2E9k9/qRmNzY5xzXcSz03fPbuc8s3wc2x73r4OaQcG6px89F68ftlo6wL8XLbegCP32ORDPccTIsmml1uee6Kve75fWoiCqLLzXLDLT steph@stephalarcon.org"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDcmNS78HLR2Q/22if7mT8yoICDQbk+wbHJqDAWWGui/V7HrzDZn9X2KtyxLPu6sdD3oohmZWYSQ9JVnIT/XQCCKrYiQt5Q/Jof4MG/evJnQEgNcmF6Cb6cFcG7dichGRiWqlNMwMG7GuvDXAsNQ/unrZFfeQTPHpKkDJkspcwxKH0+9fLgerLsJRlcAsyCb1AWtG8pwD2yKyispWhVCDKU1RbEfohxSj9tUcJJewXaiMGfn5T/t3dCLAx3zv3YrAtETAmRqfRwdztKevwqVTXU78rr9HRBwD2+YC0T0mdVUljeGhU3UzQlxSa4ZeIu1FimpyAv7jz1hu/hliQkl8BN nkinkade@npk"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/WS0rcnRQeSBnRf3IlTe+ynYjYXsErpc8DOkXGhhfzQdln7aayuT/d2autfL/TfACGV5X9ttWRIDN0k0UzqgbWwo6tlzrcm7jJgLahxdd4sdajdKeGdQtb772cZ867M2KbtU755s6WddstFNdSaK/3Pi/z3qXNSNjwNIhAmxUYLVqKYj8/kQEncQfx/K3wvRc0+gzvnuhQdKsw9DjUgLjFR+UnhZMbRdYW9LzGUyidcnxO/HNFJDihJhC6V5Eqk56hUyj7noiT4Q3HIr6MQDhzPLmlaZPSdQihO2sZlBSHcipT4bUOTqmDhfpjjkI+F+Mo1LhiU2DOelLK5lNP6gV gfr@gfr-macbookpro3.roam.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAsR0paNn6CG2et6U+B1mtClJhns00qEOc4/9idjzB/TwCB8Gx+8sGtiJYXpvLQekr1gU3CsFRFBxpjSBQ875BDCRd4/LYnChptv9inDlzF//W31k4ZWINqfOq0qoxfGpBu9jE0Yq2WypnDn9BNxKZdBjCbaIX+pxCx6ytkHmto/uix9exL1y+yQ7G85sjoXecfdsje0Mo8ZOO5ZYebEpKRhW3JhxKqklsK1SORa6WGnWySCy3dpj+XMRRrigKW0Mm4beqdl3e0b6pb3OwMtlgtBmgq246JLRnnasXCnEyQbN5DQStLPCgJGhuAoVuacGZryHTbrc4VL4d2JQfr1iJxQ== sstuart@sstuart.mtv.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDBsiVc59/cEXvB56hhFjqr189iw44nMtP8Hu6MgLaWCecjY/ICVrWN1rL0hmfyuXarYVyKcR5+81c+VJPT6zNUKiu+66TrqLex64ELyVZG0Meh9P+7VHO2is/iGBTUUfiXlvEqfALTdoUrmJdtfJSBSVtcGV2YfiHxoVdhj02nCpE90Ng6/cKr6omOEl4Ggbtx1oR0bUtBoEyg4P0XjqtuHCvSnp9lbWNXikT7m2yYAs340iDxSbS5vKN36RmprVCHwnXXp+sk6pNXG8d2EmbT+OIdvCZvW890EHtszU8Te8lOKti/ChNgM2hcAS4Gs9hyZnVtU2BlQ8LI/qV7Cm4fPeqCoHDC6Fdklh4LeBsfrOdrezS6se1xOef12WgZQqkv/v9gHAcF8QP1ZlsIoizmh8uuBlEdTaIJHZTMWlJGZtWWcjFKeT0APKjEVriZSKeJnvgN2QR89XMi9XdtISgh2zT5XNZLj7k9NrgMHlOs5DauYA025lTPhl9BTN0eChcCqIYfLE/jOWhFtLhoKoUkYvddY5h8wtDdHCmlXNg8nXtSRT/aqcGKYPRuCzHtneRt1oUc5Uzxpxr3GR9OGD06xaePUpcd082q0PZ04i37cfzhaM+ton047FCWvC3Wtdp8CYxW9Ouiqd4X2XRSpzz9pWTaUvJC0VxqpG1KohROpQ== critzo@buzzsaw"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDR5EylJIM/ZF9mSUwOSlysILS/rPfi/y6EvO19oOR+LrGmeATKFfFePKZrRD5TufNaGubxG1CeYUQ7ib50qYtivjfcf0eFJZtN3oEopLwbtihwD87Bv2jJX1YgRAMQ7Fh9FcwtOL4CdpCZ/VHe+EG32G2S9krn2SW1GifJWc/gBpb4S21igtpuQJoHAU/sxxxzEZWUm2BCUvoIQoCcwOqoor5DPB8hM4Jz0rM6uDO30EUO8YVjHr9cz8j8MA0WbLGjk7xfuIrx7SqHgoairC9s0N4AafHaKYzbvG/lz336wgpGC6gktAkHljUHnerwESF7ABTIh8iwKiq27HhO0hOt soltesz@stephens-imac-4.lan"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/+i34aBDtKSH7v67bsb1WTOg3hm+Zap45ASEwct4N87c3dwocAfXQeQIaTbSEV2px1zJKYowQnLq9YhJyyEdE5we/sbqJ+RIl+LX4vy1hK087/4fG0iG3k/bLQoy4zQZ74GdLN7rW53T6fKO9aRPc9F3vtIaX1JoqapY0Rbg9+K23P4biLjOKNQ5Y1U+Y7+psAvqEyrzBMgUGG3gfnHJ4HHWMkExEIaU9b0xNJlSQVBblQkioXE7DZ5MviLANLXrJhXgMXAzil/zo8/pcKevaULj6r6oWnAj7u5YnfuK0Wx7ADUYl8ageA/Ukzmm3bLCFXvhIcahOKxJBP2tncUIv yachang@yachang1.nyc.corp.google.com"

--- a/manual/coreos-manual/cloud-config-mlab2-lga0t.yml
+++ b/manual/coreos-manual/cloud-config-mlab2-lga0t.yml
@@ -1,0 +1,39 @@
+#cloud-config
+
+coreos:
+  units:
+    - name: systemd-networkd.service
+      command: stop
+    # TODO: Replace with a unit that reads epoxy.ip= from /proc/cmdline.
+    - name: 00-eth0.network
+      runtime: true
+      content: |
+        [Match]
+        Name=eth0
+
+        [Network]
+        Address=4.14.159.86/26
+        Gateway=4.14.159.65
+        DNS=8.8.8.8
+        DNS=8.8.4.4
+    - name: down-interfaces.service
+      command: start
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/ip link set eth0 down
+        ExecStart=/usr/bin/ip addr flush dev eth0
+    - name: systemd-networkd.service
+      command: restart
+
+ssh_authorized_keys:
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvIKeMHcEO1xnTmEdMY6E9Y4pBdGBCDXZnuQC5ZPjNQr9IG3ytw0OxwyCObAzSr+WOymYv6Cwm4Ckz2jc/bWygzWJH+DMdldZe7HVQu4YxuegqahIkB0D1OzaZGNctBgTp9bmpWGxyek7U8ff7GTiFqhcms4Oer4rdd0gqUhmv3LnRWQqrIDblrBosHBED/zXgjbOj3beWCA3xHDCaui/gkbmp0J2jzCnlsc7eSI0d6Jro2UhbiS2ssxVQsLViLh5okJJeb2JyzbLbcpselUg9DSwSk0pFH/wHL0usjvBisF/fEP8eQ1svq6N6gncvPlgoJaSvtACmDvIFkU4baA2v pboothe@pboothe3.nyc.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC6z89QMvbWXy3Xv1AVF6D7DNlYLz9GEvpsLrvk5Mlq2Yq/N+EB64gYTEx1U5fu6CtL+Upu6G+eFfLqJ4n/UDIPOi09UxSUy0vee7W6iyO1Wl/gKiQlOex6dDK4H7NSHzBMZW6RhDkCHyxeG4+m6jv3RNYpSJ2V8qNSs18HjFCdG3o5UDNJDzNVsM3d/hFiD+b6iq7WLi2q4Rdh1lTqMS/1P5IyOFkasgEYmmaEIkSkYhtgDbLJIajiTsjDeWRh4ZUra+yKBYJToiE5oAsA0X1uppafNFzp5XXrmHc7reGACHPSZtJgIAAYgCVciD5AFnTthbH0WBw1XPQe6y8dEByh LavalleF@Techs-Air.naf.chambana.net"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDE0mkNqSerk77U6xy0/FpU+G7WdXboAvXPbK3xh5f1WCegNykjkCcgb+WVZeFudEKdMG2v3RisdKNWsRBAfAs5WLiszqQwSTDqBsjljq7vpE3BcqRIof2Tgf3fpyQ88A+KZIlCUBY8Z8NPUKXAgdhAwOmzM+IQDtX3XMQ67fPP3d5DraA0aaV5GCEZoxV+/V2X/JwhxsnaYuSvix4ow0l5pC5VxOSMatqcSLC37E7XMBY7o88C4RNuFQlwEjbwKRRFuBoZrCkjXK1F9AZDv8nzqnNO1MPf4vXkcNqL2k0PGulTDt+EIkschxirPqAU13WcBZzwdj+5LTbht7ttcAq9 mattmathis@mattmathis.mtv.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDLUo2J3O0nMwlEZ7kDgYx6rHkpa1t6Z/GUQzzvOiJHgfWnQTzy0FxOMB0hDIlb+oXKbz+6URkXIlszBnhPSVVyjSDuw3LBD0WcV5N+g63u37fk+/4Ze9GFPzwBFX6NGw16KleI1pIX8s3gas6asLfJWXRgSDCXiN8ymFK88Lj0vPQBA+Lo8Gza7IGZbb2waGKUrZmrrMCk43DU5ZyRl8O6fKU4Mcs0CkYXOPvGt6WB/2Gaj2E9k9/qRmNzY5xzXcSz03fPbuc8s3wc2x73r4OaQcG6px89F68ftlo6wL8XLbegCP32ORDPccTIsmml1uee6Kve75fWoiCqLLzXLDLT steph@stephalarcon.org"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDcmNS78HLR2Q/22if7mT8yoICDQbk+wbHJqDAWWGui/V7HrzDZn9X2KtyxLPu6sdD3oohmZWYSQ9JVnIT/XQCCKrYiQt5Q/Jof4MG/evJnQEgNcmF6Cb6cFcG7dichGRiWqlNMwMG7GuvDXAsNQ/unrZFfeQTPHpKkDJkspcwxKH0+9fLgerLsJRlcAsyCb1AWtG8pwD2yKyispWhVCDKU1RbEfohxSj9tUcJJewXaiMGfn5T/t3dCLAx3zv3YrAtETAmRqfRwdztKevwqVTXU78rr9HRBwD2+YC0T0mdVUljeGhU3UzQlxSa4ZeIu1FimpyAv7jz1hu/hliQkl8BN nkinkade@npk"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/WS0rcnRQeSBnRf3IlTe+ynYjYXsErpc8DOkXGhhfzQdln7aayuT/d2autfL/TfACGV5X9ttWRIDN0k0UzqgbWwo6tlzrcm7jJgLahxdd4sdajdKeGdQtb772cZ867M2KbtU755s6WddstFNdSaK/3Pi/z3qXNSNjwNIhAmxUYLVqKYj8/kQEncQfx/K3wvRc0+gzvnuhQdKsw9DjUgLjFR+UnhZMbRdYW9LzGUyidcnxO/HNFJDihJhC6V5Eqk56hUyj7noiT4Q3HIr6MQDhzPLmlaZPSdQihO2sZlBSHcipT4bUOTqmDhfpjjkI+F+Mo1LhiU2DOelLK5lNP6gV gfr@gfr-macbookpro3.roam.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAsR0paNn6CG2et6U+B1mtClJhns00qEOc4/9idjzB/TwCB8Gx+8sGtiJYXpvLQekr1gU3CsFRFBxpjSBQ875BDCRd4/LYnChptv9inDlzF//W31k4ZWINqfOq0qoxfGpBu9jE0Yq2WypnDn9BNxKZdBjCbaIX+pxCx6ytkHmto/uix9exL1y+yQ7G85sjoXecfdsje0Mo8ZOO5ZYebEpKRhW3JhxKqklsK1SORa6WGnWySCy3dpj+XMRRrigKW0Mm4beqdl3e0b6pb3OwMtlgtBmgq246JLRnnasXCnEyQbN5DQStLPCgJGhuAoVuacGZryHTbrc4VL4d2JQfr1iJxQ== sstuart@sstuart.mtv.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDBsiVc59/cEXvB56hhFjqr189iw44nMtP8Hu6MgLaWCecjY/ICVrWN1rL0hmfyuXarYVyKcR5+81c+VJPT6zNUKiu+66TrqLex64ELyVZG0Meh9P+7VHO2is/iGBTUUfiXlvEqfALTdoUrmJdtfJSBSVtcGV2YfiHxoVdhj02nCpE90Ng6/cKr6omOEl4Ggbtx1oR0bUtBoEyg4P0XjqtuHCvSnp9lbWNXikT7m2yYAs340iDxSbS5vKN36RmprVCHwnXXp+sk6pNXG8d2EmbT+OIdvCZvW890EHtszU8Te8lOKti/ChNgM2hcAS4Gs9hyZnVtU2BlQ8LI/qV7Cm4fPeqCoHDC6Fdklh4LeBsfrOdrezS6se1xOef12WgZQqkv/v9gHAcF8QP1ZlsIoizmh8uuBlEdTaIJHZTMWlJGZtWWcjFKeT0APKjEVriZSKeJnvgN2QR89XMi9XdtISgh2zT5XNZLj7k9NrgMHlOs5DauYA025lTPhl9BTN0eChcCqIYfLE/jOWhFtLhoKoUkYvddY5h8wtDdHCmlXNg8nXtSRT/aqcGKYPRuCzHtneRt1oUc5Uzxpxr3GR9OGD06xaePUpcd082q0PZ04i37cfzhaM+ton047FCWvC3Wtdp8CYxW9Ouiqd4X2XRSpzz9pWTaUvJC0VxqpG1KohROpQ== critzo@buzzsaw"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDR5EylJIM/ZF9mSUwOSlysILS/rPfi/y6EvO19oOR+LrGmeATKFfFePKZrRD5TufNaGubxG1CeYUQ7ib50qYtivjfcf0eFJZtN3oEopLwbtihwD87Bv2jJX1YgRAMQ7Fh9FcwtOL4CdpCZ/VHe+EG32G2S9krn2SW1GifJWc/gBpb4S21igtpuQJoHAU/sxxxzEZWUm2BCUvoIQoCcwOqoor5DPB8hM4Jz0rM6uDO30EUO8YVjHr9cz8j8MA0WbLGjk7xfuIrx7SqHgoairC9s0N4AafHaKYzbvG/lz336wgpGC6gktAkHljUHnerwESF7ABTIh8iwKiq27HhO0hOt soltesz@stephens-imac-4.lan"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/+i34aBDtKSH7v67bsb1WTOg3hm+Zap45ASEwct4N87c3dwocAfXQeQIaTbSEV2px1zJKYowQnLq9YhJyyEdE5we/sbqJ+RIl+LX4vy1hK087/4fG0iG3k/bLQoy4zQZ74GdLN7rW53T6fKO9aRPc9F3vtIaX1JoqapY0Rbg9+K23P4biLjOKNQ5Y1U+Y7+psAvqEyrzBMgUGG3gfnHJ4HHWMkExEIaU9b0xNJlSQVBblQkioXE7DZ5MviLANLXrJhXgMXAzil/zo8/pcKevaULj6r6oWnAj7u5YnfuK0Wx7ADUYl8ageA/Ukzmm3bLCFXvhIcahOKxJBP2tncUIv yachang@yachang1.nyc.corp.google.com"

--- a/manual/coreos-manual/customize_coreos_pxe_image.sh
+++ b/manual/coreos-manual/customize_coreos_pxe_image.sh
@@ -2,26 +2,26 @@
 
 set -e
 set -x
-# ORIGINAL=${1:?Please provide an unmodified CoreOS PXE CPIO image}
 CONFIG=${1:?Please provide a config file to copy into output image}
 OUTPUT=${2:?Please provide the name of the output image}
 
+# Download CoreOS images.
 URL=http://stable.release.core-os.net/amd64-usr/current
 curl -O ${URL}/coreos_production_pxe.vmlinuz
 curl -O ${URL}/coreos_production_pxe_image.cpio.gz
 
 
+# Unpack the cpio and squashfs image.
 ORIGINAL=$PWD/coreos_production_pxe_image.cpio.gz
 cp ${ORIGINAL} custom.cpio.gz
 mkdir -p initrd
 pushd initrd
     gzip -d --to-stdout ${ORIGINAL} | cpio -i
 popd
-
 sudo unsquashfs initrd/usr.squashfs
 sudo cp ${CONFIG} squashfs-root/share/oem/cloud-config.yml
 
-# Rebuild squashfs image and the cpio images.
+# Rebuild the squashfs and cpio image.
 sudo mksquashfs $PWD/squashfs-root initrd/usr.squashfs -noappend -always-use-fragments
 pushd initrd
   sudo find . | cpio -o -H newc | gzip > $OUTPUT

--- a/manual/coreos-manual/customize_coreos_pxe_image.sh
+++ b/manual/coreos-manual/customize_coreos_pxe_image.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+set -x
+# ORIGINAL=${1:?Please provide an unmodified CoreOS PXE CPIO image}
+CONFIG=${1:?Please provide a config file to copy into output image}
+OUTPUT=${2:?Please provide the name of the output image}
+
+URL=http://stable.release.core-os.net/amd64-usr/current
+curl -O ${URL}/coreos_production_pxe.vmlinuz
+curl -O ${URL}/coreos_production_pxe_image.cpio.gz
+
+
+ORIGINAL=$PWD/coreos_production_pxe_image.cpio.gz
+cp ${ORIGINAL} custom.cpio.gz
+mkdir -p initrd
+pushd initrd
+    gzip -d --to-stdout ${ORIGINAL} | cpio -i
+popd
+
+sudo unsquashfs initrd/usr.squashfs
+sudo cp ${CONFIG} squashfs-root/share/oem/cloud-config.yml
+
+# Rebuild squashfs image and the cpio images.
+sudo mksquashfs $PWD/squashfs-root initrd/usr.squashfs -noappend -always-use-fragments
+pushd initrd
+  sudo find . | cpio -o -H newc | gzip > $OUTPUT
+popd
+
+# Cleanup
+sudo rm -rf squashfs-root
+sudo rm -rf initrd


### PR DESCRIPTION
This change adds minimal support for generating custom coreos images with embedded "cloud-config.yml" files.

This is a "manual" configuration because the network configuration is specified explicitly rather than being discovered at boot time.

This directory should be deleted once it is no longer needed.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/5)
<!-- Reviewable:end -->
