### PR TITLE
Pin linux-source-4.4.0 package version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,7 @@ RUN apt-get update --fix-missing
 RUN apt-get install -y unzip python-pip git vim-nox make autoconf gcc mkisofs \
     lzma-dev liblzma-dev autopoint pkg-config libtool autotools-dev upx-ucl \
     isolinux bc texinfo libncurses5-dev linux-source debootstrap gcc-4.8 \
-    strace cpio squashfs-tools curl lsb-release
+    strace cpio squashfs-tools curl lsb-release \
+    linux-source-4.4.0=4.4.0-104.127
+# TODO: remove pinned version on linux-source-4.4.0.
+#       https://github.com/m-lab/epoxy-images/issues/16


### PR DESCRIPTION
This change pins the linux-source package version to one known to build correctly.

Evidently, the latest version of this package has a known bug but fixes are not yet available upstream packages. https://github.com/m-lab/epoxy-images/issues/16

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/17)
<!-- Reviewable:end -->
