### PR TITLE
Disable ipv6 autoconf for all stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,10 +83,10 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t|lax02|bru02|syd02).*' 3.4.809
+            mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-staging /build /images/output '(mlab[1-3].(iad1t|lga0t)|mlab3.lax02|mlab3.lga03).*' 3.4.809
+            mlab-staging /build /images/output '(mlab[1-3].(iad1t|lga0t).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk"
         || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
 - $TRAVIS_BUILD_DIR/travis/install_gcloud.sh
 - $TRAVIS_BUILD_DIR/travis/activate_service_account.sh SERVICE_ACCOUNT_mlab_sandbox
 
-- mkdir $TRAVIS_BUILD_DIR/output
+- mkdir -p $TRAVIS_BUILD_DIR/output
 
 # Build stage2 vmlinuz image.
 # TODO: clean up args to setup_stage2.sh script.
@@ -86,9 +86,9 @@ script:
             mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-staging /build /images/output '(mlab[1-3].(iad1t|lga0t).*' 3.4.809
+            mlab-staging /build /images/output 'mlab[1-3].(iad1t|lga0t).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk"
-        || (tail -40 stage3_mlxupdate.log && tail -40 stage3_mlxupdate_iso.log && false)
+        || (tail stage3_mlxupdate.log stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger

--- a/actions/stage2/stage1to2.ipxe
+++ b/actions/stage2/stage1to2.ipxe
@@ -59,6 +59,7 @@ set kargs ${kargs} epoxy.report=${report_url}
 set kargs ${kargs} epoxy.allocate_k8s_token=${allocate_k8s_token_url}
 set kargs ${kargs} epoxy.server=${epoxyaddress}
 set kargs ${kargs} epoxy.project=${project}
+set kargs ${kargs} disable_ipv6=1 autoconf=0
 
 boot vmlinuz ${kargs} || shell
 

--- a/actions/stage3_coreos/stage2to3.json
+++ b/actions/stage3_coreos/stage2to3.json
@@ -24,7 +24,7 @@
             "epoxy.server={{kargs `epoxy.server`}}",
             "epoxy.project={{kargs `epoxy.project`}}"
          ],
-         "cmdline" : "net.ifnames=0 coreos.autologin=tty1"
+         "cmdline" : "net.ifnames=0 coreos.autologin=tty1 autoconf=0"
       },
       "commands" : [
          "# Run kexec using the downloaded initram and vmlinuz files.",

--- a/actions/stage3_mlxupdate/stage2to3.json
+++ b/actions/stage3_mlxupdate/stage2to3.json
@@ -24,7 +24,7 @@
             "epoxy.project={{kargs `epoxy.project`}}",
             "epoxy.mrom=https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage1_mlxrom/latest"
          ],
-         "cmdline" : "net.ifnames=0 coreos.autologin=tty1"
+         "cmdline" : "net.ifnames=0 coreos.autologin=tty1 autoconf=0"
       },
       "commands" : [
          "# Run kexec using the downloaded initram and vmlinuz files.",


### PR DESCRIPTION
During early deployments of mlab4 machines, we discovered that the machine was making requests to the ePoxy server using an autoconfigured IPv6 address. This caused the request to fail b/c ePoxy did not know about this IP.

This change adds additional kernel boot parameters to disable autoconf for all stages and disable ipv6 entirely for stage2 images.

Parameters taken from: https://www.kernel.org/doc/Documentation/networking/ipv6.txt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/75)
<!-- Reviewable:end -->
