### PR TITLE
Add bootstrapfs and stage1to2 JSON actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,9 +84,6 @@ script:
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh
             mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t).*' 3.4.809
-              /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk
-        && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-staging /build /images/output 'mlab[1-3].(iad1t|lga0t).*' 3.4.809
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk"
         || (tail stage3_mlxupdate.log stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output

--- a/.travis.yml
+++ b/.travis.yml
@@ -88,6 +88,13 @@ script:
         || (tail stage3_mlxupdate.log stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
+
+# Note: build a skeleton bootstrapfs for the modified PlanetLab bootmanager.
+- time docker run -it -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
+      bash -c "/images/setup_stage1_bootstrapfs.sh
+        /images/output/epoxy_client
+        /images/output/bootstrapfs-MeasurementLabUpdate.tar.bz2"
+
 # Deploy steps never trigger on a new Pull Request. Deploy steps will trigger
 # after a merge with matching "on:" conditions.
 deploy:

--- a/actions/stage3_coreos/stage1to2.json
+++ b/actions/stage3_coreos/stage1to2.json
@@ -1,0 +1,37 @@
+{
+   "v1" : {
+      "env" : {
+         "PATH" : "/bin:/usr/bin:/usr/local/bin"
+      },
+      "files" : {
+         "vmlinuz" : {
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_coreos/stage2_vmlinuz"
+         }
+      },
+      "vars" : {
+         "kargs" : [
+            "epoxy.ip={{kargs `epoxy.ip`}}",
+            "epoxy.ipv4={{kargs `epoxy.ipv4`}}",
+            "epoxy.ipv6={{kargs `epoxy.ipv6`}}",
+            "epoxy.interface={{kargs `epoxy.interface`}}",
+            "epoxy.hostname={{kargs `epoxy.hostname`}}",
+            "epoxy.stage2={{kargs `epoxy.stage2`}}",
+            "epoxy.stage3={{kargs `epoxy.stage3`}}",
+            "epoxy.report={{kargs `epoxy.report`}}",
+            "epoxy.allocate_k8s_token={{kargs `epoxy.allocate_k8s_token`}}",
+            "epoxy.server={{kargs `epoxy.server`}}",
+            "epoxy.project={{kargs `epoxy.project`}}"
+         ],
+         "cmdline" : "net.ifnames=0 coreos.autologin=tty1 autoconf=0"
+      },
+      "commands" : [
+         "# Run kexec using the downloaded initram and vmlinuz files.",
+         [
+            "/sbin/kexec",
+            "--force",
+            "--command-line={{.vars.kargs}} {{.vars.cmdline}}",
+            "{{.files.vmlinuz.name}}"
+         ]
+      ]
+   }
+}

--- a/actions/stage3_mlxupdate/stage1to2.json
+++ b/actions/stage3_mlxupdate/stage1to2.json
@@ -1,0 +1,37 @@
+{
+   "v1" : {
+      "env" : {
+         "PATH" : "/bin:/usr/bin:/usr/local/bin"
+      },
+      "files" : {
+         "vmlinuz" : {
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_mlxupdate/stage2_vmlinuz"
+         }
+      },
+      "vars" : {
+         "kargs" : [
+            "epoxy.ip={{kargs `epoxy.ip`}}",
+            "epoxy.ipv4={{kargs `epoxy.ipv4`}}",
+            "epoxy.ipv6={{kargs `epoxy.ipv6`}}",
+            "epoxy.interface={{kargs `epoxy.interface`}}",
+            "epoxy.hostname={{kargs `epoxy.hostname`}}",
+            "epoxy.stage2={{kargs `epoxy.stage2`}}",
+            "epoxy.stage3={{kargs `epoxy.stage3`}}",
+            "epoxy.report={{kargs `epoxy.report`}}",
+            "epoxy.allocate_k8s_token={{kargs `epoxy.allocate_k8s_token`}}",
+            "epoxy.server={{kargs `epoxy.server`}}",
+            "epoxy.project={{kargs `epoxy.project`}}"
+         ],
+         "cmdline" : "net.ifnames=0 coreos.autologin=tty1 autoconf=0"
+      },
+      "commands" : [
+         "# Run kexec using the downloaded initram and vmlinuz files.",
+         [
+            "/sbin/kexec",
+            "--force",
+            "--command-line={{.vars.kargs}} {{.vars.cmdline}}",
+            "{{.files.vmlinuz.name}}"
+         ]
+      ]
+   }
+}

--- a/configs/stage3_mlxupdate/rc.local
+++ b/configs/stage3_mlxupdate/rc.local
@@ -56,4 +56,5 @@ setup_network
 
 # Note: the stage3 action should be configured in the epoxy server. The nextboot
 # config returned should probably run /usr/local/util/updaterom.sh
-/usr/bin/epoxy_client -action epoxy.stage3 && reboot
+# TODO: add "&& reboot" once epoxy_client correctly sets exit code.
+/usr/bin/epoxy_client -action epoxy.stage3

--- a/deploy_epoxy_components.sh
+++ b/deploy_epoxy_components.sh
@@ -80,3 +80,8 @@ ${SOURCE_DIR}/travis/deploy_gcs.sh ${KEYNAME} \
 ${SOURCE_DIR}/travis/deploy_gcs.sh ${KEYNAME} \
   ${SOURCE_DIR}/output/stage1_mlxrom/*/* \
   ${BUCKET}/stage1_mlxrom/latest/
+
+# Deploy the stage1 custom bootstrapfs for the modified PlanetLab bootmanager.
+${SOURCE_DIR}/travis/deploy_gcs.sh ${KEYNAME} \
+  ${SOURCE_DIR}/output/bootstrapfs-MeasurementLabUpdate.tar.bz2* \
+  ${BUCKET}/stage1_bootstrapfs/

--- a/setup_stage1_bootstrapfs.sh
+++ b/setup_stage1_bootstrapfs.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# setup_stage1_bootstrapfs.sh creates a pseudo-bootstrapfs for a modified
+# PlanetLab BootManager.
+
+set -x
+set -e
+
+SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
+
+USAGE="$0 <build_dir> <output_dir> <config_dir>"
+BUILD_DIR=${1:?Please specify a build directory: $USAGE}
+EPOXY_CLIENT=${2:?Please specify the path to the epoxy client binary: $USAGE}
+CONFIG_DIR=${3:?Please specify a configuration directory: $USAGE}
+OUTPUT_DIR=${4:?Please specify an output directory: $USAGE}
+
+# TODO: implement bootstrapfs build.
+#
+# Steps:
+# * make tmp dir
+# * create dir tree
+# * copy epoxy client to tmpdir
+# * tar bz2 content of tmp dir
+# * copy result to output_dir
+

--- a/setup_stage1_bootstrapfs.sh
+++ b/setup_stage1_bootstrapfs.sh
@@ -8,18 +8,14 @@ set -e
 
 SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
 
-USAGE="$0 <build_dir> <output_dir> <config_dir>"
-BUILD_DIR=${1:?Please specify a build directory: $USAGE}
-EPOXY_CLIENT=${2:?Please specify the path to the epoxy client binary: $USAGE}
-CONFIG_DIR=${3:?Please specify a configuration directory: $USAGE}
-OUTPUT_DIR=${4:?Please specify an output directory: $USAGE}
+USAGE="$0 <epoxy-client> <output_file>"
+EPOXY_CLIENT=${1:?Please specify the path to the epoxy client binary: $USAGE}
+OUTPUT_FILE=${2:?Please specify an output file: $USAGE}
 
-# TODO: implement bootstrapfs build.
-#
-# Steps:
-# * make tmp dir
-# * create dir tree
-# * copy epoxy client to tmpdir
-# * tar bz2 content of tmp dir
-# * copy result to output_dir
-
+# Create a custom bootstrapfs.
+output=$( mktemp -d -t build-bootstrapfs.XXXXX )
+mkdir -p ${output}/{etc,usr/bin,boot}
+install -D -m 755 "${EPOXY_CLIENT}" "${output}/epoxy_client"
+tar -C "${output}" -jcvf "${OUTPUT_FILE}" .
+cat "${OUTPUT_FILE}" | shasum > "${OUTPUT_FILE}".sha1sum
+rm -rf "${output}"


### PR DESCRIPTION
This change adds steps to build a custom bootstrapfs for updating M-Lab servers using a modified PLC BootManager.

This change also includes two stage1to2.json files used for `epoxy_client` run in stage1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/83)
<!-- Reviewable:end -->
