### PR TITLE
Add project parameters for stage1 ROMs and stage3 update ISOs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,6 +67,9 @@ script:
 # Note: setup_stage3_mlxupdate_isos.sh depends on build artifacts from
 # setup_stage3_mlxupdate.sh in /build. If these are not present,
 # setup_stage3_mlxupdate_isos.sh will fail to generate ISOs.
+#
+# Note: reserve mlab4.lga0t for mlab-sandbox and mlab1-3.lga0t for mlab-staging.
+# TODO: larger sets of per-project images must be built outside of travis.
 - time docker run -it --privileged -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
       bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && echo 'Starting stage3_mlxupdate build'
@@ -75,8 +78,11 @@ script:
                 /images/output/epoxy_client
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
-        && /images/setup_stage3_mlxupdate_isos.sh /build /images/output '.*lga0t.*' 3.4.804
-          &> /images/stage3_mlxupdate_iso.log" || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
+        && /images/setup_stage3_mlxupdate_isos.sh
+            mlab-sandbox /build /images/output 'mlab4.lga0t.*' 3.4.805 &> /images/stage3_mlxupdate_iso.log
+        && /images/setup_stage3_mlxupdate_isos.sh
+            mlab-staging /build /images/output 'mlab[1-3].lga0t.*' 3.4.805 &>> /images/stage3_mlxupdate_iso.log"
+        || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger

--- a/configs/stage1_mlxrom/README.md
+++ b/configs/stage1_mlxrom/README.md
@@ -5,6 +5,7 @@ An example command that will be integrated into the travis build.
 
 ```
 ./setup_stage1.sh \
+    mlab-sandbox \
     /build \
     $PWD/configs/stage1_mlxrom \
     ".*lga0t.*" \
@@ -45,8 +46,8 @@ echo | openssl s_client \
     -connect storage.googleapis.com:443 2>/dev/null | openssl x509 -text
 
 echo | openssl s_client \
-    -servername boot-api-dot-mlab-staging.appspot.com \
-    -connect boot-api-dot-mlab-staging.appspot.com:443 2>/dev/null | openssl x509 -text
+    -servername boot-api-dot-mlab-sandbox.appspot.com \
+    -connect boot-api-dot-mlab-sandbox.appspot.com:443 2>/dev/null | openssl x509 -text
 ```
 
 Both certificates report:

--- a/configs/stage1_mlxrom/build-iso-template.sh
+++ b/configs/stage1_mlxrom/build-iso-template.sh
@@ -8,14 +8,18 @@
 # Note: this script should execute within the epoxy-image builer docker image.
 # Note: this script depends on the availability of the stage3_mlxupdate images.
 
+set -x
+
 BUILD_DIR=${1:?Please specify a build directory}
 OUTPUT_DIR=${2:?Please provide an output directory}
 SOURCE_DIR=${3:?Please provide the base source directory}
 ROM_VERSION=${4:?Please provide the ROM version as "3.4.800"}
 
 ${SOURCE_DIR}/setup_stage1.sh \
-    "${BUILD_DIR}" "${OUTPUT_DIR}" ${SOURCE_DIR}/configs/stage1_mlxrom \
-    "{{hostname}}" "${ROM_VERSION}" "${SOURCE_DIR}/configs/stage1_mlxrom/gtsgiag3.pem"
+    "{{project}}" "${BUILD_DIR}" "${OUTPUT_DIR}" \
+    ${SOURCE_DIR}/configs/stage1_mlxrom \
+    "{{hostname}}" "${ROM_VERSION}" \
+    "${SOURCE_DIR}/configs/stage1_mlxrom/gtsgiag3.pem"
 
 if [[ {{netmask}} != "255.255.255.192" ]] ; then
   echo 'Error: Sorry, unsupported netmask: {{netmask}}'
@@ -24,5 +28,5 @@ fi
 mask=26
 
 ${SOURCE_DIR}/create_update_iso.sh \
-    "${BUILD_DIR}" "${OUTPUT_DIR}" "${ROM_VERSION}" \
+    "{{project}}" "${BUILD_DIR}" "${OUTPUT_DIR}" "${ROM_VERSION}" \
     "{{hostname}}" "{{ip}}/${mask}" "{{gateway}}" "{{dns1}}" "8.8.4.4"

--- a/configs/stage1_mlxrom/stage1-template.ipxe
+++ b/configs/stage1_mlxrom/stage1-template.ipxe
@@ -1,8 +1,7 @@
 #!ipxe
 
 # Global settings.
-# TODO(soltesz): how to make this address configurable?
-set epoxyaddress boot-api-dot-mlab-staging.appspot.com
+set epoxyaddress boot-api-dot-{{project}}.appspot.com
 
 set menu_timeout_ms:int32 5000
 set fetch_timeout_ms 10000

--- a/create_update_iso.sh
+++ b/create_update_iso.sh
@@ -6,15 +6,18 @@
 # configuration for the kernel command line, which allows standard network
 # scripts to setup the network at boot time.
 
-USAGE="$0 <image-dir> <rom-version> <hostname> <ipv4-address>/<mask> <ipv4-gateway> [<dns1>][, <dns2>]"
-IMAGE_DIR=${1:?Error: specify input directory with vmlinuz and initram: $USAGE}
-OUTPUT_DIR=${2:?Error: specify directory for output ISO: $USAGE}
-ROM_VERSION=${3:?Error: please specify the ROM version as "3.4.800": $USAGE}
-HOSTNAME=${4:?Error: please specify the server FQDN: $USAGE}
-IPV4_ADDR=${5:?Error: please specify the server IPv4 address with mask: $USAGE}
-IPV4_GATEWAY=${6:?Error: please specify the server IPv4 gateway address: $USAGE}
-DNS1=${7:-8.8.8.8}
-DNS2=${8:-8.8.4.4}
+set -x
+
+USAGE="$0 <project> <image-dir> <rom-version> <hostname> <ipv4-address>/<mask> <ipv4-gateway> [<dns1>][, <dns2>]"
+PROJECT=${1:?Please provide the GCP Project}
+IMAGE_DIR=${2:?Error: specify input directory with vmlinuz and initram: $USAGE}
+OUTPUT_DIR=${3:?Error: specify directory for output ISO: $USAGE}
+ROM_VERSION=${4:?Error: please specify the ROM version as "3.4.800": $USAGE}
+HOSTNAME=${5:?Error: please specify the server FQDN: $USAGE}
+IPV4_ADDR=${6:?Error: please specify the server IPv4 address with mask: $USAGE}
+IPV4_GATEWAY=${7:?Error: please specify the server IPv4 gateway address: $USAGE}
+DNS1=${8:-8.8.8.8}
+DNS2=${9:-8.8.4.4}
 
 if [[ ! -f ${IMAGE_DIR}/initramfs_stage3_mlxupdate.cpio.gz || \
       ! -f ${IMAGE_DIR}/vmlinuz_stage3_mlxupdate ]] ; then
@@ -43,8 +46,7 @@ ARGS+="epoxy.interface=eth0 "
 ARGS+="epoxy.ipv4=${IPV4_ADDR},${IPV4_GATEWAY},${DNS1},${DNS2} "
 
 # Add URL to the epoxy ROM image.
-# TODO: how to optionally change this between sandbox, staging, and oti?
-URL=https://storage.googleapis.com/epoxy-mlab-staging
+URL=https://storage.googleapis.com/epoxy-${PROJECT}
 # Note: Only encode the base URL. The download script detects the device
 # model and constructs the full path ROM based on the system hostname.
 ARGS+="epoxy.mrom=$URL/stage1_mlxrom/${ROM_VERSION} "

--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -10,13 +10,14 @@ set -e
 
 SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
 
-USAGE="$0 <builddir> <output dir> <mlxrom-config> <hostname-pattern> <rom-version> <embed-cert1,embed-cert2>"
-BUILD_DIR=${1:?Please specify a build directory: $USAGE}
-OUTPUT_DIR=${2:?Please specify an output directory: $USAGE}
-CONFIG_DIR=${3:?Please specify a configuration directory: $USAGE}
-HOSTNAMES=${4:?Please specify a hostname pattern: $USAGE}
-ROM_VERSION=${5:?Please specify the ROM version as "3.4.800": $USAGE}
-CERTS=${6:?Please specify trusted certs to embed in ROM: $USAGE}
+USAGE="$0 <project> <builddir> <output dir> <mlxrom-config> <hostname-pattern> <rom-version> <embed-cert1,embed-cert2>"
+PROJECT=${1:?Please specify the GCP project to contact: $USAGE}
+BUILD_DIR=${2:?Please specify a build directory: $USAGE}
+OUTPUT_DIR=${3:?Please specify an output directory: $USAGE}
+CONFIG_DIR=${4:?Please specify a configuration directory: $USAGE}
+HOSTNAMES=${5:?Please specify a hostname pattern: $USAGE}
+ROM_VERSION=${6:?Please specify the ROM version as "3.4.800": $USAGE}
+CERTS=${7:?Please specify trusted certs to embed in ROM: $USAGE}
 
 # unpack checks whether the given directory exists and if it does not unpacks
 # the given tar archive (which should create the directory).
@@ -77,6 +78,7 @@ function generate_stage1_ipxe_scripts() {
       mkdir -p ${output_dir}
       ./mlabconfig.py --format=server-network-config \
           --select "${hostname_pattern}" \
+          --label "project=${PROJECT}" \
           --template_input "${config_dir}/stage1-template.ipxe" \
           --template_output "${output_dir}/stage1-{{hostname}}.ipxe"
     popd

--- a/setup_stage3_mlxupdate_isos.sh
+++ b/setup_stage3_mlxupdate_isos.sh
@@ -13,10 +13,11 @@ set -e
 set -x
 
 USAGE="$0 <builddir> <outputdir> <hostname-pattern> <version>"
-BUILD_DIR=${1:?Please specify a build directory: $USAGE}
-OUTPUT_DIR=${2:?Please provide an output directory}
-HOSTNAMES=${3:?Please specify a hostname pattern: $USAGE}
-ROM_VERSION=${4:?Please provide the ROM version as "3.4.800"}
+PROJECT=${1:?Please provide the GCP Project}
+BUILD_DIR=${2:?Please specify a build directory: $USAGE}
+OUTPUT_DIR=${3:?Please provide an output directory}
+HOSTNAMES=${4:?Please specify a hostname pattern: $USAGE}
+ROM_VERSION=${5:?Please provide the ROM version as "3.4.800"}
 
 # Use mlabconfig and the build-iso-template.sh to generate per-machine ROM and
 # ISO build scripts.
@@ -26,6 +27,7 @@ pushd ${BUILD_DIR}
     mkdir -p ${OUTPUT_DIR}/scripts
     ./mlabconfig.py --format=server-network-config \
         --select "${HOSTNAMES}" \
+        --label "project=${PROJECT}" \
         --template_input "${SOURCE_DIR}/configs/stage1_mlxrom/build-iso-template.sh" \
         --template_output "${OUTPUT_DIR}/scripts/build-iso-{{hostname}}.sh"
   popd


### PR DESCRIPTION
This change adds the GCP project as an explicit parameter to the image build scripts.

With this change, it is possible to target ROMs and update images at different GCP projects. In particular, the build now creates images for mlab4.lga0t tied to mlab-sandbox and mlab1-3 tied to mlab-staging.

In the future, per-project images should be built outside of travis. For now, this change will enable sandbox development and testing before review and without interfering with the operation of staging servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/40)
<!-- Reviewable:end -->
