### PR TITLE
Add disk formatting steps to first boot setup

### DIFF
--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -29,6 +29,104 @@ coreos:
     - name: systemd-networkd.service
       command: restart
 
+    # Configs to move the Docker data volume.
+    - name: "docker.service"
+      drop-ins:
+        - name: "10-data-root.conf"
+          content: |
+            [Service]
+            Environment=DOCKER_OPTS=--data-root=/cache/docker
+
+            [Unit]
+            # The docker service depends on the /cache/docker volume.
+            Requires=cache-docker.mount
+            After=cache-docker.mount
+
+    - name: format-cache.service
+      command: start
+      contents: |
+        [Unit]
+        Before=docker.service cache-docker.mount cache-data.mount cache-core.mount
+        RequiresMountsFor=/cache
+        ConditionPathExists=!/cache/docker
+        [Service]
+        Type=oneshot
+        # Create cache directory in root filesystem.
+        ExecStart=/usr/bin/mkdir -p /cache
+
+        # Clear any remaining LVM configs from prior installations.
+        ExecStart=/usr/sbin/dmsetup remove_all --force
+
+        # For a 500GB disk, this is roughly:
+        #  * 250G for experiment data.
+        #  * 150G for core experiment data.
+        #  * 100G for docker image cache.
+        ExecStart=/usr/sbin/parted --align=optimal --script /dev/sda \
+            mklabel gpt \
+            mkpart data ext4 0% 50% \
+            mkpart core ext4 50% 80% \
+            mkpart docker ext4 80% 100%
+
+        # Format and label each partition.
+        # Note: the labels could make the formatting conditional in the future.
+        ExecStart=/usr/sbin/mke2fs -t ext4 -F -L cache-data /dev/sda1
+        ExecStart=/usr/sbin/mke2fs -t ext4 -F -L cache-core /dev/sda2
+        ExecStart=/usr/sbin/mke2fs -t ext4 -F -L cache-docker /dev/sda3
+
+    - name: cache-docker.mount
+      enable: true
+      contents: |
+        [Unit]
+        Description=Mount Docker Data Volume
+        Before=docker.service
+        After=format-cache.service
+        Requires=format-cache.service
+
+        [Mount]
+        What=/dev/disk/by-label/cache-docker
+        Where=/cache/docker
+        Type=ext4
+        Options=defaults
+
+        [Install]
+        RequiredBy=docker.service
+
+    - name: cache-data.mount
+      enable: true
+      content: |
+        [Unit]
+        Description=Mount Experiment Data Volume
+        Before=docker.service
+        After=format-cache.service
+        Requires=format-cache.service
+
+        [Mount]
+        What=/dev/disk/by-label/cache-data
+        Where=/cache/data
+        Type=ext4
+        Options=defaults
+
+        [Install]
+        RequiredBy=docker.service
+
+    - name: cache-core.mount
+      enable: true
+      content: |
+        [Unit]
+        Description=Mount Core Experiment Data Volume
+        Before=docker.service
+        After=format-cache.service
+        Requires=format-cache.service
+
+        [Mount]
+        What=/dev/disk/by-label/cache-core
+        Where=/cache/core
+        Type=ext4
+        Options=defaults
+
+        [Install]
+        RequiredBy=docker.service
+
     # Add a new unit to run the post-boot script after the network is online.
     - name: setup-after-boot.service
       command: start
@@ -45,88 +143,6 @@ coreos:
         Type=oneshot
         ExecStart=/usr/share/oem/setup_after_boot.sh
 
-    # TODO: try - https://coreos.com/os/docs/latest/mounting-storage.html#creating-and-mounting-a-btrfs-volume-file
-    # Docker volume mount unit definition.
-    - name: cache-docker.mount
-      enable: true
-      content: |
-        [Unit]
-        Description=Mount Docker Data Volume
-        After=setup-after-boot.service
-
-        [Mount]
-        What=/dev/disk/by-label/cache-docker
-        Where=/cache/docker
-        Type=ext4
-        Options=defaults
-
-        [Install]
-        WantedBy=multi-user.target
-
-    # Configs to move the Docker data volume.
-    - name: "docker.service"
-      drop-ins:
-        - name: "10-data-root.conf"
-          content: |
-            [Service]
-            Environment=DOCKER_OPTS=--data-root=/cache/docker
-
-            [Unit]
-            # The docker service depends on the /cache/docker volume.
-            Requires=cache-docker.mount
-            After=cache-docker.mount
-
-write_files:
-  - path: "/etc/systemd/system/cache-data.mount"
-    permissions: "0644"
-    owner: "root"
-    content: |
-        [Unit]
-        Description=Mount Experiment Data Volume
-        After=setup-after-boot.service
-
-        [Mount]
-        What=/dev/disk/by-label/cache-data
-        Where=/cache/data
-        Type=ext4
-        Options=defaults
-
-        [Install]
-        WantedBy=multi-user.target
-
-  - path: "/etc/systemd/system/cache-core.mount"
-    permissions: "0644"
-    owner: "root"
-    content: |
-        [Unit]
-        Description=Mount Core Data Volume
-        After=setup-after-boot.service
-
-        [Mount]
-        What=/dev/disk/by-label/cache-core
-        Where=/cache/core
-        Type=ext4
-        Options=defaults
-
-        [Install]
-        WantedBy=multi-user.target
-
-#  - path: "/etc/systemd/system/cache-docker.mount"
-#    permissions: "0644"
-#    owner: "root"
-#    content: |
-#        [Unit]
-#        Description=Mount Docker Data Volume
-#        After=setup-after-boot.service
-#
-#        [Mount]
-#        What=/dev/disk/by-label/cache-docker
-#        Where=/cache/docker
-#        Type=ext4
-#        Options=defaults
-#
-#        [Install]
-#        WantedBy=multi-user.target
 
 # TODO: collect list of ssh keys from a metadata service during post-boot setup.
 ssh_authorized_keys:

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -45,6 +45,7 @@ coreos:
         Type=oneshot
         ExecStart=/usr/share/oem/setup_after_boot.sh
 
+    # TODO: try - https://coreos.com/os/docs/latest/mounting-storage.html#creating-and-mounting-a-btrfs-volume-file
     # Docker volume mount unit definition.
     - name: cache-docker.mount
       enable: true

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -45,6 +45,65 @@ coreos:
         Type=oneshot
         ExecStart=/usr/share/oem/setup_after_boot.sh
 
+    - name: "docker.service"
+      drop-ins:
+        - name: "10-data-root.conf"
+          content: |
+            [Service]
+            Environment=DOCKER_OPTS=--data-root=/cache/docker
+
+write_files:
+  - path: "/etc/systemd/system/cache-data.mount"
+    permissions: "0644"
+    owner: "root"
+    content: |
+        [Unit]
+        Description=Mount Experiment Data Volume
+        After=setup-after-boot.service
+
+        [Mount]
+        What=/dev/disk/by-label/cache-data
+        Where=/cache/data
+        Type=ext4
+        Options=defaults
+
+        [Install]
+        WantedBy=multi-user.target
+
+  - path: "/etc/systemd/system/cache-core.mount"
+    permissions: "0644"
+    owner: "root"
+    content: |
+        [Unit]
+        Description=Mount Core Data Volume
+        After=setup-after-boot.service
+
+        [Mount]
+        What=/dev/disk/by-label/cache-core
+        Where=/cache/core
+        Type=ext4
+        Options=defaults
+
+        [Install]
+        WantedBy=multi-user.target
+
+  - path: "/etc/systemd/system/cache-docker.mount"
+    permissions: "0644"
+    owner: "root"
+    content: |
+        [Unit]
+        Description=Mount Docker Data Volume
+        After=setup-after-boot.service
+
+        [Mount]
+        What=/dev/disk/by-label/cache-docker
+        Where=/cache/docker
+        Type=ext4
+        Options=defaults
+
+        [Install]
+        WantedBy=multi-user.target
+
 # TODO: collect list of ssh keys from a metadata service during post-boot setup.
 ssh_authorized_keys:
  - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvIKeMHcEO1xnTmEdMY6E9Y4pBdGBCDXZnuQC5ZPjNQr9IG3ytw0OxwyCObAzSr+WOymYv6Cwm4Ckz2jc/bWygzWJH+DMdldZe7HVQu4YxuegqahIkB0D1OzaZGNctBgTp9bmpWGxyek7U8ff7GTiFqhcms4Oer4rdd0gqUhmv3LnRWQqrIDblrBosHBED/zXgjbOj3beWCA3xHDCaui/gkbmp0J2jzCnlsc7eSI0d6Jro2UhbiS2ssxVQsLViLh5okJJeb2JyzbLbcpselUg9DSwSk0pFH/wHL0usjvBisF/fEP8eQ1svq6N6gncvPlgoJaSvtACmDvIFkU4baA2v pboothe@pboothe3.nyc.corp.google.com"

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -45,12 +45,35 @@ coreos:
         Type=oneshot
         ExecStart=/usr/share/oem/setup_after_boot.sh
 
+    # Docker volume mount unit definition.
+    - name: cache-docker.mount
+      enable: true
+      content: |
+        [Unit]
+        Description=Mount Docker Data Volume
+        After=setup-after-boot.service
+
+        [Mount]
+        What=/dev/disk/by-label/cache-docker
+        Where=/cache/docker
+        Type=ext4
+        Options=defaults
+
+        [Install]
+        WantedBy=multi-user.target
+
+    # Configs to move the Docker data volume.
     - name: "docker.service"
       drop-ins:
         - name: "10-data-root.conf"
           content: |
             [Service]
             Environment=DOCKER_OPTS=--data-root=/cache/docker
+
+            [Unit]
+            # The docker service depends on the /cache/docker volume.
+            Requires=cache-docker.mount
+            After=cache-docker.mount
 
 write_files:
   - path: "/etc/systemd/system/cache-data.mount"
@@ -87,22 +110,22 @@ write_files:
         [Install]
         WantedBy=multi-user.target
 
-  - path: "/etc/systemd/system/cache-docker.mount"
-    permissions: "0644"
-    owner: "root"
-    content: |
-        [Unit]
-        Description=Mount Docker Data Volume
-        After=setup-after-boot.service
-
-        [Mount]
-        What=/dev/disk/by-label/cache-docker
-        Where=/cache/docker
-        Type=ext4
-        Options=defaults
-
-        [Install]
-        WantedBy=multi-user.target
+#  - path: "/etc/systemd/system/cache-docker.mount"
+#    permissions: "0644"
+#    owner: "root"
+#    content: |
+#        [Unit]
+#        Description=Mount Docker Data Volume
+#        After=setup-after-boot.service
+#
+#        [Mount]
+#        What=/dev/disk/by-label/cache-docker
+#        Where=/cache/docker
+#        Type=ext4
+#        Options=defaults
+#
+#        [Install]
+#        WantedBy=multi-user.target
 
 # TODO: collect list of ssh keys from a metadata service during post-boot setup.
 ssh_authorized_keys:

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -61,11 +61,12 @@ coreos:
         #  * 250G for experiment data.
         #  * 150G for core experiment data.
         #  * 100G for docker image cache.
+        # Note: systemd translates double percent (%%) to a single percent.
         ExecStart=/usr/sbin/parted --align=optimal --script /dev/sda \
             mklabel gpt \
-            mkpart data ext4 0% 50% \
-            mkpart core ext4 50% 80% \
-            mkpart docker ext4 80% 100%
+            mkpart data ext4 0%% 50%% \
+            mkpart core ext4 50%% 80%% \
+            mkpart docker ext4 80%% 100%%
 
         # Format and label each partition.
         # Note: the labels could make the formatting conditional in the future.

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -75,7 +75,7 @@ coreos:
 
     - name: cache-docker.mount
       enable: true
-      contents: |
+      content: |
         [Unit]
         Description=Mount Docker Data Volume
         Before=docker.service

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -29,12 +29,13 @@ coreos:
     - name: systemd-networkd.service
       command: restart
 
-    # Configs to move the Docker data volume.
+    # Move the Docker data volume and add requirements on /cache/docker volume.
     - name: "docker.service"
       drop-ins:
         - name: "10-data-root.conf"
           content: |
             [Service]
+            # docker.service uses DOCKER_OPTS for extra drop-in options.
             Environment=DOCKER_OPTS="--data-root=/cache/docker --exec-root=/cache/docker/exec"
 
             [Unit]
@@ -42,6 +43,7 @@ coreos:
             Requires=cache-docker.mount
             After=cache-docker.mount
 
+    # Format the /cache volumes using /dev/sda.
     - name: format-cache.service
       command: start
       content: |
@@ -74,6 +76,7 @@ coreos:
         ExecStart=/usr/sbin/mke2fs -t ext4 -F -L cache-core /dev/sda2
         ExecStart=/usr/sbin/mke2fs -t ext4 -F -L cache-docker /dev/sda3
 
+    # Mount /cache/docker.
     - name: cache-docker.mount
       enable: true
       content: |
@@ -92,6 +95,7 @@ coreos:
         [Install]
         RequiredBy=docker.service
 
+    # Mount /cache/data.
     - name: cache-data.mount
       enable: true
       content: |
@@ -110,6 +114,7 @@ coreos:
         [Install]
         RequiredBy=docker.service
 
+    # Mount /cache/core.
     - name: cache-core.mount
       enable: true
       content: |

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -35,7 +35,7 @@ coreos:
         - name: "10-data-root.conf"
           content: |
             [Service]
-            Environment=DOCKER_OPTS=--data-root=/cache/docker
+            Environment=DOCKER_OPTS="--data-root=/cache/docker --exec-root=/cache/docker/exec"
 
             [Unit]
             # The docker service depends on the /cache/docker volume.

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -44,7 +44,7 @@ coreos:
 
     - name: format-cache.service
       command: start
-      contents: |
+      content: |
         [Unit]
         Before=docker.service cache-docker.mount cache-data.mount cache-core.mount
         RequiresMountsFor=/cache
@@ -137,7 +137,7 @@ coreos:
         # Both directives are required.
         # It is unclear why Requires= alone is not sufficient (but it isn't).
         Requires=network-online.target
-        After=systemd-networkd-wait-online.service
+        After=systemd-networkd-wait-online.service format-cache.service
 
         [Service]
         Type=oneshot

--- a/configs/stage3_coreos/resources/setup_after_boot.sh
+++ b/configs/stage3_coreos/resources/setup_after_boot.sh
@@ -37,9 +37,9 @@ date
 /usr/sbin/mke2fs -t ext4 -F -L cache-docker /dev/sda3
 
 # Actually mount.
-systemctl start cache-data.mount
-systemctl start cache-core.mount
-systemctl start cache-docker.mount
+#systemctl enable cache-docker.mount
+systemctl enable cache-data.mount
+systemctl enable cache-core.mount
 
 # Report end format time.
 date

--- a/configs/stage3_coreos/resources/setup_after_boot.sh
+++ b/configs/stage3_coreos/resources/setup_after_boot.sh
@@ -3,5 +3,46 @@
 # setup_after_boot.sh will run after boot and only once the network is online.
 # The script runs as the root user.
 
+# Log all output.
+exec 2> /var/log/setup_after_boot.log 1>&2
+
+# Stop on any failure.
+set -euxo pipefail
+
+mkdir -p /cache
+
+# Report start time.
+date
+
+# Clear any remaining LVM configs from prior installations.
+/usr/sbin/dmsetup remove_all --force
+
+# Repartition disk
+
+# For a 500GB disk, this is roughly:
+#  * 250G for experiment data.
+#  * 150G for core experiment data.
+#  * 100G for docker image cache.
+/usr/sbin/parted --align=optimal \
+    --script /dev/sda \
+    mklabel gpt \
+    mkpart data ext4 0% 50% \
+    mkpart core ext4 50% 80% \
+    mkpart docker ext4 80% 100%
+
+# Format and label each partition.
+# Note: the labels could make the formatting conditional in the future.
+/usr/sbin/mke2fs -t ext4 -F -L cache-data /dev/sda1
+/usr/sbin/mke2fs -t ext4 -F -L cache-core /dev/sda2
+/usr/sbin/mke2fs -t ext4 -F -L cache-docker /dev/sda3
+
+# Actually mount.
+systemctl start cache-data.mount
+systemctl start cache-core.mount
+systemctl start cache-docker.mount
+
+# Report end format time.
+date
+
 echo "Running epoxy client"
 /usr/bin/epoxy_client -action epoxy.stage3

--- a/configs/stage3_coreos/resources/setup_after_boot.sh
+++ b/configs/stage3_coreos/resources/setup_after_boot.sh
@@ -9,40 +9,5 @@ exec 2> /var/log/setup_after_boot.log 1>&2
 # Stop on any failure.
 set -euxo pipefail
 
-#mkdir -p /cache
-
-# Report start time.
-#date
-
-# Clear any remaining LVM configs from prior installations.
-#/usr/sbin/dmsetup remove_all --force
-
-# Repartition disk
-
-# For a 500GB disk, this is roughly:
-#  * 250G for experiment data.
-#  * 150G for core experiment data.
-#  * 100G for docker image cache.
-#/usr/sbin/parted --align=optimal \
-#    --script /dev/sda \
-#    mklabel gpt \
-#    mkpart data ext4 0% 50% \
-#    mkpart core ext4 50% 80% \
-#    mkpart docker ext4 80% 100%
-
-# Format and label each partition.
-# Note: the labels could make the formatting conditional in the future.
-#/usr/sbin/mke2fs -t ext4 -F -L cache-data /dev/sda1
-#/usr/sbin/mke2fs -t ext4 -F -L cache-core /dev/sda2
-#/usr/sbin/mke2fs -t ext4 -F -L cache-docker /dev/sda3
-
-# Actually mount.
-#systemctl enable cache-docker.mount
-#systemctl enable cache-data.mount
-#systemctl enable cache-core.mount
-
-# Report end format time.
-#date
-
 echo "Running epoxy client"
 /usr/bin/epoxy_client -action epoxy.stage3

--- a/configs/stage3_coreos/resources/setup_after_boot.sh
+++ b/configs/stage3_coreos/resources/setup_after_boot.sh
@@ -9,13 +9,13 @@ exec 2> /var/log/setup_after_boot.log 1>&2
 # Stop on any failure.
 set -euxo pipefail
 
-mkdir -p /cache
+#mkdir -p /cache
 
 # Report start time.
-date
+#date
 
 # Clear any remaining LVM configs from prior installations.
-/usr/sbin/dmsetup remove_all --force
+#/usr/sbin/dmsetup remove_all --force
 
 # Repartition disk
 
@@ -23,26 +23,26 @@ date
 #  * 250G for experiment data.
 #  * 150G for core experiment data.
 #  * 100G for docker image cache.
-/usr/sbin/parted --align=optimal \
-    --script /dev/sda \
-    mklabel gpt \
-    mkpart data ext4 0% 50% \
-    mkpart core ext4 50% 80% \
-    mkpart docker ext4 80% 100%
+#/usr/sbin/parted --align=optimal \
+#    --script /dev/sda \
+#    mklabel gpt \
+#    mkpart data ext4 0% 50% \
+#    mkpart core ext4 50% 80% \
+#    mkpart docker ext4 80% 100%
 
 # Format and label each partition.
 # Note: the labels could make the formatting conditional in the future.
-/usr/sbin/mke2fs -t ext4 -F -L cache-data /dev/sda1
-/usr/sbin/mke2fs -t ext4 -F -L cache-core /dev/sda2
-/usr/sbin/mke2fs -t ext4 -F -L cache-docker /dev/sda3
+#/usr/sbin/mke2fs -t ext4 -F -L cache-data /dev/sda1
+#/usr/sbin/mke2fs -t ext4 -F -L cache-core /dev/sda2
+#/usr/sbin/mke2fs -t ext4 -F -L cache-docker /dev/sda3
 
 # Actually mount.
 #systemctl enable cache-docker.mount
-systemctl enable cache-data.mount
-systemctl enable cache-core.mount
+#systemctl enable cache-data.mount
+#systemctl enable cache-core.mount
 
 # Report end format time.
-date
+#date
 
 echo "Running epoxy client"
 /usr/bin/epoxy_client -action epoxy.stage3


### PR DESCRIPTION
This change adds new systemd units for formatting and mounting `/cache` volumes for experiment data and docker images. This change also includes drop-in configuration updates to the docker.service to use `/cache/docker` as the docker data-root and exec-root directories.


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/41)
<!-- Reviewable:end -->
