### PR TITLE
Updates the multus-cni plugin from v3.1 to v3.2.

### DIFF
--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -70,7 +70,7 @@ pushd $IMAGEDIR
 	pushd src/github.com/intel
 	   git clone https://github.com/intel/multus-cni.git
 	   pushd multus-cni
-	     git checkout v3.1
+	     git checkout v3.2
 	   popd
 	popd
   popd


### PR DESCRIPTION
I want this feature:

https://github.com/intel/multus-cni/commit/5871c8744a54228207d82ac0efc29da2577ce84a

It will help us simplify our configs a bit by allowing us to remove the whole `delegates[]` config from our default multus-cni config and instead allow us to simply define `clusterNetwork` and `defaultNetworks` options that point to our CRDs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/99)
<!-- Reviewable:end -->
