### PR TITLE
Add crictl to coreos build

### DIFF
--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -64,6 +64,13 @@ pushd $IMAGEDIR
   chmod 755 squashfs-root/cni/bin/*
   rm -Rf ${TMPDIR}
 
+  # Install crictl.
+  mkdir -p squashfs-root/cri/bin
+  CRI_VERSION="v1.11.1"
+  wget https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRI_VERSION}/crictl-${CRI_VERSION}-linux-amd64.tar.gz
+  tar zxvf crictl-${CRI_VERSION}-linux-amd64.tar.gz -C squashfs-root/cri/bin/
+  rm -f crictl-${CRI_VERSION}-linux-amd64.tar.gz
+
   # Install the kube* commands.
   # Installation commands adapted from:
   #   https://kubernetes.io/docs/setup/independent/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -65,10 +65,10 @@ pushd $IMAGEDIR
   rm -Rf ${TMPDIR}
 
   # Install crictl.
-  mkdir -p squashfs-root/cri/bin
+  mkdir -p squashfs-root/bin
   CRI_VERSION="v1.11.1"
   wget https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRI_VERSION}/crictl-${CRI_VERSION}-linux-amd64.tar.gz
-  tar zxvf crictl-${CRI_VERSION}-linux-amd64.tar.gz -C squashfs-root/cri/bin/
+  tar zxvf crictl-${CRI_VERSION}-linux-amd64.tar.gz -C squashfs-root/bin/
   rm -f crictl-${CRI_VERSION}-linux-amd64.tar.gz
 
   # Install the kube* commands.


### PR DESCRIPTION
Recent versions of kubeadm depend on `crictl` where previously it was optional.

This change adds the `crictl` binary to `/usr/bin` in the coreos image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/67)
<!-- Reviewable:end -->
