### PR TITLE
Disables IPv6 in kernel before booting stage2.

### DIFF
--- a/actions/stage2/stage1to2.ipxe
+++ b/actions/stage2/stage1to2.ipxe
@@ -59,7 +59,6 @@ set kargs ${kargs} epoxy.report=${report_url}
 set kargs ${kargs} epoxy.allocate_k8s_token=${allocate_k8s_token_url}
 set kargs ${kargs} epoxy.server=${epoxyaddress}
 set kargs ${kargs} epoxy.project=${project}
-set kargs ${kargs} disable_ipv6=1 autoconf=0
 
 boot vmlinuz ${kargs} || shell
 

--- a/configs/stage2/rc.local
+++ b/configs/stage2/rc.local
@@ -26,6 +26,9 @@ function setup_network() {
   )
   ifconfig eth0
 
+  # TODO: Remove this one ePoxy server supports IPV6.
+  # Disables IPv6
+  echo "1" > /proc/sys/net/ipv6/conf/all/disable_ipv6
 }
 
 

--- a/configs/stage2/rc.local
+++ b/configs/stage2/rc.local
@@ -26,8 +26,8 @@ function setup_network() {
   )
   ifconfig eth0
 
-  # TODO: Remove this one ePoxy server supports IPV6.
-  # Disables IPv6
+  # TODO: Remove this once ePoxy server supports IPV6.
+  # Disables IPv6.
   echo "1" > /proc/sys/net/ipv6/conf/all/disable_ipv6
 }
 


### PR DESCRIPTION
Kernel args are apparently not honored, at least not the IPv6 ones, so instead just disable IPv6 through /proc prior to booting into stage2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/76)
<!-- Reviewable:end -->
