### PR TITLE
Update COREOS stable version to latest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@
 #    the target branch matches a supported deployment target.
 
 env:
-- COREOS_VERSION="1855.4.0"
+- COREOS_VERSION="1911.4.0"
 
 services:
 - docker

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -71,7 +71,7 @@ steps:
   env:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
-   - 'COREOS_VERSION=1855.4.0'
+   - 'COREOS_VERSION=1911.4.0'
 
 # stage3_mlxupdate images.
 # NOTE: all project cloudbuild service accounts must be granted READ access to


### PR DESCRIPTION
This change updates the CoreOS version to the latest stable to address issue https://github.com/m-lab/dev-tracker/issues/142

I have confirmed that port 10010 is no longer open on the public interface.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/88)
<!-- Reviewable:end -->
