### PR TITLE
Add stage1 minimal build

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -102,6 +102,20 @@ function stage3_mlxupdate() {
   rm -rf ${builddir}
 }
 
+function stage1_minimal() {
+  local target=${TARGET:?Please specify a target configuration name}
+  local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
+  local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
+
+  umask 0022
+  echo 'Starting stage1_minimal build'
+  ${SOURCE_DIR}/setup_stage1_minimal.sh \
+      ${builddir} ${artifacts} ${SOURCE_DIR}/configs/${target} \
+      ${artifacts}/epoxy_client &> ${SOURCE_DIR}/stage1_minimal.log
+
+  rm -rf ${builddir}
+}
+
 function stage1_isos() {
   local target=${TARGET:?Please specify a target configuration name}
   local project=${PROJECT:?Please specify the PROJECT}
@@ -123,6 +137,9 @@ case "${TARGET}" in
       ;;
   stage1_bootstrapfs)
       stage1_bootstrapfs
+      ;;
+  stage1_minimal)
+      stage1_minimal
       ;;
   stage1_isos)
       stage1_isos

--- a/configs/stage1_minimal/build.packages
+++ b/configs/stage1_minimal/build.packages
@@ -1,0 +1,2 @@
+linux-generic
+linux-base

--- a/configs/stage1_minimal/build.packages
+++ b/configs/stage1_minimal/build.packages
@@ -1,2 +1,0 @@
-linux-generic
-linux-base

--- a/configs/stage1_minimal/extra.packages
+++ b/configs/stage1_minimal/extra.packages
@@ -10,3 +10,5 @@ wget
 curl
 vim
 openssh-server
+linux-generic
+linux-base

--- a/configs/stage1_minimal/extra.packages
+++ b/configs/stage1_minimal/extra.packages
@@ -1,0 +1,12 @@
+usbutils
+pciutils
+net-tools
+iproute2
+ca-certificates
+kexec-tools
+less
+systemd-sysv
+wget
+curl
+vim
+openssh-server

--- a/configs/stage1_minimal/fstab
+++ b/configs/stage1_minimal/fstab
@@ -1,0 +1,3 @@
+# fstab for base system
+proc           /proc        proc     nosuid,noexec,nodev 0     0
+sysfs          /sys         sysfs    nosuid,noexec,nodev 0     0

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+
+function get_cmdline() {
+  local key=$1
+  local result=$2
+  # Extract the boot parameter ${key}=
+  for field in $( cat /proc/cmdline ) ; do
+    if [[ "${key}" == "${field%%=*}" ]] ; then
+      result=${field##${key}=}
+      break
+    fi
+  done
+  echo $result
+}
+
+# TODO: epoxyclient should interpret this command line parameter instead.
+function setup_network() {
+  # Set a default local network configuration.
+  ipcfg=192.168.0.2::192.168.0.1:255.255.255.0:default-net:eth0::8.8.8.8:
+
+  ipv4=$( get_cmdline epoxy.ipv4 "192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4" )
+  hostname=$( get_cmdline epoxy.hostname "default-net" )
+  interface=$( get_cmdline epoxy.interface "eth0" )
+
+  count=1
+  # Note: while using a generic kernel, we must wait for the modules to load
+  # automatically before the network configuration commands will work.  This
+  # delay could be avoided by explicitly loading the modules here (fragile) or
+  # using a custom kernel that embeds the mellanox drivers.
+  until ifconfig ${interface} 2> /dev/null || [[ $count -gt 60 ]]; do
+      echo "Waiting 1 second for ${interface} to initialize.."
+      sleep 1
+      count=$(( $count + 1 ))
+  done
+
+  echo "Applying network configuration: $ipv4"
+  echo $ipv4 | tr ',' ' ' | (
+      read addr gateway _
+      echo ifconfig ${interface} ${addr}
+      echo route add default gw ${gateway}
+      echo hostname ${hostname}
+      ifconfig ${interface} ${addr}
+      route add default gw ${gateway}
+      hostname ${hostname}
+  )
+  ifconfig ${interface}
+}
+
+
+echo "Loading mlx modules"
+modprobe mlx4_en
+modprobe mlx5_core
+modprobe mlxfw
+
+
+echo "Configuring network..."
+setup_network
+
+
+echo "Downloading next stage from ePoxy"
+if grep epoxy.stage1 /proc/cmdline > /dev/null ; then
+  epoxy_client -action epoxy.stage1 -add-kargs
+else
+  echo "WARNING: no stage1 action found in /proc/cmdline"
+fi

--- a/configs/stage1_minimal/resolv.conf
+++ b/configs/stage1_minimal/resolv.conf
@@ -1,0 +1,2 @@
+nameserver 8.8.8.8
+nameserver 8.8.4.4

--- a/setup_stage1_minimal.sh
+++ b/setup_stage1_minimal.sh
@@ -1,0 +1,190 @@
+#!/bin/bash
+#
+# setup_stage1_minimal sh builds a minimal filesystem based on the ubuntu
+# xenial OS, that includes epoxy_client and configuration suitable for stage1.
+# With this image it is possible to create UEFI stage1 boot media for USB or CD.
+#
+# Example:
+#   ./setup_stage1_minimal.sh /build /workspace/output configs/stage1_minimal \
+#       epoxy_client
+
+set -x
+set -e
+set -u
+
+BUILD_DIR=${1:?Name of build directory}
+BUILD_DIR=$( realpath $BUILD_DIR )
+
+OUTPUT_DIR=${2:?Name of directory to copy output files}
+OUTPUT_DIR=$( realpath $OUTPUT_DIR )
+
+CONFIG_DIR=${3:?Name of directory containing configuration files}
+CONFIG_DIR=$( realpath $CONFIG_DIR )
+
+EPOXY_CLIENT=${4:?Name of epoxy client binary to include in output initram}
+EPOXY_CLIENT=$( realpath $EPOXY_CLIENT )
+
+CONFIG_NAME=$( basename $CONFIG_DIR )
+BOOTSTRAP=${BUILD_DIR}/initramfs_${CONFIG_NAME}
+OUTPUT_KERNEL=${BUILD_DIR}/vmlinuz_${CONFIG_NAME}
+OUTPUT_INITRAM=${BOOTSTRAP}.cpio.gz
+
+##############################################################################
+# Functions
+##############################################################################
+
+function mount_proc_and_sys() {
+    local bootstrap=$1
+    mount -t proc proc $bootstrap/proc
+    mount -t sysfs sysfs $bootstrap/sys
+}
+
+
+function umount_proc_and_sys() {
+    local bootstrap=$1
+    umount $bootstrap/proc
+    umount $bootstrap/sys
+}
+
+##############################################################################
+# Main script
+##############################################################################
+
+# Note: this step cannot be performed by docker build because it requires
+# --privileged mode to mount /proc.
+if ! test -f $BOOTSTRAP/build.date ; then
+    mkdir -p $BOOTSTRAP
+    rm -rf $BOOTSTRAP/dev
+    # Disable interactive prompt from grub-pc or other packages.
+    export DEBIAN_FRONTEND=noninteractive
+    PACKAGES=`cat ${CONFIG_DIR}/extra.packages ${CONFIG_DIR}/build.packages \
+      | xargs echo | tr ' ' ',' `
+    debootstrap --variant=minbase --include "${PACKAGES}" \
+      --arch amd64 xenial $BOOTSTRAP
+    date --iso-8601=seconds --utc > $BOOTSTRAP/build.date
+fi
+
+# Unmount the proc & sys dirs if we encounter a problem within the following
+# block.
+trap "umount_proc_and_sys $BOOTSTRAP" EXIT
+
+# Install extra packages and
+mount_proc_and_sys $BOOTSTRAP
+
+    # Add extra apt sources to install latest kernel image and headers.
+    # TODO: only append the source once.
+    LINE='deb http://archive.ubuntu.com/ubuntu/ xenial-updates universe main multiuniverse'
+    if ! grep -q "$LINE" $BOOTSTRAP/etc/apt/sources.list ; then
+        chroot $BOOTSTRAP bash -c "echo '$LINE' >> /etc/apt/sources.list"
+    fi
+    chroot $BOOTSTRAP apt-get update --fix-missing
+
+    # Figure out the newest installed linux kernel version.
+    # TODO: is there a better way?
+    pushd $BOOTSTRAP/boot
+        KERNEL_VERSION=`ls vmlinuz-*`
+        KERNEL_VERSION=${KERNEL_VERSION##vmlinuz-}
+    popd
+
+    # Remove unnecessary packages to save space.
+    for i in 1 2 ; do
+    # TODO: order seems to matter, so run twice to get everything.
+    chroot $BOOTSTRAP apt-get autoremove -y \
+        linux-headers-generic \
+        linux-generic \
+        linux-headers-${KERNEL_VERSION} \
+        linux-headers-${KERNEL_VERSION%%-generic} \
+        linux-firmware \
+        python3 \
+        grub-pc \
+        grub-common \
+        grub2-common \
+        grub-gfxpayload-lists \
+        grub-pc-bin
+    done
+
+    chroot $BOOTSTRAP apt-get clean -y
+
+    # Copy kernel image to output directory before removing it.
+    cp $BOOTSTRAP/boot/vmlinuz-${KERNEL_VERSION} ${OUTPUT_KERNEL}
+
+    # Backup the kernel modules.
+    cp -ar $BOOTSTRAP/lib/modules/${KERNEL_VERSION} \
+        $BOOTSTRAP/lib/modules/${KERNEL_VERSION}.orig
+
+    # Frees about 50MB
+    chroot $BOOTSTRAP apt-get autoclean
+
+    # Restore the kernel modules.
+    rm -rf $BOOTSTRAP/lib/modules/${KERNEL_VERSION}
+    mv $BOOTSTRAP/lib/modules/${KERNEL_VERSION}.orig \
+        $BOOTSTRAP/lib/modules/${KERNEL_VERSION}
+
+    # Free up a little more space.
+    rm -f $BOOTSTRAP/boot/vmlinuz*
+    rm -f $BOOTSTRAP/boot/initrd*
+
+umount_proc_and_sys $BOOTSTRAP
+trap '' EXIT
+
+
+################################################################################
+# Init
+################################################################################
+# Kernel panics unless /init is defined. Use systemd for init.
+ln --force --symbolic sbin/init $BOOTSTRAP/init
+cp $CONFIG_DIR/fstab $BOOTSTRAP/etc/fstab
+
+# Enable simple rc.local script for post-setup processing.
+# rc.local.service runs after networking.service
+cp $CONFIG_DIR/rc.local $BOOTSTRAP/etc/rc.local
+chroot $BOOTSTRAP systemctl enable rc.local.service
+
+################################################################################
+# Network
+################################################################################
+# Enable static resolv.conf
+# TODO: use systemd for network configuration entirely.
+rm -f $BOOTSTRAP/etc/resolv.conf
+cp $CONFIG_DIR/resolv.conf $BOOTSTRAP/etc/resolv.conf
+# If permissions are incorrect, apt-get will fail to read contents.
+chmod 644 $BOOTSTRAP/etc/resolv.conf
+
+# Set a default root passwd.
+# TODO: disable root login except by ssh?
+chroot $BOOTSTRAP bash -c 'echo -e "demo\ndemo\n" | passwd'
+
+################################################################################
+# SSH
+################################################################################
+# Disable root login via ssh.
+if ! grep -q -E '^PermitRootLogin .*' $BOOTSTRAP/etc/ssh/sshd_config ; then
+    sed -i -e 's/^PermitRootLogin .*/PermitRootLogin prohibit-password/g' \
+        $BOOTSTRAP/etc/ssh/sshd_config
+fi
+
+# Enable sshd.
+chroot $BOOTSTRAP systemctl enable ssh.service
+
+# TODO: get ssh keys from some external source.
+# TODO: investigate ssh-import-id as an alternative here, or a copy from GCS.
+# echo "Adding SSH authorized keys"
+# mkdir -p $BOOTSTRAP/root/.ssh
+# cp $CONFIG_DIR/authorized_keys  $BOOTSTRAP/root/.ssh/authorized_keys
+# chown root:root $BOOTSTRAP/root/.ssh/authorized_keys
+# chmod 700 $BOOTSTRAP/root/
+
+################################################################################
+# Add epoxy client to initramfs
+################################################################################
+install -D -m 755 $EPOXY_CLIENT $BOOTSTRAP/usr/bin/epoxy_client
+
+# Build the initramfs from the bootstrap filesystem.
+pushd $BOOTSTRAP
+    find . | cpio -H newc -o | gzip -c > ${OUTPUT_INITRAM}
+popd
+# Copy file to output with all read permissions.
+install -m 0644 ${OUTPUT_KERNEL} ${OUTPUT_INITRAM} ${OUTPUT_DIR}
+
+echo "Success: ${OUTPUT_KERNEL}"
+echo "Success: ${OUTPUT_INITRAM}"

--- a/setup_stage1_minimal.sh
+++ b/setup_stage1_minimal.sh
@@ -149,8 +149,8 @@ chroot $BOOTSTRAP bash -c 'echo -e "demo\ndemo\n" | passwd'
 # SSH
 ################################################################################
 # Disable root login via ssh.
-if ! grep -q -E '^PermitRootLogin .*' $BOOTSTRAP/etc/ssh/sshd_config ; then
-    sed -i -e 's/^PermitRootLogin .*/PermitRootLogin prohibit-password/g' \
+if ! grep -q -E '^PermitRootLogin prohibit-password' $BOOTSTRAP/etc/ssh/sshd_config ; then
+    sed -i -e 's/.*PermitRootLogin .*/PermitRootLogin prohibit-password/g' \
         $BOOTSTRAP/etc/ssh/sshd_config
 fi
 

--- a/setup_stage1_minimal.sh
+++ b/setup_stage1_minimal.sh
@@ -90,9 +90,8 @@ mount_proc_and_sys $BOOTSTRAP
     popd
 
     # Remove unnecessary packages to save space.
-    for i in 1 2 ; do
-    # TODO: order seems to matter, so run twice to get everything.
-    chroot $BOOTSTRAP apt-get autoremove -y \
+
+    chroot $BOOTSTRAP apt-get remove -y \
         linux-headers-generic \
         linux-generic \
         linux-headers-${KERNEL_VERSION} \
@@ -104,8 +103,8 @@ mount_proc_and_sys $BOOTSTRAP
         grub2-common \
         grub-gfxpayload-lists \
         grub-pc-bin
-    done
 
+    chroot $BOOTSTRAP apt-get autoremove -y
     chroot $BOOTSTRAP apt-get clean -y
 
     # Copy kernel image to output directory before removing it.


### PR DESCRIPTION
This change adds a new build target, stage1_minimal. This creates a minimal initramfs based on Ubuntu xenial. The content of the image is simlar to the stage3_mlxupdate - however the intention of this image is for stage1 USB images.

In time, this image may also be useful for debugging systems.

The network setup logic in rc.local is identical to that in configs/stage3_mlxupdate. The only difference in that file is to the call to epoxy_client. There are opportunities to unify this in the future.

As well, some of the high level logic in setup_stage1_minimal.sh is shared with setup_stage3_mlxupdate.sh just without the extra MLX package installation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/109)
<!-- Reviewable:end -->
