### PR TITLE
Update stage1 target in stage1 template config

### DIFF
--- a/configs/stage1_mlxrom/stage1-template.ipxe
+++ b/configs/stage1_mlxrom/stage1-template.ipxe
@@ -18,8 +18,8 @@ set net0/netmask {{netmask}}
 set net0/dns {{dns1}}
 set hostname {{hostname}}
 
-# The ePoxy nextboot URL.
-set nextboot_url https://${epoxyaddress}/v1/boot/${hostname}/stage2.ipxe
+# The ePoxy stage1 URL.
+set stage1_url https://${epoxyaddress}/v1/boot/${hostname}/stage1.ipxe
 
 ########################################
 # Boot menu.
@@ -28,7 +28,7 @@ set nextboot_url https://${epoxyaddress}/v1/boot/${hostname}/stage2.ipxe
   inc menu_timeout_ms ${menu_timeout_ms}
   menu M-Lab iPXE boot menu: ${epoxyaddress}
     item --gap --   Production options:
-    item nextboot   -- Boot nextboot script
+    item stage1     -- Boot stage1 script
     item localboot  -- Boot local disk
     item --gap
     item --gap --   Diagnostic options:
@@ -59,8 +59,8 @@ set nextboot_url https://${epoxyaddress}/v1/boot/${hostname}/stage2.ipxe
 
 ########################################
 # Production options.
-:nextboot
-  echo Fetching nextboot script.
+:stage1
+  echo Fetching stage1 script.
   goto firstfetch
 
 :retry_loop iseq ${retry_delay_s} ${max_retry_delay_s} && goto fetch_timeout_local_boot ||
@@ -83,18 +83,18 @@ set nextboot_url https://${epoxyaddress}/v1/boot/${hostname}/stage2.ipxe
   param ip           ${ip}            # IP address.
   param version      ${version}       # iPXE version.
 
-  imgfetch --name nextboot.ipxe --timeout ${fetch_timeout_ms} ${nextboot_url}##params || goto retry_loop
-  # imgfetch --name nextboot.ipxe --timeout ${fetch_timeout_ms} ${nextboot_url} || goto retry_loop
+  # Issues an HTTP POST request.
+  imgfetch --name stage1.ipxe --timeout ${fetch_timeout_ms} ${stage1_url}##params || goto retry_loop
 :loop_done
 
 
 :verify_image
-  echo Verifying and booting nextboot script.
-  chain     nextboot.ipxe              || goto verify_error
+  echo Verifying and booting stage1 script.
+  chain     stage1.ipxe              || goto verify_error
 
 
 :verify_error
-  echo Failed to chain load nextboot script. Sleeping 5 seconds and starting over.
+  echo Failed to chain load stage1 script. Sleeping 5 seconds and starting over.
   sleep 5
   goto startmenu
 

--- a/setup_stage2.sh
+++ b/setup_stage2.sh
@@ -259,7 +259,7 @@ function setup_initramfs() {
     # Create top level directories.
     for dir in bin sbin usr/bin usr/sbin proc sys dev/pts \
         etc/ssl etc/dropbear lib/${ARCH}-linux-gnu lib64 \
-        var/run var/log root/.ssh newroot ; do
+        var/run var/log root/.ssh newroot tmp ; do
       mkdir -p $dir
     done
 


### PR DESCRIPTION
This change updates the stage1 template configuration to target the stage1.ipxe url on the epoxy server. This change additionally updates references in the template to reflect this name change.

This change fixes a minor bug in the stage2 image by creating a /tmp directory needed by the `epoxy_client` (but previously nothing else, surprisingly).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/34)
<!-- Reviewable:end -->
