### PR TITLE
Configures Travis-CI to build images for mlab4.lax02, mlab4.ams02 and mlab4.syd02.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t|lax02|ams02|syd02).*' 3.4.809
+            mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t|lax02|bru02|syd02).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk
         && /images/setup_stage3_mlxupdate_isos.sh
             mlab-staging /build /images/output '(mlab[1-3].(iad1t|lga0t)|mlab3.lax02|mlab3.lga03).*' 3.4.809

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t).*' 3.4.809
+            mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t|lax02|ams02|syd02).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk
         && /images/setup_stage3_mlxupdate_isos.sh
             mlab-staging /build /images/output '(mlab[1-3].(iad1t|lga0t)|mlab3.lax02|mlab3.lga03).*' 3.4.809


### PR DESCRIPTION
I suspect that this PR will fail to build because the Travis build will exceed the maximum run time. If it does fail to build, then I suppose our options are to remove some of the nodes that already have images built, or dig into the more long term build solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/74)
<!-- Reviewable:end -->
