### PR TITLE
Add generic builds for CoreOS images

### DIFF
--- a/coreos-generic/README.md
+++ b/coreos-generic/README.md
@@ -1,0 +1,29 @@
+## Customize CoreOS images
+
+The `customize_coreos_pxe_image.sh` script will download the latest stable
+CoreOS images and generate a customized version by adding the provided cloud
+config file to /usr/share/oem/cloud-config.yml
+
+You must run as root to guarantee that file permissions are preserved during the
+unpacking and repacking.
+```
+$ sudo ./customize_coreos_pxe_image.sh \
+    build/coreos_custom_pxe_image.cpio.gz
+```
+
+After downloading and generating these images, you should upload the new cpio
+files and the vmlinuz image to gs://epoxy-mlab-staging/coreos-generic/.
+
+The default cache timeout is 1h. If you need to iterate more often than once an
+hour, you must disable caching or you'll get the cached image during boot.
+
+```
+CACHE_CONTROL="Cache-Control:private, max-age=0, no-transform"
+gsutil -h "$CACHE_CONTROL" \
+    cp -r build/coreos_custom_pxe_image.cpio.gz \
+          build/coreos_production_pxe.vmlinuz \
+          gs://epoxy-mlab-staging/coreos-generic/
+```
+
+NOTE: The CoreOS kernel and cpio image must be updated at the same time.
+Mismatched versions may fail to boot or behave incorrectly.

--- a/coreos-generic/customize_coreos_pxe_image.sh
+++ b/coreos-generic/customize_coreos_pxe_image.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# customize_coreos_pxe_image.sh downloads the current stable coreos pxe images
+# and generates a modified image that embeds custom scripts and static
+# cloud-config.yml. These custom scripts conigure the static network IP and
+# allow for running a post-boot setup script.
+
+set -e
+set -x
+OUTPUT=${1:?Please provide the name of the output image}
+BASEDIR=$( dirname "${BASH_SOURCE[0]}" )
+
+# Convert relative path to an absolute path.
+BASEDIR=$( readlink -f $BASEDIR )
+OUTPUT=$( readlink -f $OUTPUT )
+
+# Download CoreOS images.
+URL=http://stable.release.core-os.net/amd64-usr/current
+pushd build
+  for file in coreos_production_pxe.vmlinuz \
+              coreos_production_pxe_image.cpio.gz ; do
+    test -f $file || curl -O ${URL}/${file}
+  done
+popd
+
+
+pushd build
+  # Unpack the cpio and squashfs image.
+  ORIGINAL=${PWD}/coreos_production_pxe_image.cpio.gz
+  mkdir -p initrd
+  pushd initrd
+      gzip -d --to-stdout ${ORIGINAL} | cpio -i
+  popd
+  unsquashfs initrd/usr.squashfs
+
+  # Copy resources to the "/usr/share/oem" directory.
+  cp -ar ${BASEDIR}/resources/* squashfs-root/share/oem/
+
+  # Rebuild the squashfs and cpio image.
+  mksquashfs squashfs-root initrd/usr.squashfs -noappend -always-use-fragments
+  pushd initrd
+    find . | cpio -o -H newc | gzip > "${OUTPUT}"
+  popd
+
+  # Cleanup
+  rm -rf squashfs-root
+  rm -rf initrd
+popd

--- a/coreos-generic/resources/cloud-config.yml
+++ b/coreos-generic/resources/cloud-config.yml
@@ -1,0 +1,57 @@
+#cloud-config
+
+coreos:
+  # TODO: during the image customization process, consider adding custom
+  # network handling units directly instead of this approach.
+  units:
+    # Stop networkd to prevent races with the following actions.
+    - name: systemd-networkd.service
+      command: stop
+
+    # Really make sure the interfaces are down.
+    - name: down-interfaces.service
+      command: start
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/bin/ip link set eth0 down
+        ExecStart=/usr/bin/ip addr flush dev eth0
+
+    # Generate a network config based on values from epoxy.ip= in /proc/cmdline.
+    - name: generate-eth0-config.service
+      command: start
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/share/oem/generate_network_config.sh /etc/systemd/network/00-eth0.network
+
+    # Restarts the networkd service using our new config.
+    - name: systemd-networkd.service
+      command: restart
+
+    # Add a new unit to run the post-boot script after the network is online.
+    - name: setup-after-boot.service
+      command: start
+      enable: true
+      content: |
+        [Unit]
+        Description=A post-boot setup command.
+        # Both directives are required.
+        # It is unclear why Requires= alone is not sufficient (but it isn't).
+        Requires=network-online.target
+        After=systemd-networkd-wait-online.service
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/share/oem/setup_after_boot.sh
+
+# TODO: collect list of ssh keys from a metadata service during post-boot setup.
+ssh_authorized_keys:
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvIKeMHcEO1xnTmEdMY6E9Y4pBdGBCDXZnuQC5ZPjNQr9IG3ytw0OxwyCObAzSr+WOymYv6Cwm4Ckz2jc/bWygzWJH+DMdldZe7HVQu4YxuegqahIkB0D1OzaZGNctBgTp9bmpWGxyek7U8ff7GTiFqhcms4Oer4rdd0gqUhmv3LnRWQqrIDblrBosHBED/zXgjbOj3beWCA3xHDCaui/gkbmp0J2jzCnlsc7eSI0d6Jro2UhbiS2ssxVQsLViLh5okJJeb2JyzbLbcpselUg9DSwSk0pFH/wHL0usjvBisF/fEP8eQ1svq6N6gncvPlgoJaSvtACmDvIFkU4baA2v pboothe@pboothe3.nyc.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDE0mkNqSerk77U6xy0/FpU+G7WdXboAvXPbK3xh5f1WCegNykjkCcgb+WVZeFudEKdMG2v3RisdKNWsRBAfAs5WLiszqQwSTDqBsjljq7vpE3BcqRIof2Tgf3fpyQ88A+KZIlCUBY8Z8NPUKXAgdhAwOmzM+IQDtX3XMQ67fPP3d5DraA0aaV5GCEZoxV+/V2X/JwhxsnaYuSvix4ow0l5pC5VxOSMatqcSLC37E7XMBY7o88C4RNuFQlwEjbwKRRFuBoZrCkjXK1F9AZDv8nzqnNO1MPf4vXkcNqL2k0PGulTDt+EIkschxirPqAU13WcBZzwdj+5LTbht7ttcAq9 mattmathis@mattmathis.mtv.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDcmNS78HLR2Q/22if7mT8yoICDQbk+wbHJqDAWWGui/V7HrzDZn9X2KtyxLPu6sdD3oohmZWYSQ9JVnIT/XQCCKrYiQt5Q/Jof4MG/evJnQEgNcmF6Cb6cFcG7dichGRiWqlNMwMG7GuvDXAsNQ/unrZFfeQTPHpKkDJkspcwxKH0+9fLgerLsJRlcAsyCb1AWtG8pwD2yKyispWhVCDKU1RbEfohxSj9tUcJJewXaiMGfn5T/t3dCLAx3zv3YrAtETAmRqfRwdztKevwqVTXU78rr9HRBwD2+YC0T0mdVUljeGhU3UzQlxSa4ZeIu1FimpyAv7jz1hu/hliQkl8BN nkinkade@npk"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/WS0rcnRQeSBnRf3IlTe+ynYjYXsErpc8DOkXGhhfzQdln7aayuT/d2autfL/TfACGV5X9ttWRIDN0k0UzqgbWwo6tlzrcm7jJgLahxdd4sdajdKeGdQtb772cZ867M2KbtU755s6WddstFNdSaK/3Pi/z3qXNSNjwNIhAmxUYLVqKYj8/kQEncQfx/K3wvRc0+gzvnuhQdKsw9DjUgLjFR+UnhZMbRdYW9LzGUyidcnxO/HNFJDihJhC6V5Eqk56hUyj7noiT4Q3HIr6MQDhzPLmlaZPSdQihO2sZlBSHcipT4bUOTqmDhfpjjkI+F+Mo1LhiU2DOelLK5lNP6gV gfr@gfr-macbookpro3.roam.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAsR0paNn6CG2et6U+B1mtClJhns00qEOc4/9idjzB/TwCB8Gx+8sGtiJYXpvLQekr1gU3CsFRFBxpjSBQ875BDCRd4/LYnChptv9inDlzF//W31k4ZWINqfOq0qoxfGpBu9jE0Yq2WypnDn9BNxKZdBjCbaIX+pxCx6ytkHmto/uix9exL1y+yQ7G85sjoXecfdsje0Mo8ZOO5ZYebEpKRhW3JhxKqklsK1SORa6WGnWySCy3dpj+XMRRrigKW0Mm4beqdl3e0b6pb3OwMtlgtBmgq246JLRnnasXCnEyQbN5DQStLPCgJGhuAoVuacGZryHTbrc4VL4d2JQfr1iJxQ== sstuart@sstuart.mtv.corp.google.com"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQDBsiVc59/cEXvB56hhFjqr189iw44nMtP8Hu6MgLaWCecjY/ICVrWN1rL0hmfyuXarYVyKcR5+81c+VJPT6zNUKiu+66TrqLex64ELyVZG0Meh9P+7VHO2is/iGBTUUfiXlvEqfALTdoUrmJdtfJSBSVtcGV2YfiHxoVdhj02nCpE90Ng6/cKr6omOEl4Ggbtx1oR0bUtBoEyg4P0XjqtuHCvSnp9lbWNXikT7m2yYAs340iDxSbS5vKN36RmprVCHwnXXp+sk6pNXG8d2EmbT+OIdvCZvW890EHtszU8Te8lOKti/ChNgM2hcAS4Gs9hyZnVtU2BlQ8LI/qV7Cm4fPeqCoHDC6Fdklh4LeBsfrOdrezS6se1xOef12WgZQqkv/v9gHAcF8QP1ZlsIoizmh8uuBlEdTaIJHZTMWlJGZtWWcjFKeT0APKjEVriZSKeJnvgN2QR89XMi9XdtISgh2zT5XNZLj7k9NrgMHlOs5DauYA025lTPhl9BTN0eChcCqIYfLE/jOWhFtLhoKoUkYvddY5h8wtDdHCmlXNg8nXtSRT/aqcGKYPRuCzHtneRt1oUc5Uzxpxr3GR9OGD06xaePUpcd082q0PZ04i37cfzhaM+ton047FCWvC3Wtdp8CYxW9Ouiqd4X2XRSpzz9pWTaUvJC0VxqpG1KohROpQ== critzo@buzzsaw"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDR5EylJIM/ZF9mSUwOSlysILS/rPfi/y6EvO19oOR+LrGmeATKFfFePKZrRD5TufNaGubxG1CeYUQ7ib50qYtivjfcf0eFJZtN3oEopLwbtihwD87Bv2jJX1YgRAMQ7Fh9FcwtOL4CdpCZ/VHe+EG32G2S9krn2SW1GifJWc/gBpb4S21igtpuQJoHAU/sxxxzEZWUm2BCUvoIQoCcwOqoor5DPB8hM4Jz0rM6uDO30EUO8YVjHr9cz8j8MA0WbLGjk7xfuIrx7SqHgoairC9s0N4AafHaKYzbvG/lz336wgpGC6gktAkHljUHnerwESF7ABTIh8iwKiq27HhO0hOt soltesz@stephens-imac-4.lan"
+ - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC/+i34aBDtKSH7v67bsb1WTOg3hm+Zap45ASEwct4N87c3dwocAfXQeQIaTbSEV2px1zJKYowQnLq9YhJyyEdE5we/sbqJ+RIl+LX4vy1hK087/4fG0iG3k/bLQoy4zQZ74GdLN7rW53T6fKO9aRPc9F3vtIaX1JoqapY0Rbg9+K23P4biLjOKNQ5Y1U+Y7+psAvqEyrzBMgUGG3gfnHJ4HHWMkExEIaU9b0xNJlSQVBblQkioXE7DZ5MviLANLXrJhXgMXAzil/zo8/pcKevaULj6r6oWnAj7u5YnfuK0Wx7ADUYl8ageA/Ukzmm3bLCFXvhIcahOKxJBP2tncUIv yachang@yachang1.nyc.corp.google.com"

--- a/coreos-generic/resources/generate_network_config.sh
+++ b/coreos-generic/resources/generate_network_config.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# generate_network_config.sh finds the epoxy.ip= kernel parameter, parses it and
+# writes a networkd configuration file for the static IP to the named file.
+# generate_network_config also sets the machine hostname.
+
+OUTPUT=${1:?Please provide the name for writing config file}
+
+# Extract the epoxy.ip= parameter from /proc/cmdline.
+#
+# For example:
+#   epoxy.ip=4.14.159.99::4.14.159.65:255.255.255.192:mlab3.lga0t.measurement-lab.org:eth0:off:8.8.8.8:8.8.4.4
+if [[ `cat /proc/cmdline` =~ epoxy.ip=([^ ]+) ]]; then
+    FIELDS=${BASH_REMATCH[1]}
+else
+    # Use default values for VM testing.
+    FIELDS="192.168.0.2::192.168.0.1:255.255.255.192:localhost:eth0:off:8.8.8.8:8.8.4.4"
+fi
+
+# Extract all helpful fields.
+IPV4ADDR=$( echo $FIELDS | awk -F: '{print $1}' )
+GATEWAY=$( echo $FIELDS | awk -F: '{print $3}' )
+HOSTNAME=$( echo $FIELDS | awk -F: '{print $5}' )
+DNS1=$( echo $FIELDS | awk -F: '{print $8}' )
+DNS2=$( echo $FIELDS | awk -F: '{print $9}' )
+
+# Note, we cannot set the hostname via networkd. Use hostnamectl instead.
+hostnamectl set-hostname ${HOSTNAME}
+
+# TODO: do not hardcode /26.
+# TODO: do not hardcode eth0.
+cat > ${OUTPUT} <<EOF
+[Match]
+Name=eth0
+
+[Network]
+Address=$IPV4ADDR/26
+Gateway=$GATEWAY
+DNS=$DNS1
+DNS=$DNS2
+EOF

--- a/coreos-generic/resources/setup_after_boot.sh
+++ b/coreos-generic/resources/setup_after_boot.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+#
+# setup_after_boot.sh will run after boot and only once the network is online.
+# The script runs as the root user.
+
+# TODO: do something useful.
+echo "After Boot Script!"
+date > /tmp/after_boot.success
+ifconfig >> /tmp/after_boot.success
+whoami >> /tmp/after_boot.success
+echo "ABS: success!"


### PR DESCRIPTION
This change adds a `coreos-generic` directory with supporting scripts for generating a custom coreos image that can be used interchangeably on machines booted with epoxy.

This change includes rudimentary support for 

The approach outlined here is not the final word on how we will do this. Instead, it is an initial generic version that will enable us to continue building on CoreOS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/7)
<!-- Reviewable:end -->
