### PR TITLE
Fix typo and add travis deploy of actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -109,6 +109,8 @@ deploy:
       $TRAVIS_BUILD_DIR/output/stage2_vmlinuz
       $TRAVIS_BUILD_DIR/output/coreos_custom_pxe_image.cpio.gz
       $TRAVIS_BUILD_DIR/output/coreos_production_pxe.vmlinuz
+      $TRAVIS_BUILD_DIR/actions/stage2/stage1to2.ipxe
+      $TRAVIS_BUILD_DIR/actions/stage3_coreos/*.json
       gs://epoxy-mlab-sandbox/stage3_coreos/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
       $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
@@ -146,6 +148,8 @@ deploy:
       $TRAVIS_BUILD_DIR/output/stage2_vmlinuz
       $TRAVIS_BUILD_DIR/output/coreos_custom_pxe_image.cpio.gz
       $TRAVIS_BUILD_DIR/output/coreos_production_pxe.vmlinuz
+      $TRAVIS_BUILD_DIR/actions/stage2/stage1to2.ipxe
+      $TRAVIS_BUILD_DIR/actions/stage3_coreos/*.json
       gs://epoxy-mlab-staging/stage3_coreos/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
       $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate

--- a/actions/stage3_coreos/stage3post.json
+++ b/actions/stage3_coreos/stage3post.json
@@ -5,7 +5,7 @@
       },
       "files" : {
          "setup_k8s" : {
-            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project}}/stage3_coreos/setup_k8s.sh"
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_coreos/setup_k8s.sh"
          }
       },
       "commands" : [


### PR DESCRIPTION
This PR fixes a typo in `actions/stage3_coreos/stage3post.json` and adds auto-deployment of epoxy actions to GCS alongside the epoxy boot images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/46)
<!-- Reviewable:end -->
