### PR TITLE
Updates CoreOS and k8s components to their latest stable versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@
 #    the target branch matches a supported deployment target.
 
 env:
-- COREOS_VERSION="1911.4.0"
+- COREOS_VERSION="2023.5.0"
 
 services:
 - docker

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -71,10 +71,10 @@ steps:
   env:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
-   - 'COREOS_VERSION=1911.4.0'
-   - 'K8S_VERSION=v1.12.3'
-   - 'CRI_VERSION=v1.12.0'
-   - 'CNI_VERSION=v0.7.1'
+   - 'COREOS_VERSION=2023.5.0'
+   - 'K8S_VERSION=v1.13.4'
+   - 'CRI_VERSION=v1.13.0'
+   - 'CNI_VERSION=v0.7.4'
 
 # stage3_mlxupdate images.
 # NOTE: all project cloudbuild service accounts must be granted READ access to

--- a/manual/manually_generate_images.sh
+++ b/manual/manually_generate_images.sh
@@ -3,7 +3,7 @@
 # A script to create ePoxy images manually.
 
 # Edit the following variable to suit your needs, most importantly PROJECT and NODE_REGEXP.
-COREOS_VERSION="1855.4.0"
+COREOS_VERSION="2023.5.0"
 PROJECT="mlab-staging"
 NODE_REGEXP="mlab4.(bru02|lax02|syd02)"
 GCS_BUCKET="gs://epoxy-${PROJECT}"

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -17,11 +17,11 @@ CUSTOM=${5:?Please provide the name for a customized initram image: $USAGE}
 # Default values that callers can override from the environment.
 #
 # Version of k8s services and cli tools.
-K8S_VERSION=${K8S_VERSION:-v1.12.3}
+K8S_VERSION=${K8S_VERSION:-v1.13.4}
 # Version of "container runtime interface". (Independent of K8S_VERSION)
-CRI_VERSION=${CRI_VERSION:-v1.12.0}
+CRI_VERSION=${CRI_VERSION:-v1.13.0}
 # Version of "container networking interface".
-CNI_VERSION=${CNI_VERSION:-v0.7.1}
+CNI_VERSION=${CNI_VERSION:-v0.7.4}
 
 SCRIPTDIR=$( dirname "${BASH_SOURCE[0]}" )
 


### PR DESCRIPTION
**NOTE**: It seems that we've got redundant version strings embedded in quite a few different files. If some are no loner needed/used, we should remove them. For all the ones we currently use we should see about consolidating them into a single file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/96)
<!-- Reviewable:end -->
