### PR TITLE
Uses mlab3.lga03 as a demo instead of mlab3.lga02

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
             mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-staging /build /images/output '(mlab[1-3].(iad1t|lga0t)|mlab3.lax02|mlab3.lga02).*' 3.4.809
+            mlab-staging /build /images/output '(mlab[1-3].(iad1t|lga0t)|mlab3.lax02|mlab3.lga03).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk"
         || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output


### PR DESCRIPTION
mlab3.lga02 uses a legacy network remap, which complicates things.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/70)
<!-- Reviewable:end -->
