### PR TITLE
Make reformat conditional on all directories in cache dir

### DIFF
--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -51,6 +51,8 @@ coreos:
         Before=docker.service cache-docker.mount cache-data.mount cache-core.mount
         RequiresMountsFor=/cache
         ConditionPathExists=!/cache/docker
+        ConditionPathExists=!/cache/data
+        ConditionPathExists=!/cache/core
         [Service]
         Type=oneshot
         # Create cache directory in root filesystem.


### PR DESCRIPTION
The previous condition resulted in a failure condition where /cache/data and /cache/core were mounted but /cache/docker was not. Since the unit does not enter a failed state when conditions are not met, this PR adds additional conditions on the other /cache directories, so that if they are present, the format-cache service will not attempt to run again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/44)
<!-- Reviewable:end -->
