### PR TITLE
Adds lax02 and lga02 to stage3 ROM and ISO builds. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,10 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t).*' 3.4.809
+            mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t|lax02|lga02).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-staging /build /images/output 'mlab[1-3].(iad1t|lga0t).*' 3.4.809
+            mlab-staging /build /images/output 'mlab[1-3].(iad1t|lga0t|lax02|lga02).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk"
         || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output

--- a/.travis.yml
+++ b/.travis.yml
@@ -80,10 +80,10 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t|lax02|lga02).*' 3.4.809
+            mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-staging /build /images/output 'mlab[1-3].(iad1t|lga0t|lax02|lga02).*' 3.4.809
+            mlab-staging /build /images/output '(mlab[1-3].(iad1t|lga0t)|mlab3.lax02|mlab3.lga02).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk"
         || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output


### PR DESCRIPTION
These two sites will be production canaries, and add two additional sandbox nodes to play with. ISOs will be created for mlab[1-2].{lax02, lga02} too, but we will only be using the ISOs for the mlab3 machines for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/68)
<!-- Reviewable:end -->
