### PR TITLE
Add support for building stage1_usb images from stage1_minimal kernel & initramfs

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -131,6 +131,21 @@ function stage1_isos() {
   return
 }
 
+function stage1_usbs() {
+  local target=${TARGET:?Please specify a target configuration name}
+  local project=${PROJECT:?Please specify the PROJECT}
+  local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
+  local regex_name="REGEXP_${PROJECT//-/_}"
+
+  local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
+
+  ${SOURCE_DIR}/setup_stage1_usbs.sh "${project}" "${builddir}" "${artifacts}" \
+      "${SOURCE_DIR}/configs/${target}" "${!regex_name}"
+
+  rm -rf "${builddir}"
+  return
+}
+
 case "${TARGET}" in
   stage1_mlxrom)
       stage1_mlxrom
@@ -143,6 +158,9 @@ case "${TARGET}" in
       ;;
   stage1_isos)
       stage1_isos
+      ;;
+  stage1_usbs)
+      stage1_usbs
       ;;
   stage2)
       stage2

--- a/configs/stage1_usbs/create-stage1-usb-template.sh
+++ b/configs/stage1_usbs/create-stage1-usb-template.sh
@@ -1,0 +1,71 @@
+#!/bin/bash
+#
+# create-stage1-usb-template.sh is a template for generating shell scripts to
+# create a bootable stage1 USB image from a suitable stage1 kernel.
+#
+# After template values are filled in, the resulting script constructs a kernel
+# command line with epoxy network configuration and stage1 URL and finally
+# generates an USB image with the stage2_vmlinuz image and the construct kernel
+# cmdline.
+
+set -x
+
+USAGE="$0 <sourcedir> <imagedir> <outputdir>"
+SOURCE_DIR=${1:?Please provide the source directory root: $USAGE}
+IMAGE_DIR=${2:?Error: specify input vmlinuz: $USAGE}
+OUTPUT_DIR=${3:?Error: specify directory for output USB: $USAGE}
+
+if [[ "{{netmask}}" != "255.255.255.192" ]] ; then
+  echo 'Error: Sorry, unsupported netmask: {{netmask}}'
+  exit 1
+fi
+mask=26
+
+if [[ ! -f "${IMAGE_DIR}/stage2_vmlinuz" ]] ; then
+    echo 'Error: vmlinuz images not found!'
+    echo "Expected: stage2_vmlinuz"
+    exit 1
+fi
+
+# ARGS are kernel command line parameters included in the syslinux.cfg. During
+# boot, parameters prefixed with "epoxy." are interpreted by the epoxy-client or
+# other epoxy related network configuration scripts. All other parameters are
+# interpreted by the kernel itself.
+#
+# Disable interface naming by the kernel. Preserves the use of `eth0`, etc.
+ARGS="net.ifnames=0 "
+
+# ePoxy server & project.
+ARGS+="epoxy.project={{project}} "
+
+# TODO: Legacy epoxy.ip= format. Remove once canonical form is supported.
+ARGS+="epoxy.ip={{ip}}::{{gateway}}:255.255.255.192:{{hostname}}:eth0:false:{{dns1}}:8.8.4.4 "
+
+# Canonical epoxy network configuration.
+ARGS+="epoxy.hostname={{hostname}} "
+ARGS+="epoxy.interface=eth0 "
+ARGS+="epoxy.ipv4={{ip}}/${mask},{{gateway}},{{dns1}},8.8.4.4 "
+
+if [[ "{{ipv6_enabled}}" == "true" ]] ; then
+  ARGS+="epoxy.ipv6={{ipv6_address}}/64,{{ipv6_gateway}},{{ipv6_dns1}},{{ipv6_dns2}} "
+else
+  ARGS+="epoxy.ipv6= "
+fi
+
+# ePoxy stage1 URL.
+ARGS+="epoxy.stage1=https://epoxy-boot-api.{{project}}.measurementlab.net/v1/boot/{{hostname}}/stage1.json"
+
+
+# If using debootstick filesystem.
+#       --config-hostname HOSTNAME
+#       --config-kernel-bootargs BOOTARGS
+
+# If using stage2 vmlinuz kernel.
+#${SOURCE_DIR}/simpleusb -x "$ARGS" "${IMAGE_DIR}/stage2_vmlinuz" \
+#    ${OUTPUT_DIR}/{{hostname}}_stage1.usb
+
+# If using stage3_mlxupdate images.
+${SOURCE_DIR}/simpleusb -x "$ARGS" \
+    -i "${IMAGE_DIR}"/initramfs_stage1_minimal.cpio.gz \
+    "${IMAGE_DIR}/vmlinuz_stage1_minimal" \
+    ${OUTPUT_DIR}/{{hostname}}_stage1.usb

--- a/configs/stage1_usbs/create-stage1-usb-template.sh
+++ b/configs/stage1_usbs/create-stage1-usb-template.sh
@@ -60,7 +60,7 @@ ARGS+="epoxy.stage1=https://epoxy-boot-api.{{project}}.measurementlab.net/v1/boo
 #    ${OUTPUT_DIR}/{{hostname}}_stage1.usb
 
 # Generate stage1 USB image.
-${SOURCE_DIR}/simpleusb -x "$ARGS" \
+"${SOURCE_DIR}"/simpleusb -x "$ARGS" \
     -i "${IMAGE_DIR}"/initramfs_stage1_minimal.cpio.gz \
-    "${IMAGE_DIR}/vmlinuz_stage1_minimal" \
-    ${OUTPUT_DIR}/{{hostname}}_stage1.fat16.gpt.img
+    "${IMAGE_DIR}"/vmlinuz_stage1_minimal \
+    "${OUTPUT_DIR}"/{{hostname}}_stage1.fat16.gpt.img

--- a/configs/stage1_usbs/create-stage1-usb-template.sh
+++ b/configs/stage1_usbs/create-stage1-usb-template.sh
@@ -5,8 +5,7 @@
 #
 # After template values are filled in, the resulting script constructs a kernel
 # command line with epoxy network configuration and stage1 URL and finally
-# generates an USB image with the stage2_vmlinuz image and the construct kernel
-# cmdline.
+# generates a USB image with the stage1_minimal image.
 
 set -x
 
@@ -21,9 +20,9 @@ if [[ "{{netmask}}" != "255.255.255.192" ]] ; then
 fi
 mask=26
 
-if [[ ! -f "${IMAGE_DIR}/stage2_vmlinuz" ]] ; then
+if [[ ! -f "${IMAGE_DIR}/vmlinuz_stage1_minimal" ]] ; then
     echo 'Error: vmlinuz images not found!'
-    echo "Expected: stage2_vmlinuz"
+    echo "Expected: vmlinuz_stage1_minimal"
     exit 1
 fi
 
@@ -56,16 +55,12 @@ fi
 ARGS+="epoxy.stage1=https://epoxy-boot-api.{{project}}.measurementlab.net/v1/boot/{{hostname}}/stage1.json"
 
 
-# If using debootstick filesystem.
-#       --config-hostname HOSTNAME
-#       --config-kernel-bootargs BOOTARGS
-
-# If using stage2 vmlinuz kernel.
-#${SOURCE_DIR}/simpleusb -x "$ARGS" "${IMAGE_DIR}/stage2_vmlinuz" \
+# TODO: update to use stage2 kernels when they support UEFI boot fully.
+# ${SOURCE_DIR}/simpleusb -x "$ARGS" "${IMAGE_DIR}/stage2_vmlinuz" \
 #    ${OUTPUT_DIR}/{{hostname}}_stage1.usb
 
-# If using stage3_mlxupdate images.
+# Generate stage1 USB image.
 ${SOURCE_DIR}/simpleusb -x "$ARGS" \
     -i "${IMAGE_DIR}"/initramfs_stage1_minimal.cpio.gz \
     "${IMAGE_DIR}/vmlinuz_stage1_minimal" \
-    ${OUTPUT_DIR}/{{hostname}}_stage1.usb
+    ${OUTPUT_DIR}/{{hostname}}_stage1.fat16.gpt.img

--- a/setup_stage1_usbs.sh
+++ b/setup_stage1_usbs.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#
+# setup_stage1_usbs.sh generates per-machine USB images.
+#
+# setup_stage1_usbs.sh should only be run after setup_stage2.sh has run
+# successfully and the stage2_vmlinuz kernel is available.
+
+SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
+
+set -e
+
+USAGE="$0 <project> <builddir> <outputdir> <configdir> <hostname-pattern>"
+PROJECT=${1:?Please provide the GCP Project: $USAGE}
+BUILD_DIR=${2:?Please specify a build directory: $USAGE}
+OUTPUT_DIR=${3:?Please provide an output directory: $USAGE}
+CONFIG_DIR=${4:?Please specify a config directory: $USAGE}
+HOSTNAMES=${5:?Please specify a hostname pattern: $USAGE}
+
+# Report all commands to log file (set -x writes to stderr).
+set -xuo pipefail
+
+# Use mlabconfig to fill in the template for every machine matching the given
+# HOSTNAMES pattern.
+pushd ${BUILD_DIR}
+  test -d operator || git clone https://github.com/m-lab/operator
+  pushd operator/plsync
+    mkdir -p ${OUTPUT_DIR}/scripts
+    ./mlabconfig.py --format=server-network-config \
+        --select "${HOSTNAMES}" \
+        --label "project=${PROJECT}" \
+        --template_input "${CONFIG_DIR}/create-stage1-usb-template.sh" \
+        --template_output "${BUILD_DIR}/create-stage1-usb-{{hostname}}.sh"
+  popd
+popd
+
+# Run each per-machine build script.
+for create_usb_script in `ls ${BUILD_DIR}/create-stage1-usb-*.sh` ; do
+  echo $create_usb_script
+  chmod 755 $create_usb_script
+  mkdir -p ${OUTPUT_DIR}/stage1_usbs
+  $create_usb_script ${SOURCE_DIR} ${OUTPUT_DIR} ${OUTPUT_DIR}/stage1_usbs
+done

--- a/setup_stage1_usbs.sh
+++ b/setup_stage1_usbs.sh
@@ -5,7 +5,8 @@
 # setup_stage1_usbs.sh should only be run after setup_stage2.sh has run
 # successfully and the stage2_vmlinuz kernel is available.
 
-SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
+SOURCE_DIR=$( dirname "${BASH_SOURCE[0]}" )
+SOURCE_DIR=$( realpath "${SOURCE_DIR}" )
 
 set -e
 
@@ -21,10 +22,10 @@ set -xuo pipefail
 
 # Use mlabconfig to fill in the template for every machine matching the given
 # HOSTNAMES pattern.
-pushd ${BUILD_DIR}
+pushd "${BUILD_DIR}"
   test -d operator || git clone https://github.com/m-lab/operator
   pushd operator/plsync
-    mkdir -p ${OUTPUT_DIR}/scripts
+    mkdir -p "${OUTPUT_DIR}/scripts"
     ./mlabconfig.py --format=server-network-config \
         --select "${HOSTNAMES}" \
         --label "project=${PROJECT}" \
@@ -34,9 +35,9 @@ pushd ${BUILD_DIR}
 popd
 
 # Run each per-machine build script.
-for create_usb_script in `ls ${BUILD_DIR}/create-stage1-usb-*.sh` ; do
-  echo $create_usb_script
-  chmod 755 $create_usb_script
-  mkdir -p ${OUTPUT_DIR}/stage1_usbs
-  $create_usb_script ${SOURCE_DIR} ${OUTPUT_DIR} ${OUTPUT_DIR}/stage1_usbs
+for create_usb_script in ${BUILD_DIR}/create-stage1-usb-*.sh ; do
+  echo "${create_usb_script}"
+  chmod 755 "${create_usb_script}"
+  mkdir -p "${OUTPUT_DIR}/stage1_usbs"
+  ${create_usb_script} "${SOURCE_DIR}" "${OUTPUT_DIR}" "${OUTPUT_DIR}/stage1_usbs"
 done


### PR DESCRIPTION
This change adds support for turning the stage1_minimal images into UEFI-capable boot images for USB media.

This change adds a new build target to builder.sh for stage1_usbs. This works like stage1_isos, except (for now) it uses the stage1_minimal images instead of stage2 kernels. This is because I'm having difficulty getting complete efi support into the stage2 kernel.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/110)
<!-- Reviewable:end -->
