### PR TITLE
Configure network using epoxy.ipv4 parameters, and reboot on success

### DIFF
--- a/configs/stage3_mlxupdate/rc.local
+++ b/configs/stage3_mlxupdate/rc.local
@@ -1,37 +1,45 @@
 #!/bin/bash
 
 
+function get_cmdline() {
+  local key=$1
+  local result=$2
+  # Extract the boot parameter ${key}=
+  for field in $( cat /proc/cmdline ) ; do
+    if [[ "${key}" == "${field%%=*}" ]] ; then
+      result=${field##${key}=}
+      break
+    fi
+  done
+  echo $result
+}
+
 # TODO: epoxyclient should interpret this command line parameter instead.
 function setup_network() {
   # Set a default local network configuration.
   ipcfg=192.168.0.2::192.168.0.1:255.255.255.0:default-net:eth0::8.8.8.8:
 
+  ipv4=$( get_cmdline epoxy.ipv4 "192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4" )
+  hostname=$( get_cmdline epoxy.hostname "default-net" )
+  interface=$( get_cmdline epoxy.interface "eth0" )
+
   # Note: while using a generic kernel, we must wait for the modules to load
   # automatically before the network configuration commands will work.  This
   # delay could be avoided by explicitly loading the modules here (fragile) or
   # using a custom kernel that embeds the mellanox drivers.
-  until ifconfig eth0 2> /dev/null ; do
-      echo "Waiting 1 second for eth0 to initialize.."
+  until ifconfig ${interface} 2> /dev/null ; do
+      echo "Waiting 1 second for ${interface} to initialize.."
       sleep 1
   done
 
-  # Extract the epoxy.ip= boot parameter.
-  for field in $( cat /proc/cmdline ) ; do
-    if [[ "epoxy.ip" == "${field%%=*}" ]] ; then
-      ipcfg=${field##epoxy.ip=}
-      break
-    fi
-  done
-
-  echo "Applying network configuration: $ipcfg"
-  echo $ipcfg | tr ':' ' ' | (
-      read addr gateway netmask hostname device _
-      ifconfig $device $addr netmask $netmask
-      route add default gw $gateway
-      hostname $hostname
+  echo "Applying network configuration: $ipv4"
+  echo $ipv4 | tr ',' ' ' | (
+      read addr gateway _
+      echo ifconfig ${interface} ${addr}
+      echo route add default gw ${gateway}
+      echo hostname ${hostname}
   )
-  ifconfig eth0
-
+  ifconfig ${interface}
 }
 
 
@@ -45,7 +53,4 @@ setup_network
 
 # Note: the stage3 action should be configured in the epoxy server. The nextboot
 # config returned should probably run /usr/local/util/updaterom.sh
-/usr/bin/epoxy_client -action epoxy.stage3
-
-# TODO: automate reboot on success.
-echo "WARNING: if the update was successful, reboot machine."
+/usr/bin/epoxy_client -action epoxy.stage3 && reboot


### PR DESCRIPTION
This change updates the stage3 mlxupdate `rc.local` script so that:

 * Reboot is automatic on successful update -- https://github.com/m-lab/epoxy/issues/46
 * Configures the network using epoxy.ipv4 and preferred cmdline parameters -- https://github.com/m-lab/epoxy/issues/7

Once all boot images are using this new format we can remove `epoxy.ip=` network parameters from stage1 scripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/60)
<!-- Reviewable:end -->
