### PR TITLE
Add stage3_mlxupdate image build & upload to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,21 +34,21 @@ script:
 # TODO: clean up args to setup_stage2.sh script.
 # TODO: use alternative to travis_wait to allow build with no output for longer
 #       than 10m.
-#- time docker run -v $PWD:/images epoxy-images-builder
-#      bash -c "/images/setup_stage2.sh
-#         /buildtmp
-#         /images/vendor
-#         /images/configs/stage2
-#         /images/output/stage2_initramfs.cpio.gz
-#         /images/output/stage2_vmlinuz &> /images/stage2.log" || (cat stage2.log && false)
+- time docker run -v $PWD:/images epoxy-images-builder
+      bash -c "/images/setup_stage2.sh
+         /buildtmp
+         /images/vendor
+         /images/configs/stage2
+         /images/output/stage2_initramfs.cpio.gz
+         /images/output/stage2_vmlinuz &> /images/stage2.log" || (cat stage2.log && false)
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
-#- time docker run -v $PWD:/images -w /images epoxy-images-builder
-#      bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
-#        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe.vmlinuz
-#        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
-#        /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (cat coreos.log && false)
+- time docker run -v $PWD:/images -w /images epoxy-images-builder
+      bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
+        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe.vmlinuz
+        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
+        /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (cat coreos.log && false)
 
 # Build stage3 mlxupdate image.
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,6 @@ script:
       bash -c "install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
         && cp /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz /images/output/"
-- ls -l $TRAVIS_BUILD_DIR/output
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
 # after a merge with matching "on:" conditions.
@@ -77,6 +76,10 @@ deploy:
       $TRAVIS_BUILD_DIR/output/coreos_custom_pxe_image.cpio.gz
       $TRAVIS_BUILD_DIR/output/coreos_production_pxe.vmlinuz
       gs://epoxy-mlab-sandbox/coreos-generic/
+      && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
+      $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
+      $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
+      gs://epoxy-mlab-sandbox/stage3_mlxupdate/
   skip_cleanup: true
   on:
     repo: m-lab/epoxy-images
@@ -90,6 +93,10 @@ deploy:
       $TRAVIS_BUILD_DIR/output/coreos_custom_pxe_image.cpio.gz
       $TRAVIS_BUILD_DIR/output/coreos_production_pxe.vmlinuz
       gs://epoxy-mlab-staging/coreos-generic/
+      && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
+      $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
+      $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
+      gs://epoxy-mlab-sandbox/stage3_mlxupdate/
   skip_cleanup: true
   on:
     repo: m-lab/epoxy-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
 - time docker run -it --privileged -v $PWD:/images epoxy-images-builder
       bash -c "install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
-        && cp /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz output/"
+        && cp /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz /images/output/"
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ script:
 
 - time docker build -t epoxy-images-builder . &> build.log || (cat build.log && false)
 
+# Enable gsutil downloads from private GCS buckets, using the mlab-sandbox SA.
+- $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
+- $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
+
 - mkdir $TRAVIS_BUILD_DIR/output
 # Build stage2 vmlinuz image.
 # TODO: clean up args to setup_stage2.sh script.
@@ -46,7 +50,20 @@ script:
         http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
         /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (cat coreos.log && false)
 
-- $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
+# Build stage3 mlxupdate image.
+#
+# Note: download the mellanox firmware tools from a faster private bucket.
+- gsutil cp gs://vendor-mlab-oti/epoxy-images/mft-4.4.0-44.tgz .
+
+# Note: build must be privilged to mount /proc & /sys during debootstrap build.
+#
+# Note: when /build location is internal to container fs, i/o is more efficient.
+#
+# TODO: add support for create_update_iso.sh. Possibly call from setup_stage1.sh
+- time docker run --privileged -v $PWD:/images epoxy-images-builder
+      bash -c "install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
+        && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
+        && cp /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz output/"
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
 # after a merge with matching "on:" conditions.

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,11 @@ script:
 # Note: when /build location is internal to container fs, i/o is more efficient.
 #
 # TODO: add support for create_update_iso.sh. Possibly call from setup_stage1.sh
-- time docker run -it --privileged -v $PWD:/images epoxy-images-builder
-      bash -c "install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
+- time docker run --privileged -v $PWD:/images epoxy-images-builder
+      bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
-        && cp /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz /images/output/"
+        && cp /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz /images/output/ &> /images/stage3_mlxupdate.log" || (cat stage3_mlxupdate.log && false)
+- ls -l $TRAVIS_BUILD_DIR/output
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
 # after a merge with matching "on:" conditions.

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,36 +34,37 @@ script:
 # TODO: clean up args to setup_stage2.sh script.
 # TODO: use alternative to travis_wait to allow build with no output for longer
 #       than 10m.
-- time docker run -v $PWD:/images epoxy-images-builder
-      bash -c "/images/setup_stage2.sh
-         /buildtmp
-         /images/vendor
-         /images/configs/stage2
-         /images/output/stage2_initramfs.cpio.gz
-         /images/output/stage2_vmlinuz &> /images/stage2.log" || (cat stage2.log && false)
+#- time docker run -v $PWD:/images epoxy-images-builder
+#      bash -c "/images/setup_stage2.sh
+#         /buildtmp
+#         /images/vendor
+#         /images/configs/stage2
+#         /images/output/stage2_initramfs.cpio.gz
+#         /images/output/stage2_vmlinuz &> /images/stage2.log" || (cat stage2.log && false)
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
-- time docker run -v $PWD:/images -w /images epoxy-images-builder
-      bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
-        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe.vmlinuz
-        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
-        /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (cat coreos.log && false)
+#- time docker run -v $PWD:/images -w /images epoxy-images-builder
+#      bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
+#        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe.vmlinuz
+#        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
+#        /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (cat coreos.log && false)
 
 # Build stage3 mlxupdate image.
 #
 # Note: download the mellanox firmware tools from a faster private bucket.
-- gsutil cp gs://vendor-mlab-oti/epoxy-images/mft-4.4.0-44.tgz .
+- gsutil cp gs://vendor-mlab-oti/epoxy-images/mft-4.4.0-44.tgz $TRAVIS_BUILD_DIR/
 
 # Note: build must be privilged to mount /proc & /sys during debootstrap build.
 #
 # Note: when /build location is internal to container fs, i/o is more efficient.
 #
 # TODO: add support for create_update_iso.sh. Possibly call from setup_stage1.sh
-- time docker run --privileged -v $PWD:/images epoxy-images-builder
+- time docker run -it --privileged -v $PWD:/images epoxy-images-builder
       bash -c "install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
         && cp /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz output/"
+- ls -l $TRAVIS_BUILD_DIR/output
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
 # after a merge with matching "on:" conditions.

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
 # TODO: clean up args to setup_stage2.sh script.
 # TODO: use alternative to travis_wait to allow build with no output for longer
 #       than 10m.
-- time docker run -v $PWD:/images epoxy-images-builder
+- time docker run -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
       bash -c "/images/setup_stage2.sh
          /buildtmp
          /images/vendor
@@ -44,7 +44,7 @@ script:
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
-- time docker run -v $PWD:/images -w /images epoxy-images-builder
+- time docker run -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
       bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
         http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe.vmlinuz
         http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
@@ -52,15 +52,17 @@ script:
 
 # Build stage3 mlxupdate image.
 #
-# Note: download the mellanox firmware tools from a faster private bucket.
+# Note: download the mellanox firmware tools from cache in private bucket,
+#       since origin (http://www.mellanox.com/downloads/MFT/mft-4.4.0-44.tgz)
+#       is sloooow.
 - gsutil cp gs://vendor-mlab-oti/epoxy-images/mft-4.4.0-44.tgz $TRAVIS_BUILD_DIR/
 
-# Note: build must be privilged to mount /proc & /sys during debootstrap build.
+# Note: build must be privileged to mount /proc & /sys during debootstrap build.
 #
 # Note: when /build location is internal to container fs, i/o is more efficient.
 #
 # TODO: add support for create_update_iso.sh. Possibly call from setup_stage1.sh
-- time docker run --privileged -v $PWD:/images epoxy-images-builder
+- time docker run --privileged -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
       bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
         && install -m 0644 /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz /images/output/ &> /images/stage3_mlxupdate.log" || (cat stage3_mlxupdate.log && false)
@@ -71,6 +73,13 @@ script:
 deploy:
 # SANDBOX: before code review for development code in a specific branch.
 # TODO: upload all support resources for a generic epoxy coreos boot.
+#
+# Deployment to gs://epoxy-mlab-sandbox/coreos-generic/
+#  * stage2 kernel (with embedded initram image)
+#  * customized coreos initramfs and stock kernel
+#
+# Deployment to gs://epoxy-mlab-sandbox/stage3_mlxupdate/
+#  * stage3 mlxupdate image and stock kernel
 - provider: script
   script: $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
       $TRAVIS_BUILD_DIR/output/stage2_vmlinuz
@@ -88,6 +97,13 @@ deploy:
     condition: $TRAVIS_BRANCH == sandbox-*
 
 # STAGING: after code review and before QA testing.
+#
+# Deployment to gs://epoxy-mlab-staging/coreos-generic/
+#  * stage2 kernel (with embedded initram image)
+#  * customized coreos initramfs and stock kernel
+#
+# Deployment to gs://epoxy-mlab-staging/stage3_mlxupdate/
+#  * stage3 mlxupdate image and stock kernel
 - provider: script
   script: $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
       $TRAVIS_BUILD_DIR/output/stage2_vmlinuz

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
 - time docker run --privileged -v $PWD:/images epoxy-images-builder
       bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
-        && cp /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz /images/output/ &> /images/stage3_mlxupdate.log" || (cat stage3_mlxupdate.log && false)
+        && install -m 0644 /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz /images/output/ &> /images/stage3_mlxupdate.log" || (cat stage3_mlxupdate.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger

--- a/setup_stage3_mlxupdate.sh
+++ b/setup_stage3_mlxupdate.sh
@@ -71,7 +71,7 @@ fi
 #     http://www.mellanox.com/downloads/MFT/mft-4.8.0-26-x86_64-deb.tgz
 if ! test -d $BOOTSTRAP/root/mft-4.4.0-44 ; then
     pushd $BUILDDIR
-        unpack mft-4.4.0-44 http://www.mellanox.com/downloads/MFT/mft-4.4.0-44.tgz
+        unpack_url mft-4.4.0-44 http://www.mellanox.com/downloads/MFT/mft-4.4.0-44.tgz
         cp -ar mft-4.4.0-44 $BOOTSTRAP/root
     popd
 fi


### PR DESCRIPTION
This change adds a new build and deploy step to the epoxy-images .travis.yaml config.

This change adds support for installing the gcloud CLI tools in order to fetch a cached version of the mft archive (~510MB) faster than it can be downloaded from mellanox. The resulting kernel and initram images are copied to `gs://epoxy-mlab-staging/stage3_mlxupdate/` bucket.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/19)
<!-- Reviewable:end -->
