### PR TITLE
Add systemd unit to run modprobe tcp_bbr.

### DIFF
--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -150,6 +150,16 @@ coreos:
         Type=oneshot
         ExecStart=/usr/share/oem/setup_after_boot.sh
 
+    - name: enable-bbr.service
+      command: start
+      enable: true
+      content: |
+        [Unit]
+        Description=Enable tcp_bbr module.
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/sbin/modprobe tcp_bbr
 
 # TODO: collect list of ssh keys from a metadata service during post-boot setup.
 ssh_authorized_keys:


### PR DESCRIPTION
This PR adds a systemd oneshot service to run `modprobe tcp_bbr` at boot time. It does not change the default CC algorithm on the node, but BBR is needed by ndt7 and might be needed by other experiments in future.

Tested on mlab4.lga0t.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/105)
<!-- Reviewable:end -->
