### PR TITLE
Pass the epoxy.project as the first parameter to node setup script

### DIFF
--- a/actions/stage3_coreos/stage3post.json
+++ b/actions/stage3_coreos/stage3post.json
@@ -11,7 +11,7 @@
       "commands" : [
          "# Make setup_k8s.sh executable and then run with the epoxy.ipv4 config",
          "/usr/bin/chmod 755 {{.files.setup_k8s.name}}",
-         "{{.files.setup_k8s.name}} {{kargs `epoxy.ipv4`}} {{kargs `epoxy.hostname`}} {{kargs `epoxy.allocate_k8s_token`}}"
+         "{{.files.setup_k8s.name}} {{kargs `epoxy.project`}} {{kargs `epoxy.ipv4`}} {{kargs `epoxy.hostname`}} {{kargs `epoxy.allocate_k8s_token`}}"
       ]
    }
 }


### PR DESCRIPTION
So that the setup script can contact a k8s master running in an appropriate GCP Project, this change passes the epoxy.project to the setup script.