### PR TITLE
Revert embedded certificate to use Google Intermediate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-sandbox /build /images/output 'mlab4.iad1t.*' 3.4.810
+            mlab-sandbox /build /images/output 'mlab4.lga1t.*' 3.4.810
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk"
         || (tail stage3_mlxupdate.log stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output

--- a/.travis.yml
+++ b/.travis.yml
@@ -83,7 +83,7 @@ script:
           &> /images/stage3_mlxupdate.log
         && echo 'Starting ROM & ISO build'
         && /images/setup_stage3_mlxupdate_isos.sh
-            mlab-sandbox /build /images/output 'mlab4.(iad1t|lga0t).*' 3.4.809
+            mlab-sandbox /build /images/output 'mlab4.iad1t.*' 3.4.810
               /images/stage3_mlxupdate_iso.log /images/travis/one_line_per_minute.awk"
         || (tail stage3_mlxupdate.log stage3_mlxupdate_iso.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output

--- a/builder.sh
+++ b/builder.sh
@@ -21,7 +21,7 @@ function stage1_mlxrom() {
 
   ${SOURCE_DIR}/setup_stage1.sh "${project}" "${builddir}" "${artifacts}" \
       "${SOURCE_DIR}/configs/${target}" "${!regex_name}" "${version}" \
-      "${SOURCE_DIR}/configs/${target}/ipxe-ca.pem"
+      "${SOURCE_DIR}/configs/${target}/gtsgiag3.pem"
 
   rm -rf "${builddir}"
 }

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
   env:
    - 'PROJECT=$PROJECT_ID'  # One of: mlab-sandbox, mlab-staging, or mlab-oti.
    - 'ARTIFACTS=/workspace/output'
-   - 'MLXROM_VERSION=3.4.809'
+   - 'MLXROM_VERSION=3.4.810'
    - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
    - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
    - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
@@ -83,6 +83,13 @@ steps:
     '-h', 'Cache-Control:private, max-age=0, no-transform',
     'cp', '-r', '/workspace/output/stage1_mlxrom/*',
     'gs://epoxy-$PROJECT_ID/stage1_mlxrom/'
+  ]
+# Deploy stage1_mlxrom images again to the 'latest' directory (without version).
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    'cp', '-r', '/workspace/output/stage1_mlxrom/*/*',
+    'gs://epoxy-$PROJECT_ID/stage1_mlxrom/latest/'
   ]
 
 # stage1_bootstrapfs.

--- a/configs/stage1_mlxrom/build-iso-template.sh
+++ b/configs/stage1_mlxrom/build-iso-template.sh
@@ -25,7 +25,7 @@ ${SOURCE_DIR}/setup_stage1.sh \
     "{{project}}" "${BUILD_DIR}" "${OUTPUT_DIR}" \
     ${SOURCE_DIR}/configs/stage1_mlxrom \
     "{{hostname}}" "${ROM_VERSION}" \
-    "${SOURCE_DIR}/configs/stage1_mlxrom/ipxe-ca.pem" 2>&1 \
+    "${SOURCE_DIR}/configs/stage1_mlxrom/gtsgiag3.pem" 2>&1 \
     | tee -a ${LOGFILE} \
     | ${FILTER}
 

--- a/configs/stage3_mlxupdate/rc.local
+++ b/configs/stage3_mlxupdate/rc.local
@@ -56,5 +56,4 @@ setup_network
 
 # Note: the stage3 action should be configured in the epoxy server. The nextboot
 # config returned should probably run /usr/local/util/updaterom.sh
-# TODO: add "&& reboot" once epoxy_client correctly sets exit code.
-/usr/bin/epoxy_client -action epoxy.stage3
+/usr/bin/epoxy_client -action epoxy.stage3 && reboot


### PR DESCRIPTION
Recently we discovered that the ipxe.org CA OCSP servers are not as reliable as we expected. This is a hard dependency that prevents machines from booting.

To work around this right now, this change reverts the CA embedded in the ipxe ROMs to use an intermediate Google CA used to sign certificates for appengine services and GCS.

With this change and after re-flashing ROMs in current machines, it should be possible to unblock the current issue with machine boots.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/85)
<!-- Reviewable:end -->
