### PR TITLE
Fix build by adding linux-base to build.packages.

### DIFF
--- a/configs/stage3_mlxupdate/build.packages
+++ b/configs/stage3_mlxupdate/build.packages
@@ -3,3 +3,4 @@ make
 dkms
 linux-headers-generic
 linux-generic
+linux-base


### PR DESCRIPTION
This PR restores the Travis CI build for stage3_mlxupdate which was failing due to the lack of `linux-update-symlinks` (contained into the `linux-base` package).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/97)
<!-- Reviewable:end -->
