### PR TITLE
Add project to stage1 image & update actions to pull from per-project URLs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,9 +79,9 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-sandbox /build /images/output 'mlab4.lga0t.*' 3.4.805 &> /images/stage3_mlxupdate_iso.log
+            mlab-sandbox /build /images/output 'mlab4.lga0t.*' 3.4.806 &> /images/stage3_mlxupdate_iso.log
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-staging /build /images/output 'mlab[1-3].lga0t.*' 3.4.805 &>> /images/stage3_mlxupdate_iso.log"
+            mlab-staging /build /images/output 'mlab[1-3].lga0t.*' 3.4.806 &>> /images/stage3_mlxupdate_iso.log"
         || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 

--- a/actions/stage2/stage1to2.ipxe
+++ b/actions/stage2/stage1to2.ipxe
@@ -1,0 +1,59 @@
+#!ipxe
+
+# Use a relative URL for the vmlinuz image.
+# NOTE: the image must be in the same directory as this iPXE script.
+set vmlinuz_url stage2_vmlinuz
+
+echo Starting stage1to2 script
+
+echo -- Downloading stage2 image from ${vmlinuz_url}
+
+# Initialize retry counters.
+set retry_count:int32 1
+set max_retry_count 20
+
+goto firstfetch
+
+:loop
+  inc retry_count 1
+  echo -- Retries ${retry_count} ${max_retry_count}
+  echo Failed ${retry_count} times... Retrying after ${retry_count} seconds
+  # This doesn't work?
+  # iseq ${retry_count} ${max_retry_count} && goto fetch_timeout
+  sleep ${retry_count}
+
+:firstfetch
+  echo -- Retries ${retry_count} ${max_retry_count}
+  kernel --name vmlinuz ${vmlinuz_url} || goto loop
+
+imgstat
+
+# TODO: use a canonical form defined by epoxy and supporing IPv6.
+set network ${ip}::${gateway}:${netmask}:${hostname}:eth0:off:${dns}:8.8.4.4
+
+echo -- Booting stage2: vmlinuz ip=${network}
+sleep 2
+
+set kargs
+# Network settings
+# TODO: remove epoxy.ip= once epoxy-images support canonical network format.
+set kargs ${kargs} epoxy.ip=${network}
+set kargs ${kargs} epoxy.ipv4=${ip}/26,${gateway},${dns},8.8.4.4
+set kargs ${kargs} epoxy.ipv6=
+set kargs ${kargs} epoxy.interface=eth0
+set kargs ${kargs} epoxy.hostname=${hostname}
+
+# Pass through the stage URLs.
+set kargs ${kargs} epoxy.stage2=${stage2_url}
+set kargs ${kargs} epoxy.stage3=${stage3_url}
+set kargs ${kargs} epoxy.report=${report_url}
+set kargs ${kargs} epoxy.server=${epoxyaddress}
+set kargs ${kargs} epoxy.project=${project}
+
+boot vmlinuz ${kargs} || shell
+
+:fetch_timeout
+  echo -- Retries ${retry_count} ${max_retry_count}
+  echo Failed too many times..
+  # Reboot?
+  shell

--- a/actions/stage3_coreos/stage2to3.json
+++ b/actions/stage3_coreos/stage2to3.json
@@ -5,18 +5,23 @@
       },
       "files" : {
          "vmlinuz" : {
-            "url" : "https://storage.googleapis.com/epoxy-mlab-staging/stage3_coreos/coreos_production_pxe.vmlinuz"
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_coreos/coreos_production_pxe.vmlinuz"
          },
          "initram" : {
-            "url" : "https://storage.googleapis.com/epoxy-mlab-staging/stage3_coreos/coreos_custom_pxe_image.cpio.gz"
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_coreos/coreos_custom_pxe_image.cpio.gz"
          }
       },
       "vars" : {
          "kargs" : [
             "epoxy.ip={{kargs `epoxy.ip`}}",
+            "epoxy.ipv4={{kargs `epoxy.ipv4`}}",
+            "epoxy.ipv6={{kargs `epoxy.ipv6`}}",
+            "epoxy.interface={{kargs `epoxy.interface`}}",
+            "epoxy.hostname={{kargs `epoxy.hostname`}}",
             "epoxy.stage3={{kargs `epoxy.stage3`}}",
             "epoxy.report={{kargs `epoxy.report`}}",
-            "epoxy.server={{kargs `epoxy.server`}}"
+            "epoxy.server={{kargs `epoxy.server`}}",
+            "epoxy.project={{kargs `epoxy.project`}}"
          ],
          "cmdline" : "net.ifnames=0 coreos.autologin=tty1"
       },

--- a/actions/stage3_coreos/stage3post.json
+++ b/actions/stage3_coreos/stage3post.json
@@ -5,7 +5,7 @@
       },
       "files" : {
          "setup_k8s" : {
-            "url" : "https://storage.googleapis.com/epoxy-mlab-staging/stage3_coreos/setup_k8s.sh"
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project}}/stage3_coreos/setup_k8s.sh"
          }
       },
       "commands" : [

--- a/configs/stage1_mlxrom/stage1-template.ipxe
+++ b/configs/stage1_mlxrom/stage1-template.ipxe
@@ -17,6 +17,9 @@ set net0/netmask {{netmask}}
 set net0/dns {{dns1}}
 set hostname {{hostname}}
 
+# Save the GCP project name.
+set project {{project}}
+
 # The ePoxy stage1 URL.
 set stage1_url https://${epoxyaddress}/v1/boot/${hostname}/stage1.ipxe
 


### PR DESCRIPTION
This PR adds the GCP "project" to the set of variables know to the stage1 image. With this, each subsequent stage can request images from per-project URLs.

As well, this PR adds the previously omitted stage1to2.ipxe script, which loads the stage2 image, and passes all interesting kernel parameters to it.

Since these changes update the stage1 ROM, the ROM will need to be updated for the changes to take effect.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/45)
<!-- Reviewable:end -->
