### PR TITLE
Update stage3_coreos k8s version to v1.12.3 and allow version override

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -72,6 +72,9 @@ steps:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
    - 'COREOS_VERSION=1911.4.0'
+   - 'K8S_VERSION=v1.12.3'
+   - 'CRI_VERSION=v1.12.0'
+   - 'CNI_VERSION=v0.7.1'
 
 # stage3_mlxupdate images.
 # NOTE: all project cloudbuild service accounts must be granted READ access to

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -18,7 +18,7 @@ CUSTOM=${5:?Please provide the name for a customized initram image: $USAGE}
 #
 # Version of k8s services and cli tools.
 K8S_VERSION=${K8S_VERSION:-v1.12.3}
-# Version of "container registry interface". (Independent of K8S_VERSION)
+# Version of "container runtime interface". (Independent of K8S_VERSION)
 CRI_VERSION=${CRI_VERSION:-v1.12.0}
 # Version of "container networking interface".
 CNI_VERSION=${CNI_VERSION:-v0.7.1}

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -76,7 +76,6 @@ pushd $IMAGEDIR
 
   # Install crictl.
   mkdir -p squashfs-root/bin
-  # TODO: temporarily disable CRI. This is required for k8s versions v1.11+
   CRI_VERSION="v1.12.0"
   wget https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRI_VERSION}/crictl-${CRI_VERSION}-linux-amd64.tar.gz
   tar zxvf crictl-${CRI_VERSION}-linux-amd64.tar.gz -C squashfs-root/bin/
@@ -85,9 +84,9 @@ pushd $IMAGEDIR
   # Install the kube* commands.
   # Installation commands adapted from:
   #   https://kubernetes.io/docs/setup/independent/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
-  RELEASE="$(echo v1.12.0 | tee squashfs-root/share/oem/installed_k8s_version.txt)"
+  K8S_RELEASE="$(echo v1.12.3 | tee squashfs-root/share/oem/installed_k8s_version.txt)"
   pushd squashfs-root/bin
-    curl --location --remote-name-all https://storage.googleapis.com/kubernetes-release/release/"${RELEASE}"/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+    curl --location --remote-name-all https://storage.googleapis.com/kubernetes-release/release/"${K8S_RELEASE}"/bin/linux/amd64/{kubeadm,kubelet,kubectl}
     chmod 755 {kubeadm,kubelet,kubectl}
   popd
 

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -14,6 +14,15 @@ VMLINUZ_URL=${3:?Please provide the URL for a coreos vmlinuz image: $USAGE}
 INITRAM_URL=${4:?Please provide the URL for a coreos initram image: $USAGE}
 CUSTOM=${5:?Please provide the name for a customized initram image: $USAGE}
 
+# Default values that callers can override from the environment.
+#
+# Version of k8s services and cli tools.
+K8S_VERSION=${K8S_VERSION:-v1.12.3}
+# Version of "container registry interface". (Independent of K8S_VERSION)
+CRI_VERSION=${CRI_VERSION:-v1.12.0}
+# Version of "container networking interface".
+CNI_VERSION=${CNI_VERSION:-v0.7.1}
+
 SCRIPTDIR=$( dirname "${BASH_SOURCE[0]}" )
 
 # Convert relative path to an absolute path.
@@ -52,7 +61,6 @@ pushd $IMAGEDIR
   # Install the cni binaries: bridge, flannel, host-local, ipvlan, loopback, and
   # others.
   mkdir -p squashfs-root/cni/bin
-  CNI_VERSION="v0.7.1"
   curl --location "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar --directory=squashfs-root/cni/bin -xz
 
   # Install multus and index2ip.
@@ -76,7 +84,6 @@ pushd $IMAGEDIR
 
   # Install crictl.
   mkdir -p squashfs-root/bin
-  CRI_VERSION="v1.12.0"
   wget https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRI_VERSION}/crictl-${CRI_VERSION}-linux-amd64.tar.gz
   tar zxvf crictl-${CRI_VERSION}-linux-amd64.tar.gz -C squashfs-root/bin/
   rm -f crictl-${CRI_VERSION}-linux-amd64.tar.gz
@@ -84,9 +91,9 @@ pushd $IMAGEDIR
   # Install the kube* commands.
   # Installation commands adapted from:
   #   https://kubernetes.io/docs/setup/independent/install-kubeadm/#installing-kubeadm-kubelet-and-kubectl
-  K8S_RELEASE="$(echo v1.12.3 | tee squashfs-root/share/oem/installed_k8s_version.txt)"
+  echo ${K8S_VERSION} > squashfs-root/share/oem/installed_k8s_version.txt
   pushd squashfs-root/bin
-    curl --location --remote-name-all https://storage.googleapis.com/kubernetes-release/release/"${K8S_RELEASE}"/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+    curl --location --remote-name-all https://storage.googleapis.com/kubernetes-release/release/"${K8S_VERSION}"/bin/linux/amd64/{kubeadm,kubelet,kubectl}
     chmod 755 {kubeadm,kubelet,kubectl}
   popd
 


### PR DESCRIPTION
This change updates the default k8s version in the coreos image to v1.12.3 and allows future changes to occur through the environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/90)
<!-- Reviewable:end -->
