### PR TITLE
Add integration for building stage1 ROMs, and stage3 update ISOs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,12 +63,12 @@ script:
 #
 # Note: setup_stage3_mlxupdate_isos.sh must run immediately after
 # setup_stage3_mlxupdate.sh so that build artifacts are still present in /build.
-#
-# TODO: add support for create_update_iso.sh. Possibly call from setup_stage1.sh
 - time docker run --privileged -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
       bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
+        && echo 'Starting stage3_mlxupdate build'
         && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
           &> /images/stage3_mlxupdate.log
+        && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802
           &> /images/stage3_mlxupdate_iso.log" || (cat stage3_mlxupdate.log stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,21 +61,17 @@ script:
 #
 # Note: when /build location is internal to container fs, i/o is more efficient.
 #
+# Note: setup_stage3_mlxupdate_isos.sh must run immediately after
+# setup_stage3_mlxupdate.sh so that build artifacts are still present in /build.
+#
 # TODO: add support for create_update_iso.sh. Possibly call from setup_stage1.sh
 - time docker run --privileged -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
       bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
-        && install -m 0644 /build/vmlinuz_stage3_mlxupdate
-          /build/initramfs_stage3_mlxupdate.cpio.gz
-          /images/output/ &> /images/stage3_mlxupdate.log" || (cat stage3_mlxupdate.log && false)
+          &> /images/stage3_mlxupdate.log
+        && /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802
+          &> /images/stage3_mlxupdate_iso.log" || (cat stage3_mlxupdate.log stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
-
-
-# Note: the stage3_mlxupdate build must have already completed successfully.
-- time docker run -it -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
-      bash -c "umask 0022;
-        /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802"
-#        # &> /images/stage3_mlxupdate_iso.log" || (cat stage3_mlxupdate_iso.log && false)
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
 # after a merge with matching "on:" conditions.
@@ -87,8 +83,11 @@ deploy:
 #  * stage2 kernel (with embedded initram image)
 #  * customized coreos initramfs and stock kernel
 #
-# Deployment to gs://epoxy-mlab-sandbox/stage3_mlxupdate/
-#  * stage3 mlxupdate image and stock kernel
+# Deployment to gs://epoxy-mlab-sandbox/stage3_mlxupdate_iso/
+#  * stage3 mlxupdate ISOs
+#
+# Deployment to gs://epoxy-mlab-sandbox/mellanox-roms/
+#  * stage1 mellanox ROMs
 - provider: script
   script: $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
       $TRAVIS_BUILD_DIR/output/stage2_vmlinuz
@@ -96,13 +95,11 @@ deploy:
       $TRAVIS_BUILD_DIR/output/coreos_production_pxe.vmlinuz
       gs://epoxy-mlab-sandbox/coreos-generic/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
-      $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
-      $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
-      gs://epoxy-mlab-sandbox/stage3_mlxupdate/
-      && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
       $TRAVIS_BUILD_DIR/output/*.iso
       gs://epoxy-mlab-sandbox/stage3_mlxupdate_iso/
-  # TODO: upload mlxupdate ISOs.
+      && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
+      $TRAVIS_BUILD_DIR/output/mellanox-roms
+      gs://epoxy-mlab-sandbox/
   skip_cleanup: true
   on:
     repo: m-lab/epoxy-images
@@ -115,8 +112,11 @@ deploy:
 #  * stage2 kernel (with embedded initram image)
 #  * customized coreos initramfs and stock kernel
 #
-# Deployment to gs://epoxy-mlab-staging/stage3_mlxupdate/
-#  * stage3 mlxupdate image and stock kernel
+# Deployment to gs://epoxy-mlab-staging/stage3_mlxupdate_iso/
+#  * stage3 mlxupdate ISOs
+#
+# Deployment to gs://epoxy-mlab-staging/mellanox-roms/
+#  * stage1 mellanox ROMs
 - provider: script
   script: $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
       $TRAVIS_BUILD_DIR/output/stage2_vmlinuz
@@ -124,9 +124,11 @@ deploy:
       $TRAVIS_BUILD_DIR/output/coreos_production_pxe.vmlinuz
       gs://epoxy-mlab-staging/coreos-generic/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
-      $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
-      $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
-      gs://epoxy-mlab-sandbox/stage3_mlxupdate/
+      $TRAVIS_BUILD_DIR/output/*.iso
+      gs://epoxy-mlab-staging/stage3_mlxupdate_iso/
+      && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
+      $TRAVIS_BUILD_DIR/output/mellanox-roms
+      gs://epoxy-mlab-staging/
   skip_cleanup: true
   on:
     repo: m-lab/epoxy-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -61,8 +61,9 @@ script:
 #
 # Note: when /build location is internal to container fs, i/o is more efficient.
 #
-# Note: setup_stage3_mlxupdate_isos.sh must run immediately after
-# setup_stage3_mlxupdate.sh so that build artifacts are still present in /build.
+# Note: setup_stage3_mlxupdate_isos.sh depends on build artifacts from
+# setup_stage3_mlxupdate.sh in /build. If these are not present,
+# setup_stage3_mlxupdate_isos.sh will fail to generate ISOs.
 - time docker run -it --privileged -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
       bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && echo 'Starting stage3_mlxupdate build'
@@ -92,7 +93,8 @@ deploy:
 # Deployment to gs://epoxy-mlab-sandbox/stage1_mlxrom/
 #  * stage1 mellanox ROMs
 - provider: script
-  script: $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
+  script:
+      $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
       $TRAVIS_BUILD_DIR/output/stage2_vmlinuz
       $TRAVIS_BUILD_DIR/output/coreos_custom_pxe_image.cpio.gz
       $TRAVIS_BUILD_DIR/output/coreos_production_pxe.vmlinuz
@@ -128,7 +130,8 @@ deploy:
 # Deployment to gs://epoxy-mlab-staging/stage1_mlxrom/
 #  * stage1 mellanox ROMs
 - provider: script
-  script: $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
+  script:
+      $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
       $TRAVIS_BUILD_DIR/output/stage2_vmlinuz
       $TRAVIS_BUILD_DIR/output/coreos_custom_pxe_image.cpio.gz
       $TRAVIS_BUILD_DIR/output/coreos_production_pxe.vmlinuz

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
 - time docker run -it --privileged -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
       bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && echo 'Starting stage3_mlxupdate build'
-        && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
+        && /images/setup_stage3_mlxupdate.sh /build /images/output /images/configs/stage3_mlxupdate
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802
@@ -79,27 +79,34 @@ deploy:
 # SANDBOX: before code review for development code in a specific branch.
 # TODO: upload all support resources for a generic epoxy coreos boot.
 #
-# Deployment to gs://epoxy-mlab-sandbox/coreos-generic/
+# Deployment to gs://epoxy-mlab-sandbox/stage3_coreos/
 #  * stage2 kernel (with embedded initram image)
 #  * customized coreos initramfs and stock kernel
 #
-# Deployment to gs://epoxy-mlab-sandbox/stage3_mlxupdate_iso/
-#  * stage3 mlxupdate ISOs
+# Deployment to gs://epoxy-mlab-sandbox/stage3_mlxupdate/
+#  * stage3 mlxupdate images
 #
-# Deployment to gs://epoxy-mlab-sandbox/mellanox-roms/
+# Deployment to gs://epoxy-mlab-sandbox/stage3_mlxupdate_iso/
+#  * stage3 mlxupdate bootable ISOs for first-time setup.
+#
+# Deployment to gs://epoxy-mlab-sandbox/stage1_mlxrom/
 #  * stage1 mellanox ROMs
 - provider: script
   script: $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
       $TRAVIS_BUILD_DIR/output/stage2_vmlinuz
       $TRAVIS_BUILD_DIR/output/coreos_custom_pxe_image.cpio.gz
       $TRAVIS_BUILD_DIR/output/coreos_production_pxe.vmlinuz
-      gs://epoxy-mlab-sandbox/coreos-generic/
+      gs://epoxy-mlab-sandbox/stage3_coreos/
+      && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
+      $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
+      $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
+      gs://epoxy-mlab-sandbox/stage3_mlxupdate/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
       $TRAVIS_BUILD_DIR/output/*.iso
       gs://epoxy-mlab-sandbox/stage3_mlxupdate_iso/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
-      $TRAVIS_BUILD_DIR/output/mellanox-roms
-      gs://epoxy-mlab-sandbox/
+      $TRAVIS_BUILD_DIR/output/stage1_mlxrom/*
+      gs://epoxy-mlab-sandbox/stage1_mlxrom/
   skip_cleanup: true
   on:
     repo: m-lab/epoxy-images
@@ -108,27 +115,34 @@ deploy:
 
 # STAGING: after code review and before QA testing.
 #
-# Deployment to gs://epoxy-mlab-staging/coreos-generic/
+# Deployment to gs://epoxy-mlab-staging/stage3_coreos/
 #  * stage2 kernel (with embedded initram image)
 #  * customized coreos initramfs and stock kernel
+#
+# Deployment to gs://epoxy-mlab-staging/stage3_mlxupdate/
+#  * stage3 mlxupdate images
 #
 # Deployment to gs://epoxy-mlab-staging/stage3_mlxupdate_iso/
 #  * stage3 mlxupdate ISOs
 #
-# Deployment to gs://epoxy-mlab-staging/mellanox-roms/
+# Deployment to gs://epoxy-mlab-staging/stage1_mlxrom/
 #  * stage1 mellanox ROMs
 - provider: script
   script: $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
       $TRAVIS_BUILD_DIR/output/stage2_vmlinuz
       $TRAVIS_BUILD_DIR/output/coreos_custom_pxe_image.cpio.gz
       $TRAVIS_BUILD_DIR/output/coreos_production_pxe.vmlinuz
-      gs://epoxy-mlab-staging/coreos-generic/
+      gs://epoxy-mlab-staging/stage3_coreos/
+      && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
+      $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
+      $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
+      gs://epoxy-mlab-staging/stage3_mlxupdate/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
       $TRAVIS_BUILD_DIR/output/*.iso
       gs://epoxy-mlab-staging/stage3_mlxupdate_iso/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
-      $TRAVIS_BUILD_DIR/output/mellanox-roms
-      gs://epoxy-mlab-staging/
+      $TRAVIS_BUILD_DIR/output/stage1_mlxrom/*
+      gs://epoxy-mlab-staging/stage1_mlxrom/
   skip_cleanup: true
   on:
     repo: m-lab/epoxy-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802
-          &> /images/stage3_mlxupdate_iso.log" || (cat stage3_mlxupdate.log stage3_mlxupdate_iso.log && false)
+          &> /images/stage3_mlxupdate_iso.log" || (tail -40 stage3_mlxupdate.log stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ script:
 #
 # Note: setup_stage3_mlxupdate_isos.sh must run immediately after
 # setup_stage3_mlxupdate.sh so that build artifacts are still present in /build.
-- time docker run --privileged -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
+- time docker run -it --privileged -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
       bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && echo 'Starting stage3_mlxupdate build'
         && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,21 +34,21 @@ script:
 # TODO: clean up args to setup_stage2.sh script.
 # TODO: use alternative to travis_wait to allow build with no output for longer
 #       than 10m.
-- time docker run -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
-      bash -c "/images/setup_stage2.sh
-         /buildtmp
-         /images/vendor
-         /images/configs/stage2
-         /images/output/stage2_initramfs.cpio.gz
-         /images/output/stage2_vmlinuz &> /images/stage2.log" || (cat stage2.log && false)
+#- time docker run -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
+#      bash -c "/images/setup_stage2.sh
+#         /buildtmp
+#         /images/vendor
+#         /images/configs/stage2
+#         /images/output/stage2_initramfs.cpio.gz
+#         /images/output/stage2_vmlinuz &> /images/stage2.log" || (cat stage2.log && false)
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
-- time docker run -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
-      bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
-        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe.vmlinuz
-        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
-        /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (cat coreos.log && false)
+#- time docker run -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
+#      bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
+#        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe.vmlinuz
+#        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
+#        /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (cat coreos.log && false)
 
 # Build stage3 mlxupdate image.
 #
@@ -70,7 +70,7 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802
-          &> /images/stage3_mlxupdate_iso.log" || (tail -40 stage3_mlxupdate.log stage3_mlxupdate_iso.log && false)
+          &> /images/stage3_mlxupdate_iso.log" || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,8 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802
-          &> /images/stage3_mlxupdate_iso.log" || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
+          &> /images/stage3_mlxupdate_iso.log" | while read X ; do echo $X ; sleep .5 ; done
+          # &> /images/stage3_mlxupdate_iso.log" || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger

--- a/.travis.yml
+++ b/.travis.yml
@@ -68,6 +68,13 @@ script:
         && install -m 0644 /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz /images/output/ &> /images/stage3_mlxupdate.log" || (cat stage3_mlxupdate.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
+
+
+# Note: the stage3_mlxupdate build must have already completed successfully.
+- time docker run -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
+      bash -c "umask 0022;
+        ./setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802 &> /images/stage3_mlxupdate_iso.log" || (cat stage3_mlxupdate_iso.log && false)
+
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
 # after a merge with matching "on:" conditions.
 deploy:
@@ -90,6 +97,7 @@ deploy:
       $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
       $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
       gs://epoxy-mlab-sandbox/stage3_mlxupdate/
+  # TODO: upload mlxupdate ISOs.
   skip_cleanup: true
   on:
     repo: m-lab/epoxy-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,9 +72,9 @@ script:
 
 
 # Note: the stage3_mlxupdate build must have already completed successfully.
-- time docker run -it -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
+- time docker run -it -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
       bash -c "umask 0022;
-        ./setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802"
+        /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802"
 #        # &> /images/stage3_mlxupdate_iso.log" || (cat stage3_mlxupdate_iso.log && false)
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,21 +34,21 @@ script:
 # TODO: clean up args to setup_stage2.sh script.
 # TODO: use alternative to travis_wait to allow build with no output for longer
 #       than 10m.
-#- time docker run -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
-#      bash -c "/images/setup_stage2.sh
-#         /buildtmp
-#         /images/vendor
-#         /images/configs/stage2
-#         /images/output/stage2_initramfs.cpio.gz
-#         /images/output/stage2_vmlinuz &> /images/stage2.log" || (cat stage2.log && false)
+- time docker run -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
+      bash -c "/images/setup_stage2.sh
+         /buildtmp
+         /images/vendor
+         /images/configs/stage2
+         /images/output/stage2_initramfs.cpio.gz
+         /images/output/stage2_vmlinuz &> /images/stage2.log" || (cat stage2.log && false)
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
-#- time docker run -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
-#      bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
-#        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe.vmlinuz
-#        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
-#        /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (cat coreos.log && false)
+- time docker run -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
+      bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
+        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe.vmlinuz
+        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
+        /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (cat coreos.log && false)
 
 # Build stage3 mlxupdate image.
 #
@@ -63,16 +63,14 @@ script:
 #
 # Note: setup_stage3_mlxupdate_isos.sh must run immediately after
 # setup_stage3_mlxupdate.sh so that build artifacts are still present in /build.
-- time docker run -it --privileged -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
+- time docker run -it --privileged -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
       bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && echo 'Starting stage3_mlxupdate build'
         && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802
-          &> /images/stage3_mlxupdate_iso.log" ||
-          (cat $TRAVIS_BUILD_DIR/stage3_mlxupdate.log $TRAVIS_BUILD_DIR/stage3_mlxupdate_iso.log | while read X ; do echo $X ; sleep .5 ; done)
-          # &> /images/stage3_mlxupdate_iso.log" || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
+          &> /images/stage3_mlxupdate_iso.log" || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,15 +65,17 @@ script:
 - time docker run --privileged -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
       bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && /images/setup_stage3_mlxupdate.sh /build /images/configs/stage3_mlxupdate
-        && install -m 0644 /build/vmlinuz_stage3_mlxupdate /build/initramfs_stage3_mlxupdate.cpio.gz /images/output/ &> /images/stage3_mlxupdate.log" || (cat stage3_mlxupdate.log && false)
+        && install -m 0644 /build/vmlinuz_stage3_mlxupdate
+          /build/initramfs_stage3_mlxupdate.cpio.gz
+          /images/output/ &> /images/stage3_mlxupdate.log" || (cat stage3_mlxupdate.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 
-
 # Note: the stage3_mlxupdate build must have already completed successfully.
-- time docker run -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
+- time docker run -it -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
       bash -c "umask 0022;
-        ./setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802 &> /images/stage3_mlxupdate_iso.log" || (cat stage3_mlxupdate_iso.log && false)
+        ./setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802"
+#        # &> /images/stage3_mlxupdate_iso.log" || (cat stage3_mlxupdate_iso.log && false)
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
 # after a merge with matching "on:" conditions.
@@ -97,6 +99,9 @@ deploy:
       $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
       $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
       gs://epoxy-mlab-sandbox/stage3_mlxupdate/
+      && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
+      $TRAVIS_BUILD_DIR/output/*.iso
+      gs://epoxy-mlab-sandbox/stage3_mlxupdate_iso/
   # TODO: upload mlxupdate ISOs.
   skip_cleanup: true
   on:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,8 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802
-          &> /images/stage3_mlxupdate_iso.log" | while read X ; do echo $X ; sleep .5 ; done
+          &> /images/stage3_mlxupdate_iso.log" ||
+          (cat $TRAVIS_BUILD_DIR/stage3_mlxupdate.log $TRAVIS_BUILD_DIR/stage3_mlxupdate_iso.log | while read X ; do echo $X ; sleep .5 ; done)
           # &> /images/stage3_mlxupdate_iso.log" || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 

--- a/configs/stage1_mlxrom/build-iso-template.sh
+++ b/configs/stage1_mlxrom/build-iso-template.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 #
+# build-iso-template.sh is a template bash script used by
+# setup_stage3_mlxupdate_isos.sh to build per-machine Mellanox stage1 ROMs and
+# stage3 mlxupdate ISO images, suitable for flashing the ROM during initial
+# machine setup.
+#
 # Note: this script should execute within the epoxy-image builer docker image.
+# Note: this script depends on the availability of the stage3_mlxupdate images.
 
 BUILD_DIR=${1:?Please specify a build directory}
 OUTPUT_DIR=${2:?Please provide an output directory}

--- a/configs/stage1_mlxrom/build-iso-template.sh
+++ b/configs/stage1_mlxrom/build-iso-template.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# Note: this script should execute within the epoxy-image builer docker image.
+
+BUILD_DIR=${1:?Please specify a build directory}
+OUTPUT_DIR=${2:?Please provide an output directory}
+SOURCE_DIR=${3:?Please provide the base source directory}
+ROM_VERSION=${4:?Please provide the ROM version as "3.4.800"}
+
+./setup_stage1.sh \
+    "${BUILD_DIR}" "${OUTPUT_DIR}" ${SOURCE_DIR}/configs/stage1_mlxrom \
+    "{{hostname}}" "${ROM_VERSION}" "${SOURCE_DIR}/configs/stage1_mlxrom/giag2.pem"
+
+if [[ {{netmask}} != "255.255.255.192" ]] ; then
+  echo 'Error: Sorry, unsupported netmask: {{netmask}}'
+  exit 1
+fi
+mask=26
+
+./create_update_iso.sh \
+    "${BUILD_DIR}" "${OUTPUT_DIR}" "${ROM_VERSION}" \
+    "{{hostname}}" "{{ip}}/${mask}" "{{gateway}}" "{{dns1}}" "8.8.4.4"

--- a/configs/stage1_mlxrom/build-iso-template.sh
+++ b/configs/stage1_mlxrom/build-iso-template.sh
@@ -13,7 +13,7 @@ OUTPUT_DIR=${2:?Please provide an output directory}
 SOURCE_DIR=${3:?Please provide the base source directory}
 ROM_VERSION=${4:?Please provide the ROM version as "3.4.800"}
 
-./setup_stage1.sh \
+${SOURCE_DIR}/setup_stage1.sh \
     "${BUILD_DIR}" "${OUTPUT_DIR}" ${SOURCE_DIR}/configs/stage1_mlxrom \
     "{{hostname}}" "${ROM_VERSION}" "${SOURCE_DIR}/configs/stage1_mlxrom/giag2.pem"
 
@@ -23,6 +23,6 @@ if [[ {{netmask}} != "255.255.255.192" ]] ; then
 fi
 mask=26
 
-./create_update_iso.sh \
+${SOURCE_DIR}/create_update_iso.sh \
     "${BUILD_DIR}" "${OUTPUT_DIR}" "${ROM_VERSION}" \
     "{{hostname}}" "{{ip}}/${mask}" "{{gateway}}" "{{dns1}}" "8.8.4.4"

--- a/create_update_iso.sh
+++ b/create_update_iso.sh
@@ -47,7 +47,7 @@ ARGS+="epoxy.ipv4=${IPV4_ADDR},${IPV4_GATEWAY},${DNS1},${DNS2} "
 URL=https://storage.googleapis.com/epoxy-mlab-staging
 # Note: Only encode the base URL. The download script detects the device
 # model and constructs the full path ROM based on the system hostname.
-ARGS+="epoxy.mrom=$URL/mellanox-roms/${ROM_VERSION} "
+ARGS+="epoxy.mrom=$URL/stage1_mlxrom/${ROM_VERSION} "
 
 
 SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )

--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -191,6 +191,8 @@ function build_roms() {
         cp bin/${device} ${rom_output_dir}/${version}/${device%%.mrom}/${hostname}.mrom
       done
     popd
+    # Remove old files to prevent regenerating ROMs during multiple builds.
+    rm -f ${stage1}
   done
 }
 

--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -241,8 +241,8 @@ build_roms \
     "${ROM_VERSION}" \
     "${DEBUG}" \
     "${CERTS}" \
-    ${BUILD_DIR}/mellanox-roms
+    ${BUILD_DIR}/stage1_mlxrom
 
 copy_roms_to_output \
-    ${BUILD_DIR}/mellanox-roms/ \
-    ${OUTPUT_DIR}/mellanox-roms
+    ${BUILD_DIR}/stage1_mlxrom/ \
+    ${OUTPUT_DIR}/stage1_mlxrom

--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -186,8 +186,8 @@ function build_roms() {
 
         # Copy it to a structured location.
         # Note: the update image depends on this structure to locate an image.
-        mkdir -p ${rom_output_dir}/${device}/${version}
-        cp bin/${device} ${rom_output_dir}/${device}/${version}/${hostname}.mrom
+        mkdir -p ${rom_output_dir}/${version}/${device%%.mrom}/
+        cp bin/${device} ${rom_output_dir}/${version}/${device%%.mrom}/${hostname}.mrom
       done
     popd
   done

--- a/setup_stage3_mlxupdate.sh
+++ b/setup_stage3_mlxupdate.sh
@@ -223,4 +223,5 @@ cp $CONFIG_DIR/updaterom.sh $BOOTSTRAP/usr/local/util
 pushd $BOOTSTRAP
     find . | cpio -H newc -o | gzip -c > ${OUTPUT_INITRAM}
 popd
-cp ${OUTPUT_KERNEL} ${OUTPUT_INITRAM} ${OUTPUT_DIR}
+# Copy file to output with all read permissions.
+install -m 0644 ${OUTPUT_KERNEL} ${OUTPUT_INITRAM} ${OUTPUT_DIR}

--- a/setup_stage3_mlxupdate.sh
+++ b/setup_stage3_mlxupdate.sh
@@ -11,14 +11,19 @@ set -x
 set -e
 set -u
 
-BUILDDIR=${1:?Name of build directory}
-BUILDDIR=$( realpath $BUILDDIR )
+BUILD_DIR=${1:?Name of build directory}
+BUILD_DIR=$( realpath $BUILD_DIR )
 
-CONFIGDIR=${2:?Name of directory containing configuration files}
-CONFIGDIR=$( realpath $CONFIGDIR )
+OUTPUT_DIR=${2:?Name of directory to copy output files}
+OUTPUT_DIR=$( realpath $OUTPUT_DIR )
 
-CONFIG_NAME=$( basename $CONFIGDIR )
-BOOTSTRAP=$BUILDDIR/initramfs_${CONFIG_NAME}
+CONFIG_DIR=${3:?Name of directory containing configuration files}
+CONFIG_DIR=$( realpath $CONFIG_DIR )
+
+CONFIG_NAME=$( basename $CONFIG_DIR )
+BOOTSTRAP=${BUILD_DIR}/initramfs_${CONFIG_NAME}
+OUTPUT_KERNEL=${BUILD_DIR}/vmlinuz_${CONFIG_NAME}
+OUTPUT_INITRAM=${BOOTSTRAP}.cpio.gz
 
 ##############################################################################
 # Functions
@@ -70,7 +75,7 @@ fi
 # smaller and includes pre-built deb files. For example:
 #     http://www.mellanox.com/downloads/MFT/mft-4.8.0-26-x86_64-deb.tgz
 if ! test -d $BOOTSTRAP/root/mft-4.4.0-44 ; then
-    pushd $BUILDDIR
+    pushd $BUILD_DIR
         unpack_url mft-4.4.0-44 http://www.mellanox.com/downloads/MFT/mft-4.4.0-44.tgz
         cp -ar mft-4.4.0-44 $BOOTSTRAP/root
     popd
@@ -84,7 +89,7 @@ trap "umount_proc_and_sys $BOOTSTRAP" EXIT
 mount_proc_and_sys $BOOTSTRAP
 
     # Extra packages needed for correct operation.
-    PACKAGES=`cat ${CONFIGDIR}/extra.packages ${CONFIGDIR}/build.packages`
+    PACKAGES=`cat ${CONFIG_DIR}/extra.packages ${CONFIG_DIR}/build.packages`
 
     # Add extra apt sources to install latest kernel image and headers.
     # TODO: only append the source once.
@@ -140,8 +145,7 @@ mount_proc_and_sys $BOOTSTRAP
     chroot $BOOTSTRAP apt-get clean -y
 
     # Copy kernel image to output directory before removing it.
-    cp $BOOTSTRAP/boot/vmlinuz-${KERNEL_VERSION} \
-        ${BUILDDIR}/vmlinuz_${CONFIG_NAME}
+    cp $BOOTSTRAP/boot/vmlinuz-${KERNEL_VERSION} ${OUTPUT_KERNEL}
 
     # Backup the kernel modules with the dkms module.
     cp -ar $BOOTSTRAP/lib/modules/${KERNEL_VERSION} \
@@ -165,11 +169,11 @@ trap '' EXIT
 ################################################################################
 # Kernel panics unless /init is defined. Use systemd for init.
 ln --force --symbolic sbin/init $BOOTSTRAP/init
-cp $CONFIGDIR/fstab $BOOTSTRAP/etc/fstab
+cp $CONFIG_DIR/fstab $BOOTSTRAP/etc/fstab
 
 # Enable simple rc.local script for post-setup processing.
 # rc.local.service runs after networking.service
-cp $CONFIGDIR/rc.local $BOOTSTRAP/etc/rc.local
+cp $CONFIG_DIR/rc.local $BOOTSTRAP/etc/rc.local
 chroot $BOOTSTRAP systemctl enable rc.local.service
 
 ################################################################################
@@ -178,7 +182,7 @@ chroot $BOOTSTRAP systemctl enable rc.local.service
 # Enable static resolv.conf
 # TODO: use systemd for network configuration entirely.
 rm -f $BOOTSTRAP/etc/resolv.conf
-cp $CONFIGDIR/resolv.conf $BOOTSTRAP/etc/resolv.conf
+cp $CONFIG_DIR/resolv.conf $BOOTSTRAP/etc/resolv.conf
 # If permissions are incorrect, apt-get will fail to read contents.
 chmod 644 $BOOTSTRAP/etc/resolv.conf
 
@@ -202,14 +206,14 @@ chroot $BOOTSTRAP systemctl enable ssh.service
 # TODO: investigate ssh-import-id as an alternative here, or a copy from GCS.
 # echo "Adding SSH authorized keys"
 # mkdir -p $BOOTSTRAP/root/.ssh
-# cp $CONFIGDIR/authorized_keys  $BOOTSTRAP/root/.ssh/authorized_keys
+# cp $CONFIG_DIR/authorized_keys  $BOOTSTRAP/root/.ssh/authorized_keys
 # chown root:root $BOOTSTRAP/root/.ssh/authorized_keys
 # chmod 700 $BOOTSTRAP/root/
 
 
 mkdir -p $BOOTSTRAP/usr/local/util
-cp $CONFIGDIR/flashrom.sh $BOOTSTRAP/usr/local/util
-cp $CONFIGDIR/updaterom.sh $BOOTSTRAP/usr/local/util
+cp $CONFIG_DIR/flashrom.sh $BOOTSTRAP/usr/local/util
+cp $CONFIG_DIR/updaterom.sh $BOOTSTRAP/usr/local/util
 ################################################################################
 # TODO:
 ################################################################################
@@ -217,5 +221,6 @@ cp $CONFIGDIR/updaterom.sh $BOOTSTRAP/usr/local/util
 
 # Build the initramfs from the bootstrap filesystem.
 pushd $BOOTSTRAP
-    find . | cpio -H newc -o | gzip -c > ${BOOTSTRAP}.cpio.gz
+    find . | cpio -H newc -o | gzip -c > ${OUTPUT_INITRAM}
 popd
+cp ${OUTPUT_KERNEL} ${OUTPUT_INITRAM} ${OUTPUT_DIR}

--- a/setup_stage3_mlxupdate_isos.sh
+++ b/setup_stage3_mlxupdate_isos.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 #
-# setup_stage3_mlxupdate_isos.sh should be run after setup_stage3_mlxupdate.sh
-# has run successfully and the update image and kernel are available.
+# setup_stage3_mlxupdate_isos.sh generates per-machine Mellanox ROM and
+# stage3_mlxupdate ISO images.
+#
+# setup_stage3_mlxupdate_isos.sh should only be run after
+# setup_stage3_mlxupdate.sh has run successfully and the stage3_mlxupdate image
+# and kernel are available.
 
 SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
 
@@ -14,6 +18,8 @@ OUTPUT_DIR=${2:?Please provide an output directory}
 HOSTNAMES=${3:?Please specify a hostname pattern: $USAGE}
 ROM_VERSION=${4:?Please provide the ROM version as "3.4.800"}
 
+# Use mlabconfig and the build-iso-template.sh to generate per-machine ROM and
+# ISO build scripts.
 pushd ${BUILD_DIR}
   test -d operator || git clone https://github.com/m-lab/operator
   pushd operator/plsync
@@ -25,7 +31,7 @@ pushd ${BUILD_DIR}
   popd
 popd
 
-
+# Run each per-machine build script.
 for script in `ls ${OUTPUT_DIR}/scripts/build-iso-*.sh` ; do
   echo $script
   chmod 755 $script

--- a/setup_stage3_mlxupdate_isos.sh
+++ b/setup_stage3_mlxupdate_isos.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# setup_stage3_mlxupdate_isos.sh should be run after setup_stage3_mlxupdate.sh
+# has run successfully and the update image and kernel are available.
+
+SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
+
+set -e
+set -x
+
+USAGE="$0 <builddir> <outputdir> <hostname-pattern> <version>"
+BUILD_DIR=${1:?Please specify a build directory: $USAGE}
+OUTPUT_DIR=${2:?Please provide an output directory}
+HOSTNAMES=${3:?Please specify a hostname pattern: $USAGE}
+ROM_VERSION=${4:?Please provide the ROM version as "3.4.800"}
+
+pushd ${BUILD_DIR}
+  test -d operator || git clone https://github.com/m-lab/operator
+  pushd operator/plsync
+    mkdir -p ${OUTPUT_DIR}/scripts
+    ./mlabconfig.py --format=server-network-config \
+        --select "${HOSTNAMES}" \
+        --template_input "${SOURCE_DIR}/configs/stage1_mlxrom/build-iso-template.sh" \
+        --template_output "${OUTPUT_DIR}/scripts/build-iso-{{hostname}}.sh"
+  popd
+popd
+
+
+for script in `ls ${OUTPUT_DIR}/scripts/build-iso-*.sh` ; do
+  echo $script
+  chmod 755 $script
+  $script ${BUILD_DIR} ${OUTPUT_DIR} ${SOURCE_DIR} "${ROM_VERSION}"
+done


### PR DESCRIPTION
This change adds two new build and deploy targets to the .travis.yml for building stage1 ROM images and stage3 mlxupdate ISOs for flashing those ROM images during initial machine setup.

The .travis.yml build step allows us to specify the set of machines and the ROM version number, which should generally increase.

Because both the ISO and ROM images require the network configuration of a single machine, this change also adds a new script `setup_stage3_mlxupdate_isos.sh` which uses mlabconfig.py and a template build script to generate the scripts needed to both build a ROM and ISO for a given machine.

Additionally, this changes updates the behavior of  `create_update_iso.sh` & `updaterom.sh` to construct the ROM URL at run time based on a baseurl passed to `epoxy.mrom=` kernel parameter, the device type, and machine hostname.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/20)
<!-- Reviewable:end -->
