### PR TITLE
Sets up common state directory for IPAM plugin host-local used by flannel

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -72,9 +72,9 @@ steps:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
    - 'COREOS_VERSION=2023.5.0'
-   - 'K8S_VERSION=v1.13.4'
+   - 'K8S_VERSION=v1.13.5'
    - 'CRI_VERSION=v1.13.0'
-   - 'CNI_VERSION=v0.7.4'
+   - 'CNI_VERSION=v0.7.5'
 
 # stage3_mlxupdate images.
 # NOTE: all project cloudbuild service accounts must be granted READ access to

--- a/configs/stage3_coreos/resources/setup_after_boot.sh
+++ b/configs/stage3_coreos/resources/setup_after_boot.sh
@@ -9,5 +9,13 @@ exec 2> /var/log/setup_after_boot.log 1>&2
 # Stop on any failure.
 set -euxo pipefail
 
+# Create a state directory for the IPAM host-local plugin (which is the IPAM
+# plugin used by flannel). And create two symlinks to is named after the
+# names of our two flannel networks. This causes both flannel networks to use
+# a common state directory to avoid IP assignment conflics for pods.
+mkdir -p /var/lib/cni/networks/flannel
+ln -s flannel /var/lib/cni/networks/flannel-conf
+ln -s flannel /var/lib/cni/networks/flannel-experiment-conf
+
 echo "Running epoxy client"
 /usr/bin/epoxy_client -action epoxy.stage3

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -97,14 +97,6 @@ pushd $IMAGEDIR
     chmod 755 {kubeadm,kubelet,kubectl}
   popd
 
-  # Create a state directory for the IPAM host-local plugin (which is the IPAM
-  # plugin used by flannel). And create two symlinks to is named after the
-  # names of our two flannel networks. This causes both flannel networks to use
-  # a common state directory to avoid IP assignment conflics for pods.
-  mkdir -p squashfs-root/var/lib/cni/networks/flannel
-  ln -s flannel squashfs-root/var/lib/cni/networks/flannel-conf
-  ln -s flannel squashfs-root/var/lib/cni/networks/flannel-experiment-conf
-
   # Rebuild the squashfs and cpio image.
   mksquashfs squashfs-root initrd-contents/usr.squashfs \
       -noappend -always-use-fragments

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -17,11 +17,11 @@ CUSTOM=${5:?Please provide the name for a customized initram image: $USAGE}
 # Default values that callers can override from the environment.
 #
 # Version of k8s services and cli tools.
-K8S_VERSION=${K8S_VERSION:-v1.13.4}
+K8S_VERSION=${K8S_VERSION:-v1.13.5}
 # Version of "container runtime interface". (Independent of K8S_VERSION)
 CRI_VERSION=${CRI_VERSION:-v1.13.0}
 # Version of "container networking interface".
-CNI_VERSION=${CNI_VERSION:-v0.7.4}
+CNI_VERSION=${CNI_VERSION:-v0.7.5}
 
 SCRIPTDIR=$( dirname "${BASH_SOURCE[0]}" )
 
@@ -96,6 +96,14 @@ pushd $IMAGEDIR
     curl --location --remote-name-all https://storage.googleapis.com/kubernetes-release/release/"${K8S_VERSION}"/bin/linux/amd64/{kubeadm,kubelet,kubectl}
     chmod 755 {kubeadm,kubelet,kubectl}
   popd
+
+  # Create a state directory for the IPAM host-local plugin (which is the IPAM
+  # plugin used by flannel). And create two symlinks to is named after the
+  # names of our two flannel networks. This causes both flannel networks to use
+  # a common state directory to avoid IP assignment conflics for pods.
+  mkdir -p squashfs-root/var/lib/cni/networks/flannel
+  ln -s flannel squashfs-root/var/lib/cni/networks/flannel-conf
+  ln -s flannel squashfs-root/var/lib/cni/networks/flannel-experiment-conf
 
   # Rebuild the squashfs and cpio image.
   mksquashfs squashfs-root initrd-contents/usr.squashfs \


### PR DESCRIPTION
We define two flannel networks in our NetworkAttachmentDefinitions, one for experiment pods and one for non-experiment pods. This is necessary because on experiment pods we do not want the bridge interface to be the default gateway and instead want the ipvlan interface to be the gateway for experiment traffic. However, on non-experiment pods we do want the bridge interface to be to the default gateway. However, the outcome of this is that each network thinks it is unique, even though it is using a common subnet, and IP address conflicts start happening. 

This PR sets up a common state directory for both IPAM host-local networks to avoid IP address duplication/conflicts, since they both share a common state.

While we are at it we might as well update k8s components.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/100)
<!-- Reviewable:end -->
