### PR TITLE
Disable router advertisements

### DIFF
--- a/configs/stage3_coreos/resources/generate_network_config.sh
+++ b/configs/stage3_coreos/resources/generate_network_config.sh
@@ -15,6 +15,7 @@ OUTPUT=${1:?Please provide the name for writing config file}
 # legitimate nodes from IPv6 addresses will fail.
 #
 # Disable IPv6 autoconf.
+echo "0" > /proc/sys/net/ipv6/conf/all/accept_ra
 echo "0" > /proc/sys/net/ipv6/conf/all/autoconf
 
 # Extract the epoxy.ip= parameter from /proc/cmdline.


### PR DESCRIPTION
After finding that some machines would automatically assign an IPV6 address (rather than our standarad IPv6 address), we attempted to disable autoconf. In fact, the IPv6 addr comes from router advertisements "ra". This option should disable accepting router advertisements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/80)
<!-- Reviewable:end -->
