### PR TITLE
Add initial support for cloudbuild.yaml

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -1,0 +1,112 @@
+#!/bin/bash
+#
+# builder.sh should be called by cloudbuilder.yaml. builder accepts a single
+# parameter (target) and multiple parameters from the environment. builder.sh
+# transalates these into calls to specific build scripts.
+
+set -eu
+SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
+
+USAGE="$0 <target>"
+TARGET=${1:?Please provide a build target: $USAGE}
+
+function stage1_mlxrom() {
+  local target=${TARGET:?Please specify a target configuration name}
+  local project=${PROJECT:?Please specify the PROJECT}
+  local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
+  local version=${MLXROM_VERSION:?Please define the MLXROM_VERSION to build}
+  local regex_name="REGEXP_${PROJECT//-/_}"
+
+  local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
+
+  ${SOURCE_DIR}/setup_stage1.sh "${project}" "${builddir}" "${artifacts}" \
+      "${SOURCE_DIR}/configs/${target}" "${!regex_name}" "${version}" \
+      "${SOURCE_DIR}/configs/${target}/ipxe-ca.pem"
+
+  rm -rf "${builddir}"
+}
+
+function stage2() {
+  local target=${TARGET:?Please specify a target configuration name}
+  local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
+
+  local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
+
+  ${SOURCE_DIR}/setup_stage2.sh "${builddir}" "${SOURCE_DIR}/vendor" \
+     "${SOURCE_DIR}/configs/${target}" \
+     "${artifacts}/stage2_initramfs.cpio.gz" \
+     "${artifacts}/stage2_vmlinuz" \
+     "${artifacts}/epoxy_client" \
+     "${SOURCE_DIR}/stage2.log" \
+     "${SOURCE_DIR}/travis/one_line_per_minute.awk" \
+  || (
+     tail -100 ${SOURCE_DIR}/stage2.log && false
+  )
+
+  rm -rf "${builddir}"
+}
+
+# Build coreos custom initram image.
+function stage3_coreos() {
+  local target=${TARGET:?Please specify a target configuration name}
+  local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
+  local version=${COREOS_VERSION:?Please specify the coreos version}
+  local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
+
+  umask 0022
+  ${SOURCE_DIR}/setup_stage3_coreos.sh \
+      "${SOURCE_DIR}/configs/${target}" \
+      "${artifacts}/epoxy_client" \
+      http://stable.release.core-os.net/amd64-usr/${version}/coreos_production_pxe.vmlinuz \
+      http://stable.release.core-os.net/amd64-usr/${version}/coreos_production_pxe_image.cpio.gz \
+      "${artifacts}/coreos_custom_pxe_image.cpio.gz" &> ${SOURCE_DIR}/coreos.log \
+  || (
+      tail -100 ${SOURCE_DIR}/coreos.log && false
+  )
+
+  rm -rf ${builddir}
+}
+
+function stage3_mlxupdate() {
+  local target=${TARGET:?Please specify a target configuration name}
+  local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
+  local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
+
+  umask 0022
+  install -D -m 644 ${SOURCE_DIR}/vendor/mft-4.4.0-44.tgz \
+      ${builddir}/mft-4.4.0-44.tgz
+
+  echo 'Starting stage3_mlxupdate build'
+  ${SOURCE_DIR}/setup_stage3_mlxupdate.sh \
+      ${builddir} ${artifacts} ${SOURCE_DIR}/configs/${target} \
+      ${artifacts}/epoxy_client # &> ${SOURCE_DIR}/stage3_mlxupdate.log
+
+  rm -rf ${builddir}
+}
+
+function stage3_mlxupdate_iso() {
+  # TODO: restructure setup_stage3_mlxupdate_isos.sh
+  return
+}
+
+case "${TARGET}" in
+  stage1_mlxrom)
+      stage1_mlxrom
+      ;;
+  stage2)
+      stage2
+      ;;
+  stage3_coreos)
+      stage3_coreos
+      ;;
+  stage3_mlxupdate)
+      stage3_mlxupdate
+      ;;
+  stage3_mlxupdate_iso)
+      stage3_mlxupdate_iso
+      ;;
+  *)
+      echo "Unknown target: ${TARGET}"
+      exit 1
+      ;;
+esac

--- a/builder.sh
+++ b/builder.sh
@@ -26,6 +26,17 @@ function stage1_mlxrom() {
   rm -rf "${builddir}"
 }
 
+function stage1_bootstrapfs() {
+  local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
+  local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
+
+  ${SOURCE_DIR}/setup_stage1_bootstrapfs.sh \
+      ${artifacts}/epoxy_client \
+      ${artifacts}/bootstrapfs-MeasurementLabUpdate.tar.bz2
+
+  rm -rf "${builddir}"
+}
+
 function stage2() {
   local target=${TARGET:?Please specify a target configuration name}
   local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
@@ -92,6 +103,9 @@ function stage3_mlxupdate_iso() {
 case "${TARGET}" in
   stage1_mlxrom)
       stage1_mlxrom
+      ;;
+  stage1_bootstrapfs)
+      stage1_bootstrapfs
       ;;
   stage2)
       stage2

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -55,9 +55,11 @@ steps:
    - 'COREOS_VERSION=1855.4.0'
 
 # stage3_mlxupdate images.
+# NOTE: all project cloudbuild service accounts must be granted READ access to
+# the vendor-mlab-oti bucket.
 - name: gcr.io/cloud-builders/gsutil
   args: [
-    'cp', 'gs://vendor-mlab-sandbox/mft-4.4.0-44.tgz', '/workspace/vendor'
+    'cp', 'gs://vendor-mlab-oti/epoxy-images/mft-4.4.0-44.tgz', '/workspace/vendor'
   ]
 - name: epoxy-images-builder
   args: [

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -25,19 +25,20 @@ steps:
    - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
    - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
 
-# stage1 bootstrapfs.
+# stage2 kernel.
 - name: epoxy-images-builder
   args: [
-    '/workspace/builder.sh', 'stage1_bootstrapfs'
+    '/workspace/builder.sh', 'stage2'
   ]
   env:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
 
-# stage2 kernel.
+# stage1 bootstrapfs.
+# NOTE: this must run after stage2 so that the epoxy_client is available.
 - name: epoxy-images-builder
   args: [
-    '/workspace/builder.sh', 'stage2'
+    '/workspace/builder.sh', 'stage1_bootstrapfs'
   ]
   env:
    - 'PROJECT=$PROJECT_ID'

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,12 +1,11 @@
 # Timeout for complete build. Default is 10m.
 timeout: 7200s
 
-steps:
-
 ############################################################################
 # BUILD ARTIFACTS
 ############################################################################
 
+steps:
 # Create the image builder for later steps.
 - name: gcr.io/cloud-builders/docker
   args: [
@@ -25,6 +24,15 @@ steps:
    - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
    - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
    - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
+
+# stage1 bootstrapfs.
+- name: epoxy-images-builder
+  args: [
+    '/workspace/builder.sh', 'stage1_bootstrapfs'
+  ]
+  env:
+   - 'PROJECT=$PROJECT_ID'
+   - 'ARTIFACTS=/workspace/output'
 
 # stage2 kernel.
 - name: epoxy-images-builder
@@ -66,12 +74,20 @@ steps:
 # not support multiple target locations. So, the steps below are explicit.
 ############################################################################
 
-# stage1 images.
+# stage1_mlxrom.
 - name: gcr.io/cloud-builders/gsutil
   args: [
     '-h', 'Cache-Control:private, max-age=0, no-transform',
     'cp', '-r', '/workspace/output/stage1_mlxrom/*',
     'gs://epoxy-$PROJECT_ID/stage1_mlxrom/'
+  ]
+
+# stage1_bootstrapfs.
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    'cp', '-r', '/workspace/output/bootstrapfs-MeasurementLabUpdate.tar.bz2*',
+    'gs://epoxy-$PROJECT_ID/stage1_bootstrapfs/'
   ]
 
 # stage3_coreos.

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,101 @@
+# Timeout for complete build. Default is 10m.
+timeout: 7200s
+
+steps:
+
+############################################################################
+# BUILD ARTIFACTS
+############################################################################
+
+# Create the image builder for later steps.
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build', '-t', 'epoxy-images-builder', '.'
+  ]
+
+# stage1 ROMs.
+- name: epoxy-images-builder
+  args: [
+    '/workspace/builder.sh', 'stage1_mlxrom'
+  ]
+  env:
+   - 'PROJECT=$PROJECT_ID'  # One of: mlab-sandbox, mlab-staging, or mlab-oti.
+   - 'ARTIFACTS=/workspace/output'
+   - 'MLXROM_VERSION=3.4.809'
+   - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
+   - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
+   - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
+
+# stage2 kernel.
+- name: epoxy-images-builder
+  args: [
+    '/workspace/builder.sh', 'stage2'
+  ]
+  env:
+   - 'PROJECT=$PROJECT_ID'
+   - 'ARTIFACTS=/workspace/output'
+
+# stage3_coreos images.
+- name: epoxy-images-builder
+  args: [
+    '/workspace/builder.sh', 'stage3_coreos'
+  ]
+  env:
+   - 'PROJECT=$PROJECT_ID'
+   - 'ARTIFACTS=/workspace/output'
+   - 'COREOS_VERSION=1855.4.0'
+
+# stage3_mlxupdate images.
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    'cp', 'gs://vendor-mlab-sandbox/mft-4.4.0-44.tgz', '/workspace/vendor'
+  ]
+- name: epoxy-images-builder
+  args: [
+    '/workspace/builder.sh', 'stage3_mlxupdate'
+  ]
+  env:
+   - 'PROJECT=$PROJECT_ID'
+   - 'ARTIFACTS=/workspace/output'
+
+############################################################################
+# DEPLOY ARTIFACTS
+#
+# Note: the artifacts built above need to be copied to specific locations in
+# the target bucket. Currently, the cloudbuilder 'artifacts' directive does
+# not support multiple target locations. So, the steps below are explicit.
+############################################################################
+
+# stage1 images.
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    'cp', '-r', '/workspace/output/stage1_mlxrom/*',
+    'gs://soltesz-$PROJECT_ID/stage1_mlxrom/'
+  ]
+
+# stage3_coreos.
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    'cp', '-r',
+    '/workspace/output/stage2_vmlinuz',
+    '/workspace/output/coreos_custom_pxe_image.cpio.gz',
+    '/workspace/output/coreos_production_pxe.vmlinuz',
+    '/workspace/actions/stage2/stage1to2.ipxe',
+    '/workspace/actions/stage3_coreos/*.json',
+    'gs://soltesz-$PROJECT_ID/stage3_coreos/'
+  ]
+
+# stage3_mlxupdate.
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    'cp', '-r',
+    '/workspace/output/stage2_vmlinuz',
+    '/workspace/output/vmlinuz_stage3_mlxupdate',
+    '/workspace/output/initramfs_stage3_mlxupdate.cpio.gz',
+    '/workspace/actions/stage2/stage1to2.ipxe',
+    '/workspace/actions/stage3_mlxupdate/*.json',
+    'gs://soltesz-$PROJECT_ID/stage3_mlxupdate/'
+  ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -71,7 +71,7 @@ steps:
   args: [
     '-h', 'Cache-Control:private, max-age=0, no-transform',
     'cp', '-r', '/workspace/output/stage1_mlxrom/*',
-    'gs://soltesz-$PROJECT_ID/stage1_mlxrom/'
+    'gs://epoxy-$PROJECT_ID/stage1_mlxrom/'
   ]
 
 # stage3_coreos.
@@ -84,7 +84,7 @@ steps:
     '/workspace/output/coreos_production_pxe.vmlinuz',
     '/workspace/actions/stage2/stage1to2.ipxe',
     '/workspace/actions/stage3_coreos/*.json',
-    'gs://soltesz-$PROJECT_ID/stage3_coreos/'
+    'gs://epoxy-$PROJECT_ID/stage3_coreos/'
   ]
 
 # stage3_mlxupdate.
@@ -97,5 +97,5 @@ steps:
     '/workspace/output/initramfs_stage3_mlxupdate.cpio.gz',
     '/workspace/actions/stage2/stage1to2.ipxe',
     '/workspace/actions/stage3_mlxupdate/*.json',
-    'gs://soltesz-$PROJECT_ID/stage3_mlxupdate/'
+    'gs://epoxy-$PROJECT_ID/stage3_mlxupdate/'
   ]

--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -197,6 +197,7 @@ function copy_roms_to_output() {
   local build_dir=$1
   local output_dir=$2
 
+  mkdir -p "${output_dir}"
   # Copy files to output.
   rsync -ar "${build_dir}" "${output_dir}"
   # Assure that the output files are readable.

--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -164,15 +164,19 @@ function build_roms() {
   local extra_cflags=
   local procs=`getconf _NPROCESSORS_ONLN`
 
-  for stage1 in `ls ${stage1_config_dir}/*.ipxe` ; do
-    # Extract the hostname from the filename.
-    hostname=${stage1##*stage1-}
-    hostname=${hostname%%.ipxe}
+  for device in ConnectX-3.mrom ConnectX-3Pro.mrom ; do
 
+    extra_cflags="$( get_extra_flags $device $version )"
     pushd ${flexboot_src}
-      # TODO: select image type more intelligently.
-      for device in ConnectX-3.mrom ConnectX-3Pro.mrom ; do
-        extra_cflags="$( get_extra_flags $device $version )"
+      # NOTE: clean the build environment between devices. Without resetting,
+      # ROMs for the ConnectX-3Pro have the wrong device ID.
+      make clean
+      rm -rf bin
+
+      for stage1 in `ls ${stage1_config_dir}/*.ipxe` ; do
+        # Extract the hostname from the filename.
+        hostname=${stage1##*stage1-}
+        hostname=${hostname%%.ipxe}
 
         # The generated ROM file is the device name.
         make -j ${procs} bin/${device} \
@@ -187,9 +191,9 @@ function build_roms() {
         cp bin/${device} ${rom_output_dir}/${version}/${device%%.mrom}/${hostname}.mrom
       done
     popd
-    # Remove old files to prevent regenerating ROMs during multiple builds.
-    rm -f ${stage1}
   done
+  # Remove old files to prevent regenerating ROMs during multiple builds.
+  rm -f ${stage1_config_dir}/*.ipxe
 }
 
 


### PR DESCRIPTION
This change adds support for building epoxy-images using [GCP cloud builder](https://cloud.google.com/cloud-build/docs/configuring-builds/create-basic-configuration). While previously only a subset of mlx ROM images were built, this change allows all ROMs (matching the per-project machine regex) to be built at once with much longer timeouts than what was allowed from travis.

This change does not include automatic triggering of the cloudbuild.yaml configuration. So at this time, the cloud builder is only manually run using:

```
gcloud builds submit --config cloudbuild.yaml .
```

To prevent multiple deployments, ultimately, the .travis.yml deploy steps should be removed in favor of cloudbuild.yml and the travis build steps simplified using `builder.sh`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/84)
<!-- Reviewable:end -->
