### PR TITLE
Confiures optical drive as 2nd boot device.

### DIFF
--- a/manual/boot_from_nic.sh
+++ b/manual/boot_from_nic.sh
@@ -104,6 +104,6 @@ racadm serveraction powerdown
 
 sleep 5
 
-retry_racadm "set bios.biosbootsettings.bootseq NIC.Slot.1-1-1" \
+retry_racadm "set bios.biosbootsettings.bootseq NIC.Slot.1-1-1,Optical.SATAEmbedded.J-1" \
     "Max retry count reached for setting first boot device as NIC."
 racadm jobqueue create BIOS.Setup.1-1 -r pwrcycle -s TIME_NOW


### PR DESCRIPTION
After setting the NIC as the first boot device, it is possible that the 2nd device will be the optical drive, since it was previously 1st. This small change makes that configuration explicit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/78)
<!-- Reviewable:end -->
