### PR TITLE
Scripts to set node to boot from NIC and to manually generate ePoxy images.

### DIFF
--- a/configs/stage3_coreos/resources/generate_network_config.sh
+++ b/configs/stage3_coreos/resources/generate_network_config.sh
@@ -6,6 +6,17 @@
 
 OUTPUT=${1:?Please provide the name for writing config file}
 
+# TODO: Modify ePoxy to recognize both IPv4 and IPv6 addresses when
+# authenticating requests from nodes. For nodes in an environment where an
+# upstream device may have IPv6 autoconfiguration/discovery turned on, the node
+# may get an autoconf address which is not the one we use for the node.
+# Additionally, when we finally configure IPv6 on nodes, if ePoxy is not
+# configured to recognize both IPv4 and IPv6 addresses, then requests from
+# legitimate nodes from IPv6 addresses will fail.
+#
+# Disable IPv6 autoconf.
+echo "0" > /proc/sys/net/ipv6/conf/all/autoconf
+
 # Extract the epoxy.ip= parameter from /proc/cmdline.
 #
 # For example:

--- a/manual/README.md
+++ b/manual/README.md
@@ -99,3 +99,17 @@ First-time updates are not yet automated. So, login in as `root` and run:
 ## Reboot the machine
 If everything has gone correctly, the machine will boot from the NIC, contact
 the ePoxy server, boot, and automatically join the platform cluster.
+
+
+# Manually generating ePoxy images
+Run the script `manually_generate_images`. This script must be run on a GCE VM
+in the same project you are building for. Make it a powerful VM so that the
+building process happens much more quickly, and since we will be deleting the VM
+as soon as we are done with it, we aren't worried about the cost. n1-standard-8
+is probably good enough. When creating the VM, be sure to give the VM full
+access to all APIs (enable all scopes). When the VM is up and running, copy this
+script to it, edit the variables in the top section to suit your needs then run it.
+```
+$ ./manually_generate_images.sh
+```
+

--- a/manual/README.md
+++ b/manual/README.md
@@ -65,7 +65,7 @@ example, in ~/Downloads (use whichever directory your ISO image resides in).
 ```
 docker run -v ~/Downloads:/images -v $PWD:/scripts -it epoxy-racadm \
     /scripts/mount_update_iso.sh ${DRAC_IP} ${DRAC_PASSWORD} \
-    ~/Downloads/mlab1.iad1t.measurement-lab.org_mlxupdate.iso
+    /images/<node>.<site>.measurement-lab.org_mlxupdate.iso
 ```
 
 ## Start a virtual console to the node.

--- a/manual/README.md
+++ b/manual/README.md
@@ -3,19 +3,6 @@
 NOTE: The Java Virtual Console Applet no longer works. Instead, we mount the
 virtual media locally and use the HTML5 Virtual Console.
 
-Outline of steps:
-
-* Register node with ePoxy server.
-* Download Mellanox ROM update ISO from GCS.
-* Turn off IP-blocking on the iDRAC.
-* Build the epoxy-racadm image.
-* Run the epoxy-racadm image to set node to boot from NIC.
-* Run the epoxy-racadm container to update Mellanox ROM.
-* Start a virtual console to the node.
-* Run Mellanox ROM update from virtual console.
-* Reboot the machine.
-
-
 ## Register Machine with ePoxy Server
 On first boot, the ipxe firmware will try to contact the ePoxy server but the
 request will be rejected with a "Not Found" error until the machine is
@@ -39,8 +26,8 @@ go get -u google.golang.org/grpc/health/grpc_health_v1
 To add custom boot or update stage targets, see the help text.
 
 ## Download the Mellanox ROM update ISO(s)
-Mellanox ROM update ISOs are created by a separate process (by Travis-CI builds,
-currently). Before you start this process, download the ISO for the machine in
+Mellanox ROM update ISOs are created by a separate process, and uploaded to a
+GCS bucket. Before you start this process, download the ISO for the machine in
 question from GCS. Images are stored in GCS in this bucket:
 ```
 epoxy-<project>/stage3_mlxupdate_iso
@@ -62,9 +49,9 @@ docker build -t epoxy-racadm .
 ```
 
 ## Run the epoxy-racadm image to set node to boot from NIC
-Run the epoxy-racadm container to configure the node to boot from the NIC. When
-this script has finished running, the machine _should_ be configured to boot
-from the NIC first, but keep your eye on the terminal output for errors because
+Run the epoxy-racadm image to configure the node to boot from the NIC. When this
+script has finished running, the machine _should_ be configured to boot from the
+NIC first, but keep your eye on the terminal output for errors because
 configuring iDRACs is seemingly flaky and unstable.
 ```
 docker run --rm --volume $PWD:/scripts -it epoxy-racadm \
@@ -72,7 +59,7 @@ docker run --rm --volume $PWD:/scripts -it epoxy-racadm \
 ```
 
 ## Run the epoxy-racadm container to update Mellanox ROM
-Run the epoxy-racadm container with a Mellanox ROM update ISO image, for
+Run the epoxy-racadm image with a Mellanox ROM update ISO image, for
 example, in ~/Downloads (use whichever directory your ISO image resides in).
 ```
 docker run --rm --volume ~/Downloads:/images --volume $PWD:/scripts -it epoxy-racadm \
@@ -100,16 +87,16 @@ First-time updates are not yet automated. So, login in as `root` and run:
 If everything has gone correctly, the machine will boot from the NIC, contact
 the ePoxy server, boot, and automatically join the platform cluster.
 
-
 # Manually generating ePoxy images
-Run the script `manually_generate_images`. This script must be run on a GCE VM
-in the same project you are building for. Make it a powerful VM so that the
-building process happens much more quickly, and since we will be deleting the VM
-as soon as we are done with it, we aren't worried about the cost. n1-standard-8
-is probably good enough. When creating the VM, be sure to give the VM full
-access to all APIs (enable all scopes). When the VM is up and running, copy this
-script to it, edit the variables in the top section to suit your needs then run it.
+To manually generate ePoxy images, you can run the script in this directory
+named `manually_generate_images`. This script must be run on a GCE VM in the
+same project you are building for. Make it a powerful VM so that the building
+process happens much more quickly, and since we will be deleting the VM as soon
+as we are done with it, we aren't worried about the cost. n1-standard-8 is
+probably good enough. When creating the VM, be sure to give the VM full access
+to all APIs. When the VM is up and running, copy this script to it, edit the
+variables in the top section to suit your needs then run it. Specifically, you
+will surely want to change $PROJECT and $NODE\_REGEXP.
 ```
 $ ./manually_generate_images.sh
 ```
-

--- a/manual/boot_from_nic.sh
+++ b/manual/boot_from_nic.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+#
+# Configure the machine to boot from the NIC, then reboot the machine.
+#
+# There are possibly superfluous sleeps thrown all over the place in here
+# because iDRAC seem terribly flaky and unpredictable, so the sleeps are just to
+# be sure that the previous command completed and the internal state of the
+# iDRAC is mostly settled before moving on to the next command. It's unclear if
+# this helps anything, but it can't hurt.
+
+set -x
+
+DRAC_IP=${1:?Error provide drac IP}
+DRAC_PASSWORD=${2:?Error provide drac password}
+
+# Maximum number of times to rety any given iDRAC command before giving up.
+MAX_RETRIES=5
+
+function racadm() {
+    local ip=$1
+    local passwd=$2
+    shift 2
+    idracadm -r ${DRAC_IP} -u admin -p ${DRAC_PASSWORD} $@
+}
+
+echo "NOTE: you may want to open the virtual console to watch the system boot."
+
+# Stop the server to quiet all systems.
+racadm ${DRAC_IP} ${DRAC_PASSWORD} serveraction powerdown
+
+sleep 10
+
+# TODO: Be sure that BIOS versions are consistent across the platform.
+#
+# Because we have inconsistent BIOS versions on platform nodes, not every BIOS
+# has all the same options. Some BIOSs appear to have an option BootOptionRom
+# that must be enabled in order to set the NIC as a boot device. Other BIOSs
+# seem to not have this option, but instead have the option LegacyBootProto,
+# which likewise must be set to "PXE" (default seems to be "None") in order to
+# set the NIC as the first boot device. If either one of these options doesn't
+# exist in the BIOS, then the command should benignly fail, but this makes sure
+# that at least one of them, maybe both, get set.
+# 
+# First make sure that the option exists and that the value isn't what we want
+# already. If it does exist and isn't set correctly then, try MAX_RETRIES to set
+# it to what we want. We attempt this multiple times due to observed flakiness
+# in the ability of any given command to succeed any given time.
+
+# Track how many changes to the BIOS were actually made, because if we don't
+# make any changes and then try schedule a job in the jobqueue, we will get an
+# error.
+MOD_COUNT=0
+
+COUNT=0
+STATUS=$(racadm ${DRAC_IP} ${DRAC_PASSWORD} get nic.nicconfig.1.bootoptionrom)
+if [[ "$?" == "0" ]]; then
+  if ! echo "$STATUS" | grep 'bootoptionrom=Enabled'; then
+    until racadm ${DRAC_IP} ${DRAC_PASSWORD} set nic.nicconfig.1.bootoptionrom Enabled; do
+      COUNT=$((COUNT + 1))
+      if [[ "$COUNT" == "$MAX_RETRIES" ]]; then
+        echo "Max retry count reached for setting BootOptionRom to Enabled."
+        exit 1
+      fi
+      sleep 5
+    done
+    MOD_COUNT=$((MOD_COUNT + 1))
+  fi
+fi
+
+sleep 5
+
+COUNT=0
+STATUS=$(racadm ${DRAC_IP} ${DRAC_PASSWORD} get nic.nicconfig.1.legacybootproto)
+if [[ "$?" == "0" ]]; then
+  if ! echo "$STATUS" | grep 'legacybootproto=PXE'; then
+    until racadm ${DRAC_IP} ${DRAC_PASSWORD} set nic.nicconfig.1.legacybootproto PXE; do
+      COUNT=$((COUNT + 1))
+      if [[ "$COUNT" == "$MAX_RETRIES" ]]; then
+        echo "Max retry count reached for setting LegacyBootProto to PXE."
+        exit 1
+      fi
+      sleep 5
+    done
+    MOD_COUNT=$((MOD_COUNT + 1))
+  fi
+fi
+
+sleep 5
+
+# Create the jobqueue entry, then powerup, but only if we actually made any
+# changes.
+if [[ "$MOD_COUNT" > 0 ]]; then
+  racadm ${DRAC_IP} ${DRAC_PASSWORD} jobqueue create NIC.Slot.1-1-1 -r pwrcycle -s TIME_NOW
+  # Give the machine a while to powerup and make the BIOS config change. 180
+  # seconds is arbitrary, and may be too much, though likely not too little.
+  sleep 180
+fi
+
+# Power the machine back down and set the first boot device to be the NIC.
+racadm ${DRAC_IP} ${DRAC_PASSWORD} serveraction powerdown
+
+sleep 5
+
+# This command sometimes fails for no apparent reason. Try it a few times before
+# giving up.
+COUNT=0
+until racadm ${DRAC_IP} ${DRAC_PASSWORD} set bios.biosbootsettings.bootseq NIC.Slot.1-1-1; do
+  COUNT=$((COUNT + 1))
+  if [[ "$COUNT" == "$MAX_RETRIES" ]]; then
+    echo "Max retry count reached for setting first boot device as NIC."
+    exit 1
+  fi
+  sleep 5
+done
+
+racadm ${DRAC_IP} ${DRAC_PASSWORD} jobqueue create BIOS.Setup.1-1 -r pwrcycle -s TIME_NOW

--- a/manual/boot_from_nic.sh
+++ b/manual/boot_from_nic.sh
@@ -25,7 +25,7 @@ function racadm() {
 # and it fails, and the next time if succeeds. This is a small wrapper that
 # will try a command MAX_RETRIES times before giving up and exiting with a
 # debug message.
-function set_retries() {
+function retry_racadm() {
   local command=$1
   local msg=$2
 
@@ -71,7 +71,7 @@ MOD_COUNT=0
 STATUS=$(racadm get nic.nicconfig.1.bootoptionrom)
 if [[ "$?" -eq "0" ]]; then
   if ! echo "${STATUS}" | grep 'bootoptionrom=Enabled'; then
-    set_retries "set nic.nicconfig.1.bootoptionrom Enabled" \
+    retry_racadm "set nic.nicconfig.1.bootoptionrom Enabled" \
         "Max retry count reached for setting BootOptionRom to Enabled."
     MOD_COUNT=$((MOD_COUNT + 1))
   fi
@@ -82,7 +82,7 @@ sleep 5
 STATUS=$(racadm get nic.nicconfig.1.legacybootproto)
 if [[ "$?" -eq "0" ]]; then
   if ! echo "${STATUS}" | grep 'legacybootproto=PXE'; then
-    set_retries "set nic.nicconfig.1.legacybootproto PXE" \
+    retry_racadm "set nic.nicconfig.1.legacybootproto PXE" \
         "Max retry count reached for setting LegacyBootProto to PXE."
     MOD_COUNT=$((MOD_COUNT + 1))
   fi
@@ -104,6 +104,6 @@ racadm serveraction powerdown
 
 sleep 5
 
-set_retries "set bios.biosbootsettings.bootseq NIC.Slot.1-1-1" \
+retry_racadm "set bios.biosbootsettings.bootseq NIC.Slot.1-1-1" \
     "Max retry count reached for setting first boot device as NIC."
 racadm jobqueue create BIOS.Setup.1-1 -r pwrcycle -s TIME_NOW

--- a/manual/manually_generate_images.sh
+++ b/manual/manually_generate_images.sh
@@ -1,0 +1,101 @@
+#!/bin/bash
+#
+# A script to create ePoxy images manually.
+
+# Edit the following variable to suit your needs, most importantly PROJECT and NODE_REGEXP.
+COREOS_VERSION="1855.4.0"
+PROJECT="mlab-staging"
+NODE_REGEXP="mlab4.(bru02|lax02|syd02)"
+GCS_BUCKET="gs://epoxy-${PROJECT}"
+GSUTIL_HEADER="Cache-Control:private, max-age=0, no-transform"
+
+# Install Docker.
+apt-get update
+apt-get install -y \
+    apt-transport-https \
+    ca-certificates \
+    curl \
+    software-properties-common
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
+   $(lsb_release -cs) \
+   stable"
+apt-get update
+apt-get install -y docker-ce
+
+# Clone the epoxy-images repository.
+git clone --recurse-submodules https://github.com/m-lab/epoxy-images.git
+cd epoxy-images
+
+# Install Google Cloud SDK
+travis/install_gcloud.sh
+
+# Make the output directory.
+mkdir output
+
+# Create the epoxy-images Docker image.
+docker build -t epoxy-images-builder . &> build.log
+
+# Build images.
+
+docker run -t -v ${PWD}:/images epoxy-images-builder \
+  bash -c "/images/setup_stage2.sh   \
+  /buildtmp \
+  /images/vendor \
+  /images/configs/stage2 \
+  /images/output/stage2_initramfs.cpio.gz \
+  /images/output/stage2_vmlinuz \
+  /images/output/epoxy_client /images/stage2.log \
+  /images/travis/one_line_per_minute.awk"
+
+docker run -v ${PWD}:/images -w /images epoxy-images-builder \
+  bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos \
+  /images/output/epoxy_client \
+  http://stable.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe.vmlinuz \
+  http://stable.release.core-os.net/amd64-usr/${COREOS_VERSION}/coreos_production_pxe_image.cpio.gz \
+  /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log"
+
+gsutil cp gs://vendor-mlab-oti/epoxy-images/mft-4.4.0-44.tgz ${PWD}
+
+docker run -it --privileged -v ${PWD}:/images -w /images epoxy-images-builder \
+  bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz \
+    && echo 'Starting stage3_mlxupdate build' \
+    && /images/setup_stage3_mlxupdate.sh \
+        /build /images/output /images/configs/stage3_mlxupdate \
+        /images/output/epoxy_client \
+      &> /images/stage3_mlxupdate.log \
+    && echo 'Starting ROM & ISO build' \
+    && /images/setup_stage3_mlxupdate_isos.sh \
+      ${PROJECT} /build /images/output '${NODE_REGEXP}.*' 3.4.809 \
+        /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk"
+
+# Copy all artifacts to GCS.
+
+gsutil -h "${GSUTIL_HEADER}" cp -r \
+  ${PWD}/output/stage2_vmlinuz \
+  ${PWD}/output/coreos_custom_pxe_image.cpio.gz \
+  ${PWD}/output/coreos_production_pxe.vmlinuz \
+  ${PWD}/actions/stage2/stage1to2.ipxe \
+  ${PWD}/actions/stage3_coreos/*.json \
+  ${GCS_BUCKET}/stage3_coreos/
+
+gsutil -h "${GSUTIL_HEADER}" cp -r \
+  ${PWD}/output/stage2_vmlinuz \
+  ${PWD}/output/vmlinuz_stage3_mlxupdate \
+  ${PWD}/output/initramfs_stage3_mlxupdate.cpio.gz \
+  ${PWD}/actions/stage2/stage1to2.ipxe \
+  ${PWD}/actions/stage3_mlxupdate/*.json \
+  ${GCS_BUCKET}/stage3_mlxupdate/
+
+gsutil -h "${GSUTIL_HEADER}" cp -r \
+  ${PWD}/output/*.iso \
+  ${GCS_BUCKET}/stage3_mlxupdate_iso/
+
+gsutil -h "${GSUTIL_HEADER}" cp -r \
+  ${PWD}/output/stage1_mlxrom/* \
+  ${GCS_BUCKET}/stage1_mlxrom/
+
+gsutil -h "${GSUTIL_HEADER}" cp -r \
+  ${PWD}/output/stage1_mlxrom/*/* \
+  ${GCS_BUCKET}/stage1_mlxrom/latest/

--- a/manual/manually_generate_images.sh
+++ b/manual/manually_generate_images.sh
@@ -31,7 +31,8 @@ cd epoxy-images
 # Install Google Cloud SDK
 travis/install_gcloud.sh
 
-# Make the output directory.
+# Make the output directory, removing any existing one first.
+rm -rf output
 mkdir output
 
 # Create the epoxy-images Docker image.


### PR DESCRIPTION
The previous README has instructions for setting various BIOS parameters to configure the machine to boot from the NIC first. This PR introduces a new script which helps to automate this a little. This script should be run prior to flashing the ROM on the NIC.

Additionally, it may sometimes be useful to manually generate an ePoxy image for testing, or for some other one-off reason. This PR adds a new script to help facilitate this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/77)
<!-- Reviewable:end -->
