### PR TITLE
Output minimal logs during stage2 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ script:
 - $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
 
 - mkdir $TRAVIS_BUILD_DIR/output
+
 # Build stage2 vmlinuz image.
 # TODO: clean up args to setup_stage2.sh script.
 # TODO: use alternative to travis_wait to allow build with no output for longer

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,13 +34,13 @@ script:
 # TODO: clean up args to setup_stage2.sh script.
 # TODO: use alternative to travis_wait to allow build with no output for longer
 #       than 10m.
-- time docker run -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
+- time docker run -t -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
       bash -c "/images/setup_stage2.sh
          /buildtmp
          /images/vendor
          /images/configs/stage2
          /images/output/stage2_initramfs.cpio.gz
-         /images/output/stage2_vmlinuz &> /images/stage2.log" || (cat stage2.log && false)
+         /images/output/stage2_vmlinuz | tee /images/stage2.log" || (cat stage2.log && false)
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,12 +35,12 @@ script:
 # TODO: use alternative to travis_wait to allow build with no output for longer
 #       than 10m.
 - time docker run -t -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
-      bash -c "set -e; set -o pipefail; /images/setup_stage2.sh
+      bash -c "/images/setup_stage2.sh
          /buildtmp
          /images/vendor
          /images/configs/stage2
          /images/output/stage2_initramfs.cpio.gz
-         /images/output/stage2_vmlinuz | tee /images/stage2.log" || (cat stage2.log && false)
+         /images/output/stage2_vmlinuz /images/stage2.log" || (cat stage2.log && false)
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ script:
 # TODO: use alternative to travis_wait to allow build with no output for longer
 #       than 10m.
 - time docker run -t -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
-      bash -c "/images/setup_stage2.sh
+      bash -c "set -e; set -o pipefail; /images/setup_stage2.sh
          /buildtmp
          /images/vendor
          /images/configs/stage2

--- a/setup_stage2.sh
+++ b/setup_stage2.sh
@@ -3,9 +3,6 @@
 # Builds a stage2 ePoxy image, including all binary dependencies for a minimal
 # initramfs and stand-alone kernel.
 
-# Report all commands.
-set -x
-
 # Exit on any error.
 set -e
 
@@ -16,6 +13,10 @@ CONFIG_DIR=${3:?Error: Please specify path to configuration directory}
 INITRAM_NAME=${4:?Error: Please specify path of initramfs output file}
 KERNEL_NAME=${5:?Error: Please specify path to vmlinuz output file}
 LOGFILE=${6:?Error: Please specify a path to write build log output}
+
+# Report all commands to log file (set -x writes to stderr).
+exec 2> $LOGFILE
+set -x
 
 
 # Get canonical paths for each argument.
@@ -423,6 +424,8 @@ function build_kernel() {
   popd
 }
 
+
+# Echoes all parameters to stdout, prefixed with the current timestamp.
 function report() {
   echo `date --iso-8601=seconds` $@
 }


### PR DESCRIPTION
This change fixes the build from https://github.com/m-lab/epoxy-images/pull/32

This change updates the behavior of setup_stage2.sh to:

 * log all activity to a file
 * periodically output short log messages

This change is necessary because travis judges a build as progressing if it sees some output within 10min of the last output. And, evidently, recent changes have pushed the stage2 build beyond 10min.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/33)
<!-- Reviewable:end -->
