### PR TITLE
Add stage3 actions & Fix epoxy_client mode & Run update ISOs automatically

### DIFF
--- a/actions/stage3_coreos/stage2to3.json
+++ b/actions/stage3_coreos/stage2to3.json
@@ -1,0 +1,35 @@
+{
+   "v1" : {
+      "env" : {
+         "PATH" : "/bin:/usr/bin:/usr/local/bin"
+      },
+      "files" : {
+         "vmlinuz" : {
+            "url" : "https://storage.googleapis.com/epoxy-mlab-staging/stage3_coreos/coreos_production_pxe.vmlinuz"
+         },
+         "initram" : {
+            "url" : "https://storage.googleapis.com/epoxy-mlab-staging/stage3_coreos/coreos_custom_pxe_image.cpio.gz"
+         }
+      },
+      "vars" : {
+         "kargs" : [
+            "epoxy.ip={{kargs `epoxy.ip`}}",
+            "epoxy.stage3={{kargs `epoxy.stage3`}}",
+            "epoxy.report={{kargs `epoxy.report`}}",
+            "epoxy.server={{kargs `epoxy.server`}}"
+         ],
+         "cmdline" : "net.ifnames=0 coreos.autologin=tty1"
+      },
+      "commands" : [
+         "# Run kexec using the downloaded initram and vmlinuz files.",
+         [
+            "/sbin/kexec",
+            "--force",
+            "--command-line={{.vars.kargs}} {{.vars.cmdline}}",
+            "--initrd",
+            "{{.files.initram.name}}",
+            "{{.files.vmlinuz.name}}"
+         ]
+      ]
+   }
+}

--- a/actions/stage3_coreos/stage3post.json
+++ b/actions/stage3_coreos/stage3post.json
@@ -1,0 +1,17 @@
+{
+   "v1" : {
+      "env" : {
+         "PATH" : "/bin:/usr/bin:/usr/local/bin"
+      },
+      "files" : {
+         "setup_k8s" : {
+            "url" : "https://storage.googleapis.com/epoxy-mlab-staging/stage3_coreos/setup_k8s.sh"
+         }
+      },
+      "commands" : [
+         "# Make setup_k8s.sh executable and then run with the epoxy.ipv4 config",
+         "/usr/bin/chmod 755 {{.files.setup_k8s.name}}",
+         "{{.files.setup_k8s.name}} {{kargs `epoxy.ipv4`}}"
+      ]
+   }
+}

--- a/actions/stage3_mlxupdate/stage2to3.json
+++ b/actions/stage3_mlxupdate/stage2to3.json
@@ -1,0 +1,36 @@
+{
+   "v1" : {
+      "env" : {
+         "PATH" : "/bin:/usr/bin:/usr/local/bin"
+      },
+      "files" : {
+         "vmlinuz" : {
+            "url" : "https://storage.googleapis.com/epoxy-mlab-staging/stage3_mlxupdate/vmlinuz_stage3_mlxupdate"
+         },
+         "initram" : {
+            "url" : "https://storage.googleapis.com/epoxy-mlab-staging/stage3_mlxupdate/initramfs_stage3_mlxupdate.cpio.gz"
+         }
+      },
+      "vars" : {
+         "kargs" : [
+            "epoxy.ip={{kargs `epoxy.ip`}}",
+            "epoxy.stage3={{kargs `epoxy.stage3`}}",
+            "epoxy.report={{kargs `epoxy.report`}}",
+            "epoxy.server={{kargs `epoxy.server`}}",
+            "epoxy.mrom=https://storage.googleapis.com/epoxy-mlab-staging/stage1_mlxrom/3.4.804"
+         ],
+         "cmdline" : "net.ifnames=0 coreos.autologin=tty1"
+      },
+      "commands" : [
+         "# Run kexec using the downloaded initram and vmlinuz files.",
+         [
+            "/sbin/kexec",
+            "--force",
+            "--command-line={{.vars.kargs}} {{.vars.cmdline}}",
+            "--initrd",
+            "{{.files.initram.name}}",
+            "{{.files.vmlinuz.name}}"
+         ]
+      ]
+   }
+}

--- a/actions/stage3_mlxupdate/stage3post.json
+++ b/actions/stage3_mlxupdate/stage3post.json
@@ -1,0 +1,13 @@
+{
+   "v1" : {
+      "env" : {
+         "PATH" : "/bin:/usr/bin:/usr/local/bin"
+      },
+      "commands" : [
+         "# Run the updaterom utility.",
+         [
+            "/usr/local/util/updaterom.sh"
+         ]
+      ]
+   }
+}

--- a/create_update_iso.sh
+++ b/create_update_iso.sh
@@ -49,6 +49,10 @@ URL=https://storage.googleapis.com/epoxy-mlab-staging
 # model and constructs the full path ROM based on the system hostname.
 ARGS+="epoxy.mrom=$URL/stage1_mlxrom/${ROM_VERSION} "
 
+# Note: Add a epoxy.stage3 action so the mlxupdate can automatically run
+# updaterom.sh after boot.
+ARGS+="epoxy.stage3=$URL/stage3_mlxupdate/stage3post.json "
+
 
 SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
 ${SOURCE_DIR}/simpleiso -x "$ARGS" \

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -45,7 +45,7 @@ pushd $IMAGEDIR
   cp -a ${CONFIG_DIR}/resources/* squashfs-root/share/oem/
 
   # Copy epoxy client to squashfs bin.
-  cp -a ${EPOXY_CLIENT} squashfs-root/bin
+  install -D -m 755 ${EPOXY_CLIENT} squashfs-root/bin/
 
   # Rebuild the squashfs and cpio image.
   mksquashfs squashfs-root initrd-contents/usr.squashfs \


### PR DESCRIPTION
Now that epoxy_client is embedded in the stage3 images for coreos and mlxupdate, we can define epoxy_client actions to run post boot.

This PR makes the epoxy_client mode executable in the coreos image (oops). And, adds an explicit action for mlxupdate ISO images so ROM updates occur automatically upon boot.

Finally, this PR adds action definitions for stage3_coreos and stage3_mlxupdate. In both cases,

 * stage2to3.json defines the images to download and kexec command to run for stage3
 * stage3post.json defines the command to run after booting stage3

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/39)
<!-- Reviewable:end -->
