### PR TITLE
c/s/r/cloud-config.yml: load tcp_bbr at boot

### DIFF
--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -2,7 +2,7 @@
 
 write_files:
 
-# Purpose: make sure TCP BBR is available for ndt7 et al.
+# Purpose: make sure TCP BBR is loaded for ndt7 et al.
 - content: tcp_bbr
   permissions: '0644'
   owner: root:root

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -3,10 +3,10 @@
 write_files:
 
 # Purpose: make sure TCP BBR is loaded for ndt7 et al.
-- content: tcp_bbr
-  permissions: '0644'
+- path: /etc/modules-load.d/bbr.conf
   owner: root:root
-  path: /etc/modules-load.d/bbr.conf
+  permissions: '0644'
+  content: tcp_bbr
 
 coreos:
   # TODO: during the image customization process, consider adding custom

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -1,5 +1,14 @@
 #cloud-config
 
+storage:
+  files:
+    # Purpose: make sure TCP BBR is available for ndt7 et al.
+    - path: /etc/modules-load.d/bbr.conf
+      filesystem: root
+      mode: 0644
+      contents:
+        inline: tcp_bbr
+
 coreos:
   # TODO: during the image customization process, consider adding custom
   # network handling units directly instead of this approach.

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -1,13 +1,12 @@
 #cloud-config
 
-storage:
-  files:
-    # Purpose: make sure TCP BBR is available for ndt7 et al.
-    - path: /etc/modules-load.d/bbr.conf
-      filesystem: root
-      mode: 0644
-      contents:
-        inline: tcp_bbr
+write_files:
+
+# Purpose: make sure TCP BBR is available for ndt7 et al.
+- content: tcp_bbr
+  permissions: '0644'
+  owner: root:root
+  path: /etc/modules-load.d/bbr.conf
 
 coreos:
   # TODO: during the image customization process, consider adding custom


### PR DESCRIPTION
This has been discussed with many at @m-lab, it seems this is
a solution to have support for BBR available for ndt7.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/103)
<!-- Reviewable:end -->
