### PR TITLE
Enable epoxy_client build and include in stage2 image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,6 @@ RUN apt-get install -y unzip python-pip git vim-nox make autoconf gcc mkisofs \
     lzma-dev liblzma-dev autopoint pkg-config libtool autotools-dev upx-ucl \
     isolinux bc texinfo libncurses5-dev linux-source debootstrap gcc-4.8 \
     strace cpio squashfs-tools curl lsb-release \
-    linux-source-4.4.0=4.4.0-104.127
+    linux-source-4.4.0=4.4.0-104.127 golang-1.9
 # TODO: remove pinned version on linux-source-4.4.0.
 #       https://github.com/m-lab/epoxy-images/issues/16

--- a/configs/stage2/rc.local
+++ b/configs/stage2/rc.local
@@ -78,7 +78,8 @@ echo "Starting dropbear sshd..."
 dropbear -g
 
 # TODO(soltesz): Publish ssh key.
+# Publish ssh host key before running epoxy_client:
 #    --public_ssh_host_key=/etc/dropbear/dropbear_rsa_host_key.pub
 
-echo "TODO: Downloading next stage from ePoxy"
-# epoxyclient --nextstage
+echo "Downloading next stage from ePoxy"
+epoxy_client --action epoxy.stage2

--- a/setup_stage2.sh
+++ b/setup_stage2.sh
@@ -190,9 +190,22 @@ function build_haveged() {
 }
 
 
-# TODO(soltesz): build epoxyclient.
-function build_epoxyclient() {
-  echo "TODO: build epoxyclient"
+# Builds the epoxy_client command line tool.
+function build_epoxy_client() {
+  local build=$1
+  local vendor=$2
+  local config=$3
+  echo "TODO: build epoxy_client"
+  pushd $build
+    export PATH=$PATH:/usr/lib/go-1.9/bin
+    export GOROOT=/usr/lib/go-1.9
+    export GOPATH=$build
+    # The -ldflags drop another 2.5MB from the binary size.
+    # -w 	Omit the DWARF symbol table.
+    # -s 	Omit the symbol table and debug information.
+    CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client
+    cp $build/bin/epoxy_client $build/local/bin/
+  popd
 }
 
 
@@ -266,8 +279,8 @@ function setup_initramfs() {
     cp $build/local/upx/rngd          sbin
     cp $build/local/upx/haveged       sbin
 
-    # TODO(soltesz): install epoxyclient
-    # cp $build/local/upx/epoxyclient   bin
+    # Install epoxy_client
+    cp $build/local/upx/epoxy_client   bin
 
     ##
     # Install libraries.
@@ -420,14 +433,15 @@ function main() {
   build_kexec kexec-tools-2.0.13 $BUILD_DIR $VENDOR_DIR $CONFIG_DIR
   build_rngd rng-tools-5 $BUILD_DIR $VENDOR_DIR $CONFIG_DIR
   build_haveged haveged-1.9.1 $BUILD_DIR $VENDOR_DIR $CONFIG_DIR
-  build_epoxyclient $BUILD_DIR $VENDOR_DIR $CONFIG_DIR
+  build_epoxy_client $BUILD_DIR $VENDOR_DIR $CONFIG_DIR
 
   compress_binaries $BUILD_DIR/local \
       bin/busybox \
       bin/dropbearmulti \
       sbin/kexec \
       sbin/haveged \
-      sbin/rngd
+      sbin/rngd \
+      bin/epoxy_client
 
   setup_initramfs $BUILD_DIR $CONFIG_DIR $INITRAMFS_DIR
   write_initramfs $INITRAMFS_DIR $INITRAM_NAME


### PR DESCRIPTION
This change enables the building of epoxy_client during the creation of the state2 boot image.

It also runs the epoxy_client during the state2 startup.

Modulo some minor bugs, this should be enough to enable an unacknowledge boot to stage3 coreos on test machines. The next step will be to enable epoxy_client in the customized coreos images so stage3 can be acknowledged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/32)
<!-- Reviewable:end -->
