### PR TITLE
Support mlxupdate boot sequence

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -158,6 +158,7 @@ deploy:
       $TRAVIS_BUILD_DIR/actions/stage3_coreos/*.json
       gs://epoxy-mlab-staging/stage3_coreos/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
+      $TRAVIS_BUILD_DIR/output/stage2_vmlinuz
       $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
       $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
       $TRAVIS_BUILD_DIR/actions/stage2/stage1to2.ipxe

--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-sandbox /build /images/output 'mlab4.lga0t.*' 3.4.806 &> /images/stage3_mlxupdate_iso.log
+            mlab-sandbox /build /images/output 'mlab4.lga0t.*' 3.4.807 &> /images/stage3_mlxupdate_iso.log
         && /images/setup_stage3_mlxupdate_isos.sh
             mlab-staging /build /images/output 'mlab[1-3].lga0t.*' 3.4.806 &>> /images/stage3_mlxupdate_iso.log"
         || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,6 +115,8 @@ deploy:
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
       $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
       $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
+      $TRAVIS_BUILD_DIR/actions/stage2/stage1to2.ipxe
+      $TRAVIS_BUILD_DIR/actions/stage3_mlxupdate/*.json
       gs://epoxy-mlab-sandbox/stage3_mlxupdate/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
       $TRAVIS_BUILD_DIR/output/*.iso

--- a/.travis.yml
+++ b/.travis.yml
@@ -122,6 +122,9 @@ deploy:
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
       $TRAVIS_BUILD_DIR/output/stage1_mlxrom/*
       gs://epoxy-mlab-sandbox/stage1_mlxrom/
+      && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
+      $TRAVIS_BUILD_DIR/output/stage1_mlxrom/*/*
+      gs://epoxy-mlab-sandbox/stage1_mlxrom/latest/
   skip_cleanup: true
   on:
     repo: m-lab/epoxy-images
@@ -161,6 +164,9 @@ deploy:
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
       $TRAVIS_BUILD_DIR/output/stage1_mlxrom/*
       gs://epoxy-mlab-staging/stage1_mlxrom/
+      && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
+      $TRAVIS_BUILD_DIR/output/stage1_mlxrom/*/*
+      gs://epoxy-mlab-staging/stage1_mlxrom/latest/
   skip_cleanup: true
   on:
     repo: m-lab/epoxy-images

--- a/.travis.yml
+++ b/.travis.yml
@@ -113,6 +113,7 @@ deploy:
       $TRAVIS_BUILD_DIR/actions/stage3_coreos/*.json
       gs://epoxy-mlab-sandbox/stage3_coreos/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_sandbox
+      $TRAVIS_BUILD_DIR/output/stage2_vmlinuz
       $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
       $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
       $TRAVIS_BUILD_DIR/actions/stage2/stage1to2.ipxe
@@ -159,6 +160,8 @@ deploy:
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
       $TRAVIS_BUILD_DIR/output/vmlinuz_stage3_mlxupdate
       $TRAVIS_BUILD_DIR/output/initramfs_stage3_mlxupdate.cpio.gz
+      $TRAVIS_BUILD_DIR/actions/stage2/stage1to2.ipxe
+      $TRAVIS_BUILD_DIR/actions/stage3_mlxupdate/*.json
       gs://epoxy-mlab-staging/stage3_mlxupdate/
       && $TRAVIS_BUILD_DIR/travis/deploy_gcs.sh SERVICE_ACCOUNT_mlab_staging
       $TRAVIS_BUILD_DIR/output/*.iso

--- a/actions/stage3_mlxupdate/stage2to3.json
+++ b/actions/stage3_mlxupdate/stage2to3.json
@@ -5,19 +5,24 @@
       },
       "files" : {
          "vmlinuz" : {
-            "url" : "https://storage.googleapis.com/epoxy-mlab-staging/stage3_mlxupdate/vmlinuz_stage3_mlxupdate"
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_mlxupdate/vmlinuz_stage3_mlxupdate"
          },
          "initram" : {
-            "url" : "https://storage.googleapis.com/epoxy-mlab-staging/stage3_mlxupdate/initramfs_stage3_mlxupdate.cpio.gz"
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_mlxupdate/initramfs_stage3_mlxupdate.cpio.gz"
          }
       },
       "vars" : {
          "kargs" : [
             "epoxy.ip={{kargs `epoxy.ip`}}",
+            "epoxy.ipv4={{kargs `epoxy.ipv4`}}",
+            "epoxy.ipv6={{kargs `epoxy.ipv6`}}",
+            "epoxy.interface={{kargs `epoxy.interface`}}",
+            "epoxy.hostname={{kargs `epoxy.hostname`}}",
             "epoxy.stage3={{kargs `epoxy.stage3`}}",
             "epoxy.report={{kargs `epoxy.report`}}",
             "epoxy.server={{kargs `epoxy.server`}}",
-            "epoxy.mrom=https://storage.googleapis.com/epoxy-mlab-staging/stage1_mlxrom/3.4.804"
+            "epoxy.project={{kargs `epoxy.project`}}",
+            "epoxy.mrom=https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage1_mlxrom/latest"
          ],
          "cmdline" : "net.ifnames=0 coreos.autologin=tty1"
       },


### PR DESCRIPTION
To date, MLX ROM updates have been performed ad-hoc using the mlx_update_iso images. The ISO images will still be necessary for initial-setup of machines. But, all subsequent updates can now be performed using an epoxy "Update" boot sequence.

This PR adds support for the mlxupdate boot sequence. The necessary images and actions are copied to the `stage3_mlxupdate` directory in GCS. As well, this change adds additional common `epoxy.*` kargs, and makes the actions refer to URLs by project.

This PR adds a deploy target for the MLX ROMS named "latest". This allows the `epoxy.mrom=` base URL used by the `updaterom.sh` script to be a generic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/47)
<!-- Reviewable:end -->
