### PR TITLE
Adds a forceAddress option for the flannel delegate in the multus config.

### DIFF
--- a/configs/stage3_coreos/resources/multus-cni.conf
+++ b/configs/stage3_coreos/resources/multus-cni.conf
@@ -7,7 +7,8 @@
       "type": "flannel",
       "delegate": {
         "hairpinMode": true,
-        "isDefaultGateway": false
+        "isDefaultGateway": false,
+        "forceAddress": true
       },
       "masterplugin": true
     }


### PR DESCRIPTION
…fig, which can hopefully help resolve k8s-support/issues/111

We [have an issue](https://github.com/m-lab/k8s-support/issues/111) that crops up on nodes where NDT pods fail to start due this CNI error:

```
Warning  FailedCreatePodSandBox  3m44s (x64 over 8m9s)  kubelet, mlab4.lhr05.measurement-lab.org  (combined from similar events): Failed create pod sandbox: rpc error: code = Unknown desc = failed to set up sandbox container "aec2a297def431ea4e8b4266c16e5c8bdf8225c766d467a9db894b56f8a40c3a" network for pod "ndt-5bqlc": NetworkPlugin cni failed to set up pod "ndt-5bqlc_default" network: Multus: Err in tearing down failed plugins: Multus: error in invoke Delegate add - "flannel": failed to set bridge addr: "cni0" already has an IP address different from 192.168.4.65/26
```

This PR adds a `forceAddress: true` configuration to the flannel delegate of the multus configs. This option is very poorly documented, but from what I can tell may cause this sort of error to go away.

```
[Plugin (bridge) specific parameters](https://www.dasblinkenlichten.com/understanding-cni-container-networking-interface/)
    forceAddress: Tells the plugin to allocate a new IP address if the previous value has changed.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/92)
<!-- Reviewable:end -->
