### PR TITLE
Wraps all racadm commands in retry_racadm, and tries to resets iDRAC once on failure.

### DIFF
--- a/manual/boot_from_nic.sh
+++ b/manual/boot_from_nic.sh
@@ -27,18 +27,17 @@ function racadm() {
 # debug message.
 function retry_racadm() {
   local command=$1
+  local count=0
   local msg=$2
 
-  COUNT=0
   until racadm "${command}"; do
-    COUNT=$((COUNT + 1))
-    if [[ "${COUNT}" -ge "${MAX_RETRIES}" ]]; then
-      # Try resetting the iDRAC, then try the command again.
+    count=$((count + 1))
+    if [[ "${count}" -ge "${MAX_RETRIES}" ]]; then
+      # Try resetting the iDRAC, then try MAX_RETRIES again.
       if [[ -z "${FINAL_ATTEMPT}" ]]; then
-        racadm racreset
+        count=0
         sleep 120
         FINAL_ATTEMPT="yes"
-        retry_racadm "$command" "$msg"
       else
         echo "${msg}"
         exit 1


### PR DESCRIPTION
This PR wraps all `racadm` commands with the `retry_racadm` function, since in testing it became apparently that every single possible command can fail a few times then randomly work another time.  Dell apparently knows this is true because even the iDRAC emits a message similar to this when a failure occurs:

`ERROR: SUP002: Job creation failure. Retry the action. If this fails, reboot the iDRAC.`

In the spirit of that message, the `retry_racadm` function will now attempt to reset the iDRAC once if a command fails `MAX_RETRIES` times, then it will try `MAX_RETRIES` times again before finally giving up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/79)
<!-- Reviewable:end -->
