### PR TITLE
Add epoxy client to stage3 images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,12 +41,14 @@ script:
          /images/vendor
          /images/configs/stage2
          /images/output/stage2_initramfs.cpio.gz
-         /images/output/stage2_vmlinuz /images/stage2.log" || (cat stage2.log && false)
+         /images/output/stage2_vmlinuz
+         /images/output/epoxy_client /images/stage2.log" || (cat stage2.log && false)
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
 - time docker run -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
       bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
+        /images/output/epoxy_client
         http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe.vmlinuz
         http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
         /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (cat coreos.log && false)
@@ -68,10 +70,12 @@ script:
 - time docker run -it --privileged -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
       bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && echo 'Starting stage3_mlxupdate build'
-        && /images/setup_stage3_mlxupdate.sh /build /images/output /images/configs/stage3_mlxupdate
+        && /images/setup_stage3_mlxupdate.sh
+                /build /images/output /images/configs/stage3_mlxupdate
+                /images/output/epoxy_client
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
-        && /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.802
+        && /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.804
           &> /images/stage3_mlxupdate_iso.log" || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 

--- a/configs/stage3_coreos/resources/setup_after_boot.sh
+++ b/configs/stage3_coreos/resources/setup_after_boot.sh
@@ -3,9 +3,5 @@
 # setup_after_boot.sh will run after boot and only once the network is online.
 # The script runs as the root user.
 
-# TODO: do something useful.
-echo "After Boot Script!"
-date > /tmp/after_boot.success
-ifconfig >> /tmp/after_boot.success
-whoami >> /tmp/after_boot.success
-echo "ABS: success!"
+echo "Running epoxy client"
+/usr/bin/epoxy_client -action epoxy.stage3

--- a/configs/stage3_mlxupdate/rc.local
+++ b/configs/stage3_mlxupdate/rc.local
@@ -43,6 +43,9 @@ echo "Configuring network..."
 setup_network
 
 
-# TODO(soltesz): enable automatic rom update.
-echo "WARNING: the ROM update is not yet complete."
-echo "WARNING: to complete update, run: /usr/local/util/updaterom.sh"
+# Note: the stage3 action should be configured in the epoxy server. The nextboot
+# config returned should probably run /usr/local/util/updaterom.sh
+/usr/bin/epoxy_client -action epoxy.stage3
+
+# TODO: automate reboot on success.
+echo "WARNING: if the update was successful, reboot machine."

--- a/setup_stage2.sh
+++ b/setup_stage2.sh
@@ -12,7 +12,8 @@ VENDOR_DIR=${2:?Error: Please specify path to vendor package directory}
 CONFIG_DIR=${3:?Error: Please specify path to configuration directory}
 INITRAM_NAME=${4:?Error: Please specify path of initramfs output file}
 KERNEL_NAME=${5:?Error: Please specify path to vmlinuz output file}
-LOGFILE=${6:?Error: Please specify a path to write build log output}
+EPOXY_CLIENT=${6:?Error: Please specify path of epoxy_client output file}
+LOGFILE=${7:?Error: Please specify a path to write build log output}
 
 # Report all commands to log file (set -x writes to stderr).
 exec 2> $LOGFILE
@@ -458,6 +459,9 @@ function main() {
 
   report "Building stage2 kernel"
   build_kernel $BUILD_DIR $CONFIG_DIR $INITRAMFS_DIR $INITRAM_NAME $KERNEL_NAME &>> $LOGFILE
+
+  report "Copying epoxy_client"
+  install -D -m 644 $BUILD_DIR/local/upx/epoxy_client $EPOXY_CLIENT
 }
 
 main

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -7,11 +7,12 @@
 
 set -e
 set -x
-USAGE="USAGE: $0 <config dir> <vmlinuz-url> <initram-url> <custom-initram-name>"
+USAGE="USAGE: $0 <config dir> <epoxy-client> <vmlinuz-url> <initram-url> <custom-initram-name>"
 CONFIG_DIR=${1:?Please specify path to configuration directory: $USAGE}
-VMLINUZ_URL=${2:?Please provide the URL for a coreos vmlinuz image: $USAGE}
-INITRAM_URL=${3:?Please provide the URL for a coreos initram image: $USAGE}
-CUSTOM=${4:?Please provide the name for a customized initram image: $USAGE}
+EPOXY_CLIENT=${2:?Please specify the path to the epoxy client binary: $USAGE}
+VMLINUZ_URL=${3:?Please provide the URL for a coreos vmlinuz image: $USAGE}
+INITRAM_URL=${4:?Please provide the URL for a coreos initram image: $USAGE}
+CUSTOM=${5:?Please provide the name for a customized initram image: $USAGE}
 
 SCRIPTDIR=$( dirname "${BASH_SOURCE[0]}" )
 
@@ -42,6 +43,9 @@ pushd $IMAGEDIR
 
   # Copy resources to the "/usr/share/oem" directory.
   cp -a ${CONFIG_DIR}/resources/* squashfs-root/share/oem/
+
+  # Copy epoxy client to squashfs bin.
+  cp -a ${EPOXY_CLIENT} squashfs-root/bin
 
   # Rebuild the squashfs and cpio image.
   mksquashfs squashfs-root initrd-contents/usr.squashfs \

--- a/setup_stage3_mlxupdate.sh
+++ b/setup_stage3_mlxupdate.sh
@@ -20,6 +20,9 @@ OUTPUT_DIR=$( realpath $OUTPUT_DIR )
 CONFIG_DIR=${3:?Name of directory containing configuration files}
 CONFIG_DIR=$( realpath $CONFIG_DIR )
 
+EPOXY_CLIENT=${4:?Name of epoxy client binary to include in output initram}
+EPOXY_CLIENT=$( realpath $EPOXY_CLIENT )
+
 CONFIG_NAME=$( basename $CONFIG_DIR )
 BOOTSTRAP=${BUILD_DIR}/initramfs_${CONFIG_NAME}
 OUTPUT_KERNEL=${BUILD_DIR}/vmlinuz_${CONFIG_NAME}
@@ -215,9 +218,10 @@ mkdir -p $BOOTSTRAP/usr/local/util
 cp $CONFIG_DIR/flashrom.sh $BOOTSTRAP/usr/local/util
 cp $CONFIG_DIR/updaterom.sh $BOOTSTRAP/usr/local/util
 ################################################################################
-# TODO:
+# Add epoxy client to initramfs
 ################################################################################
 # Make updaterom run automatically after start up.
+install -D -m 755 $EPOXY_CLIENT $BOOTSTRAP/usr/bin/epoxy_client
 
 # Build the initramfs from the bootstrap filesystem.
 pushd $BOOTSTRAP

--- a/setup_stage3_mlxupdate.sh
+++ b/setup_stage3_mlxupdate.sh
@@ -220,7 +220,6 @@ cp $CONFIG_DIR/updaterom.sh $BOOTSTRAP/usr/local/util
 ################################################################################
 # Add epoxy client to initramfs
 ################################################################################
-# Make updaterom run automatically after start up.
 install -D -m 755 $EPOXY_CLIENT $BOOTSTRAP/usr/bin/epoxy_client
 
 # Build the initramfs from the bootstrap filesystem.


### PR DESCRIPTION
This change adds the epoxy_client to the current stage3 coreos and mlxupdate images.

This change will enable stage3 actions after boot up, for example:

 * run updaterom.sh after booting the mlxupdate image
 * run k8s setup after booting the coreos image

This change modifies setup_stage2.sh to copy the epoxy_client binary to an output location so that it can be provided to the stage3 build scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/37)
<!-- Reviewable:end -->
