### PR TITLE
Add update and flash ROM scripts to the stage3 update image

### DIFF
--- a/configs/stage3_mlxupdate/flashrom.sh
+++ b/configs/stage3_mlxupdate/flashrom.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# flashrom.sh accepts a ROM image and burns it to the local NIC. The NIC must
+# be one of ConnectX3 or ConnectX3-Pro models. And, the ROM image must have a
+# version strictly greater than the current version.
+#
+# For more detailed documentation on the MFT commands below, see:
+#   http://www.mellanox.com/related-docs/MFT/MFT_user_manual_4_4_0.pdf
+
+set -x
+set -e
+
+ROM=${1:?PXE ROM to burn to NIC}
+# TODO: is there a better way to identify models?
+if [[ -e /dev/mst/mt4099_pci_cr0 ]] ; then
+    # ConnectX3, model 4099/0x1003
+    DEV=/dev/mst/mt4099_pci_cr0
+elif [[ -e /dev/mst/mt4103_pci_cr0 ]] ; then
+    # ConnectX3-Pro, model 4103/0x1007
+    DEV=/dev/mst/mt4103_pci_cr0
+fi
+ERROR_DELAY=60
+PAUSE=5
+
+
+# Backup current ROM by "reading" the ROM (rrom) from the local device.
+flint --device "${DEV}" rrom current.mrom
+
+# "Query" the new and current ROM versions (qrom).
+NEW_VERSION=$( flint --image "${ROM}" qrom )
+CUR_VERSION=$( flint --image current.mrom qrom )
+
+echo "ROM Versions:"
+echo "   Currently installed: $CUR_VERSION"
+echo "   Updating to:         $NEW_VERSION"
+
+# TODO: We must permit rollback or reset, in which case, "NEW_VERSION" could be
+# less than or equal to "CUR_VERSION".
+if [[ ! "${NEW_VERSION}" > "${CUR_VERSION}" ]] ; then
+    echo "Oops! Current ROM version already matches new ROM version."
+    echo "Taking no action."
+    echo "Sleeping $ERROR_DELAY seconds..."
+    # TODO(soltesz): log everything.
+    sleep $ERROR_DELAY
+    exit 0
+fi
+
+# NOTE: This is required for configuring systems for the first time. These will
+# be a no-ops for previously-updated machines.
+# NOTE: port numbers start at 1.
+# NOTE: "BOOT_OPTION_ROM_EN" means enable the BIOS PXE option ROM on port 1.
+# NOTE: "LEGACY_BOOT_PROTOCOL" means use the "PXE" protocol when booting the
+#       option rom on port 1.
+echo "Setting device options to PXE boot on PORT 1."
+mlxconfig --dev "${DEV}" --yes --show_default set BOOT_OPTION_ROM_EN_P1=True
+mlxconfig --dev "${DEV}" --yes --show_default set LEGACY_BOOT_PROTOCOL_P1=PXE
+
+# For debugging, query the device to report current configuration.
+echo "Before update"
+flint --device "$DEV" query
+mlxconfig --dev "$DEV" query
+sleep $PAUSE
+
+# Burn ROM to NIC.
+echo "Performing update now..."
+# NOTE: To prevent the following error on new NICs, we must specify
+#      --allow_rom_change.
+#
+# Error:
+#     "Burn ROM failed: The device FW contains common FW/ROM Product Version -
+#      The ROM cannot be updated separately."
+#
+# While it's true that the Firmware "Product Version" is out of sync with a
+# custom ROM, but we are building images that are functionally compatible.
+#
+# NOTE: "Burn" the ROM (brom) to the device.
+# TODO: flip out if burning or verifying images fail.
+flint --allow_rom_change --device "$DEV" brom "$ROM"
+# Verify that the device recognizes the new image.
+flint --device "$DEV" verify
+sleep $PAUSE
+
+# For debugging, query the device to report new configuration.
+echo "After update"
+flint --device "$DEV" query
+mlxconfig --dev "$DEV" query
+sleep $PAUSE
+
+# Perform a final verification that the new ROM matches the expected ROM.
+flint --device "$DEV" rrom latest.mrom
+diff latest.mrom "$ROM"

--- a/configs/stage3_mlxupdate/updaterom.sh
+++ b/configs/stage3_mlxupdate/updaterom.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# updaterom.sh is the entrypoint for downloading a ROM image and flashing it
+# to the local NIC.
+#
+# The ROM location is expected to be present in the kernel cmdline with the
+# name epoxy.mrom=https://... to a location in GCS or similar.
+#
+# TODO: rewrite as Go command, e.g. possibly as part of epoxy-client.
+
+set -x
+set -e
+
+romurl=
+for field in $( cat /proc/cmdline ) ; do
+  if [[ "epoxy.mrom" == "${field%%=*}" ]] ; then
+    romurl=${field##epoxy.mrom=}
+    break
+  fi
+done
+
+if test -z "$romurl" ; then
+  echo "WARNING: no ROM URL found. Giving up."
+  exit 1
+fi
+
+# TODO: discover the device type, and download the appropriate rom image from a
+# base URL.
+echo "Downloading ROM"
+wget -O epoxy.mrom "${romurl}"
+if ! test -f epoxy.mrom || ! test -s epoxy.mrom ; then
+    echo "Error: failed to download epoxy.mrom from ${romurl}"
+    exit 1
+fi
+
+echo "Updating ROM"
+/usr/local/util/flashrom.sh epoxy.mrom
+
+# TODO(soltesz): use `epoxy-client --complete` to acknowldge this step.
+echo "WARNING: Not acknowledging success. Taking no action."
+# TODO: restart system on success.

--- a/setup_stage3_mlxupdate.sh
+++ b/setup_stage3_mlxupdate.sh
@@ -207,12 +207,12 @@ chroot $BOOTSTRAP systemctl enable ssh.service
 # chmod 700 $BOOTSTRAP/root/
 
 
+mkdir -p $BOOTSTRAP/usr/local/util
+cp $CONFIGDIR/flashrom.sh $BOOTSTRAP/usr/local/util
+cp $CONFIGDIR/updaterom.sh $BOOTSTRAP/usr/local/util
 ################################################################################
 # TODO:
 ################################################################################
-# mkdir -p $BOOTSTRAP/usr/local/util
-# cp $CONFIGDIR/flashrom.sh $BOOTSTRAP/usr/local/util
-# cp $CONFIGDIR/updaterom.sh $BOOTSTRAP/usr/local/util
 # Make updaterom run automatically after start up.
 
 # Build the initramfs from the bootstrap filesystem.


### PR DESCRIPTION
This change adds two new files to complete the initial version of the stage3 update image.

- `updaterom.sh` downloads a ROM url, as passed to the kernel before boot.
- `flashrom.sh` uses the Mellanox MFT tools to burn the downloaded ROM to the local NIC.

These are initial versions. Ultimately the download function should be rewritten as a Go command, and likely integrated into the epoxy-client command line tool. Similarly, the flashrom script should support logging, and robust fallback in the event of failure. Finally, the last step should be to confirm success with the epoxy server and reboot the machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/13)
<!-- Reviewable:end -->
