### PR TITLE
Brings various tools up to near latest versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@
 #  * on success, deploy the result to the correct Cloud Storage bucket when
 #    the target branch matches a supported deployment target.
 
+env:
+- COREOS_VERSION="1855.4.0"
+
 services:
 - docker
 
@@ -50,8 +53,8 @@ script:
 - time docker run -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
       bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
         /images/output/epoxy_client
-        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe.vmlinuz
-        http://stable.release.core-os.net/amd64-usr/1576.4.0/coreos_production_pxe_image.cpio.gz
+        http://stable.release.core-os.net/amd64-usr/$COREOS_VERSION/coreos_production_pxe.vmlinuz
+        http://stable.release.core-os.net/amd64-usr/$COREOS_VERSION/coreos_production_pxe_image.cpio.gz
         /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (tail -20 coreos.log && false)
 
 # Build stage3 mlxupdate image.

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ script:
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
-- time docker run -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
+- travis_wait time docker run -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
       bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
         /images/output/epoxy_client
         http://stable.release.core-os.net/amd64-usr/$COREOS_VERSION/coreos_production_pxe.vmlinuz

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -52,18 +52,17 @@ pushd $IMAGEDIR
   # Install the cni binaries: bridge, flannel, host-local, ipvlan, loopback, and
   # others.
   mkdir -p squashfs-root/cni/bin
-  CNI_VERSION="v0.6.0"
+  CNI_VERSION="v0.7.1"
   curl --location "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar --directory=squashfs-root/cni/bin -xz
 
   # Install multus and index2ip.
   TMPDIR=$(mktemp -d)
-  # TODO: remove pinned version of multus after debugging issues with v3.0 on k8s v1.11.
   pushd ${TMPDIR}
     mkdir -p src/github.com/intel
 	pushd src/github.com/intel
 	   git clone https://github.com/intel/multus-cni.git
 	   pushd multus-cni
-	     git checkout v2.1
+	     git checkout v3.1
 	   popd
 	popd
   popd
@@ -78,17 +77,15 @@ pushd $IMAGEDIR
   # Install crictl.
   mkdir -p squashfs-root/bin
   # TODO: temporarily disable CRI. This is required for k8s versions v1.11+
-  #CRI_VERSION="v1.11.1"
-  #wget https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRI_VERSION}/crictl-${CRI_VERSION}-linux-amd64.tar.gz
-  #tar zxvf crictl-${CRI_VERSION}-linux-amd64.tar.gz -C squashfs-root/bin/
-  #rm -f crictl-${CRI_VERSION}-linux-amd64.tar.gz
+  CRI_VERSION="v1.12.0"
+  wget https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRI_VERSION}/crictl-${CRI_VERSION}-linux-amd64.tar.gz
+  tar zxvf crictl-${CRI_VERSION}-linux-amd64.tar.gz -C squashfs-root/bin/
+  rm -f crictl-${CRI_VERSION}-linux-amd64.tar.gz
 
   # Install the kube* commands.
   # Installation commands adapted from:
   #   https://kubernetes.io/docs/setup/independent/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
-  # TODO: temporarily pin to k8s v1.10 to work around multus v3.0 incompatibility.
-  # RELEASE="$(curl --location --show-error --silent https://dl.k8s.io/release/stable.txt | tee squashfs-root/share/oem/installed_k8s_version.txt)"
-  RELEASE="$(echo v1.10.6 | tee squashfs-root/share/oem/installed_k8s_version.txt)"
+  RELEASE="$(echo v1.12.0 | tee squashfs-root/share/oem/installed_k8s_version.txt)"
   pushd squashfs-root/bin
     curl --location --remote-name-all https://storage.googleapis.com/kubernetes-release/release/"${RELEASE}"/bin/linux/amd64/{kubeadm,kubelet,kubectl}
     chmod 755 {kubeadm,kubelet,kubectl}


### PR DESCRIPTION
* CoreOS from 1576.4.0 to 1855.4.0
* kubernetes from 1.10.6 to 1.12.0
* cni-plugins from v0.6.0 v0.7.1
* cri-tools from 1.11.1 to 1.12.0

Also, adds `travis_wait` in front of command that build the custom CoreOS initram images, because we were seeing Travis-CI timeouts on that command for not outputting anything in >10m. The build succeeded after adding this, but it's not clear if this flag was the reason or we just got lucky. In any case, it doesn't seem to hurt.

```
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
Check the details on how to adjust your build configuration on: https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received
The build has been terminated
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/73)
<!-- Reviewable:end -->
