### PR TITLE
Add ipv6 variables to epoxy ROM images & normalize ipv4 variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,9 +80,9 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-sandbox /build /images/output 'mlab4.lga0t.*' 3.4.808 &> /images/stage3_mlxupdate_iso.log
+            mlab-sandbox /build /images/output 'mlab4.lga0t.*' 3.4.809 &> /images/stage3_mlxupdate_iso.log
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-staging /build /images/output 'mlab[1-3].lga0t.*' 3.4.808 &>> /images/stage3_mlxupdate_iso.log"
+            mlab-staging /build /images/output 'mlab[1-3].lga0t.*' 3.4.809 &>> /images/stage3_mlxupdate_iso.log"
         || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 

--- a/actions/stage2/stage1to2.ipxe
+++ b/actions/stage2/stage1to2.ipxe
@@ -39,7 +39,16 @@ set kargs
 # TODO: remove epoxy.ip= once epoxy-images support canonical network format.
 set kargs ${kargs} epoxy.ip=${network}
 set kargs ${kargs} epoxy.ipv4=${ipv4_address}/${ipv4_subnet},${ipv4_gateway},${ipv4_dns1},${ipv4_dns2}
-set kargs ${kargs} epoxy.ipv6=${ipv6_address}/${ipv6_subnet},${ipv6_gateway},${ipv6_dns1},${ipv6_dns2}
+
+# Set the epoxy.ipv6= karg appropriately based on the value in ipv6_enabled.
+iseq ${ipv6_enabled} true && goto v6_enabled || goto v6_disabled
+v6_enabled:
+  set kargs ${kargs} epoxy.ipv6=${ipv6_address}/${ipv6_subnet},${ipv6_gateway},${ipv6_dns1},${ipv6_dns2}
+  goto v6_done
+v6_disabled:
+  set kargs ${kargs} epoxy.ipv6=
+v6_done:
+
 set kargs ${kargs} epoxy.interface=eth0
 set kargs ${kargs} epoxy.hostname=${hostname}
 

--- a/actions/stage2/stage1to2.ipxe
+++ b/actions/stage2/stage1to2.ipxe
@@ -42,12 +42,12 @@ set kargs ${kargs} epoxy.ipv4=${ipv4_address}/${ipv4_subnet},${ipv4_gateway},${i
 
 # Set the epoxy.ipv6= karg appropriately based on the value in ipv6_enabled.
 iseq ${ipv6_enabled} true && goto v6_enabled || goto v6_disabled
-v6_enabled:
+:v6_enabled
   set kargs ${kargs} epoxy.ipv6=${ipv6_address}/${ipv6_subnet},${ipv6_gateway},${ipv6_dns1},${ipv6_dns2}
   goto v6_done
-v6_disabled:
+:v6_disabled
   set kargs ${kargs} epoxy.ipv6=
-v6_done:
+:v6_done
 
 set kargs ${kargs} epoxy.interface=eth0
 set kargs ${kargs} epoxy.hostname=${hostname}

--- a/actions/stage2/stage1to2.ipxe
+++ b/actions/stage2/stage1to2.ipxe
@@ -38,8 +38,8 @@ set kargs
 # Network settings
 # TODO: remove epoxy.ip= once epoxy-images support canonical network format.
 set kargs ${kargs} epoxy.ip=${network}
-set kargs ${kargs} epoxy.ipv4=${ip}/26,${gateway},${dns},8.8.4.4
-set kargs ${kargs} epoxy.ipv6=
+set kargs ${kargs} epoxy.ipv4=${ipv4_address}/${ipv4_subnet},${ipv4_gateway},${ipv4_dns1},${ipv4_dns2}
+set kargs ${kargs} epoxy.ipv6=${ipv6_address}/${ipv6_subnet},${ipv6_gateway},${ipv6_dns1},${ipv6_dns2}
 set kargs ${kargs} epoxy.interface=eth0
 set kargs ${kargs} epoxy.hostname=${hostname}
 

--- a/configs/stage1_mlxrom/stage1-template.ipxe
+++ b/configs/stage1_mlxrom/stage1-template.ipxe
@@ -9,12 +9,27 @@ set fetch_timeout_ms 10000
 set retry_delay_s:int32 30
 set max_retry_delay_s 480
 
-# Setup static network configuration.
+# IPv6 network configuration.
+set ipv6_address {{ipv6_address}}
+set ipv6_gateway {{ipv6_gateway}}
+set ipv6_subnet  64
+set ipv6_dns1    {{ipv6_dns1}}
+set ipv6_dns2    {{ipv6_dns2}}
+
+# IPv4 network configuration.
+set ipv4_address {{ip}}
+set ipv4_gateway {{gateway}}
+set ipv4_subnet  26
+set ipv4_netmask {{netmask}}
+set ipv4_dns1    {{dns1}}
+set ipv4_dns2    {{dns2}}
+
+# Apply ipxe network settings (IPv4 only).
 ifopen net0
-set net0/ip {{ip}}
-set net0/gateway {{gateway}}
-set net0/netmask {{netmask}}
-set net0/dns {{dns1}}
+set net0/ip ${ipv4_address}
+set net0/gateway ${ipv4_gateway}
+set net0/netmask ${ipv4_netmask}
+set net0/dns ${ipv4_dns1}
 set hostname {{hostname}}
 
 # Save the GCP project name.

--- a/configs/stage1_mlxrom/stage1-template.ipxe
+++ b/configs/stage1_mlxrom/stage1-template.ipxe
@@ -10,6 +10,9 @@ set retry_delay_s:int32 30
 set max_retry_delay_s 480
 
 # IPv6 network configuration.
+# ipv6_enabled will always be defined. When ipv6_enabled is "false", then other
+# ipv6 variables are undefined.
+set ipv6_enabled {{ipv6_enabled}}
 set ipv6_address {{ipv6_address}}
 set ipv6_gateway {{ipv6_gateway}}
 set ipv6_subnet  64


### PR DESCRIPTION
This change normalizes naming of IPv4 and adds IPv6 network configurations to the epoxy ROM images.

Some startup scripts will need to be changed to use epoxy.ipv4 or epoxy.ipv6 values. However, because the values are both present, this PR resolves https://github.com/m-lab/epoxy/issues/7

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/59)
<!-- Reviewable:end -->
