### PR TITLE
Add multus-cni.conf in stage3_coreos/resources.

### DIFF
--- a/configs/stage3_coreos/resources/README.md
+++ b/configs/stage3_coreos/resources/README.md
@@ -1,0 +1,7 @@
+## multus-cni.conf
+
+The `multus-cni.conf` file is included in the `stage3_coreos` image so that it
+can be copied to the correct folder as part of the k8s setup script (found [here](https://github.com/m-lab/k8s-support/blob/master/node/setup_k8s.sh.template)).
+
+This file is needed to allow kubelet to join the k8s cluster.
+

--- a/configs/stage3_coreos/resources/multus-cni.conf
+++ b/configs/stage3_coreos/resources/multus-cni.conf
@@ -1,0 +1,15 @@
+{
+  "name": "multus-network",
+  "type": "multus",
+  "kubeconfig": "/etc/kubernetes/kubelet.conf",
+  "delegates": [
+    {
+      "type": "flannel",
+      "delegate": {
+        "hairpinMode": true,
+        "isDefaultGateway": false
+      },
+      "masterplugin": true
+    }
+  ]
+}


### PR DESCRIPTION
This change allows us to insert the multus-cni configuration file directly
into the CoreOS image, so it can be copied into the right configuration
folder on first boot, before kubelet tries to join the cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/91)
<!-- Reviewable:end -->
