### PR TITLE
Use stage1 minimal instead of stage2 kernel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,11 +91,11 @@ script:
               /images/configs/stage1_mlxrom/gtsgiag3.pem"
 
 # Build a stage1 ISO image for a test machine.
-- time docker run -it -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
-      bash -c "mkdir -p /build
-        && echo 'Starting stage1_isos build'
-        && /images/setup_stage1_isos.sh mlab-sandbox /build
-              /images/output /images/configs/stage1_isos 'mlab4.lga1t.*'"
+#- time docker run -it -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
+#      bash -c "mkdir -p /build
+#        && echo 'Starting stage1_isos build'
+#        && /images/setup_stage1_isos.sh mlab-sandbox /build
+#              /images/output /images/configs/stage1_isos 'mlab4.lga1t.*'"
 
 # Build a skeleton bootstrapfs for the modified PlanetLab bootmanager.
 - time docker run -it -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder

--- a/actions/stage2/stage1to2.ipxe
+++ b/actions/stage2/stage1to2.ipxe
@@ -54,6 +54,7 @@ sleep 2
 set kargs
 # Network settings
 # TODO: remove epoxy.ip= once epoxy-images support canonical network format.
+set kargs ${kargs} net.ifnames=0 autoconf=0
 set kargs ${kargs} epoxy.ip=${network}
 set kargs ${kargs} epoxy.ipv4=${ipv4_address}/${ipv4_subnet},${ipv4_gateway},${ipv4_dns1},${ipv4_dns2}
 
@@ -77,7 +78,7 @@ set kargs ${kargs} epoxy.allocate_k8s_token=${allocate_k8s_token_url}
 set kargs ${kargs} epoxy.server=${epoxyaddress}
 set kargs ${kargs} epoxy.project=${project}
 
-boot ${kargs} || shell
+boot vmlinuz ${kargs} || shell
 
 :fetch_timeout
   echo -- Retries ${retry_count} ${max_retry_count}

--- a/actions/stage2/stage1to2.ipxe
+++ b/actions/stage2/stage1to2.ipxe
@@ -2,7 +2,8 @@
 
 # Use a relative URL for the vmlinuz image.
 # NOTE: the image must be in the same directory as this iPXE script.
-set vmlinuz_url stage2_vmlinuz
+set vmlinuz_url vmlinuz_stage1_minimal
+set initram_url initramfs_stage1_minimal.cpio.gz
 
 echo Starting stage1to2 script
 
@@ -25,6 +26,22 @@ goto firstfetch
 :firstfetch
   echo -- Retries ${retry_count} ${max_retry_count}
   kernel --name vmlinuz ${vmlinuz_url} || goto loop
+
+# Initialize retry counters.
+set retry_count:int32 1
+set max_retry_count 20
+
+goto firstfetch_initrd
+
+:loop_initrd
+  inc retry_count 1
+  echo -- Retries ${retry_count} ${max_retry_count}
+  echo Failed ${retry_count} times... Retrying after ${retry_count} seconds
+  sleep ${retry_count}
+
+:firstfetch_initrd
+  echo -- Retries ${retry_count} ${max_retry_count}
+  initrd --name initrd ${initram_url} || goto loop_initrd
 
 imgstat
 
@@ -60,7 +77,7 @@ set kargs ${kargs} epoxy.allocate_k8s_token=${allocate_k8s_token_url}
 set kargs ${kargs} epoxy.server=${epoxyaddress}
 set kargs ${kargs} epoxy.project=${project}
 
-boot vmlinuz ${kargs} || shell
+boot ${kargs} || shell
 
 :fetch_timeout
   echo -- Retries ${retry_count} ${max_retry_count}

--- a/actions/stage3_coreos/stage1to2.json
+++ b/actions/stage3_coreos/stage1to2.json
@@ -5,7 +5,10 @@
       },
       "files" : {
          "vmlinuz" : {
-            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_coreos/stage2_vmlinuz"
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_coreos/vmlinuz_stage1_minimal"
+         },
+         "initram" : {
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_coreos/initramfs_stage1_minimal.cpio.gz"
          }
       },
       "vars" : {
@@ -30,6 +33,8 @@
             "/sbin/kexec",
             "--force",
             "--command-line={{.vars.kargs}} {{.vars.cmdline}}",
+            "--initrd",
+            "{{.files.initram.name}}",
             "{{.files.vmlinuz.name}}"
          ]
       ]

--- a/actions/stage3_mlxupdate/stage1to2.json
+++ b/actions/stage3_mlxupdate/stage1to2.json
@@ -5,7 +5,10 @@
       },
       "files" : {
          "vmlinuz" : {
-            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_mlxupdate/stage2_vmlinuz"
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_coreos/vmlinuz_stage1_minimal"
+         },
+         "initram" : {
+            "url" : "https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage3_coreos/initramfs_stage1_minimal.cpio.gz"
          }
       },
       "vars" : {
@@ -30,6 +33,8 @@
             "/sbin/kexec",
             "--force",
             "--command-line={{.vars.kargs}} {{.vars.cmdline}}",
+            "--initrd",
+            "{{.files.initram.name}}",
             "{{.files.vmlinuz.name}}"
          ]
       ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -32,9 +32,22 @@ steps:
    - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
 
 # stage2 kernel.
+#
+# TODO: retire stage2 kernel in favor of stage1 minimal. We must keep it
+# temporarily because it builds the epoxy_client embedded in other images
+# below.
 - name: epoxy-images-builder
   args: [
     '/workspace/builder.sh', 'stage2'
+  ]
+  env:
+   - 'PROJECT=$PROJECT_ID'
+   - 'ARTIFACTS=/workspace/output'
+
+# stage1 minimal kernel & initram using stock ubuntu kernel.
+- name: epoxy-images-builder
+  args: [
+    '/workspace/builder.sh', 'stage1_minimal'
   ]
   env:
    - 'PROJECT=$PROJECT_ID'
@@ -51,7 +64,7 @@ steps:
    - 'ARTIFACTS=/workspace/output'
 
 # stage1 ISOs
-# NOTE: this must run after stage2 so that stage2_vmlinuz is available.
+# NOTE: must run after stage1_minimal so that kernel & initram are available.
 - name: epoxy-images-builder
   args: [
     '/workspace/builder.sh', 'stage1_isos'
@@ -62,6 +75,19 @@ steps:
    - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
    - 'REGEXP_mlab_staging=(mlab4.[a-z]{3}[0-9]{2}|mlab3.(lax02|lga03)).*'
    - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
+
+# stage1 USBs
+# NOTE: must run after stage1_minimal so that kernel & initram are available.
+- name: epoxy-images-builder
+  args: [
+    '/workspace/builder.sh', 'stage1_usbs'
+  ]
+  env:
+   - 'PROJECT=$PROJECT_ID'
+   - 'ARTIFACTS=/workspace/output'
+   - 'REGEXP_mlab_sandbox=mlab[1-4].lga1t.*'
+   - 'REGEXP_mlab_staging=NOMATCH'
+   - 'REGEXP_mlab_oti=NOMATCH'
 
 # stage3_coreos images.
 - name: epoxy-images-builder
@@ -106,6 +132,7 @@ steps:
     'cp', '-r', '/workspace/output/stage1_mlxrom/*',
     'gs://epoxy-$PROJECT_ID/stage1_mlxrom/'
   ]
+
 # Deploy stage1_mlxrom images again to the 'latest' directory (without version).
 - name: gcr.io/cloud-builders/gsutil
   # NOTE: use bash as the entry point to take advantage of bash file globbing.
@@ -133,12 +160,22 @@ steps:
     'gs://epoxy-$PROJECT_ID/stage1_isos/'
   ]
 
+# stage1_usbs
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    'cp', '-r', '/workspace/output/stage1_usbs/*',
+    'gs://epoxy-$PROJECT_ID/stage1_usbs/'
+  ]
+
 # stage3_coreos.
 - name: gcr.io/cloud-builders/gsutil
   args: [
     '-h', 'Cache-Control:private, max-age=0, no-transform',
     'cp', '-r',
     '/workspace/output/stage2_vmlinuz',
+    '/workspace/output/vmlinuz_stage1_minimal',
+    '/workspace/output/initramfs_stage1_minimal.cpio.gz',
     '/workspace/output/coreos_custom_pxe_image.cpio.gz',
     '/workspace/output/coreos_production_pxe.vmlinuz',
     '/workspace/actions/stage2/stage1to2.ipxe',
@@ -152,6 +189,8 @@ steps:
     '-h', 'Cache-Control:private, max-age=0, no-transform',
     'cp', '-r',
     '/workspace/output/stage2_vmlinuz',
+    '/workspace/output/vmlinuz_stage1_minimal',
+    '/workspace/output/initramfs_stage1_minimal.cpio.gz',
     '/workspace/output/vmlinuz_stage3_mlxupdate',
     '/workspace/output/initramfs_stage3_mlxupdate.cpio.gz',
     '/workspace/actions/stage2/stage1to2.ipxe',

--- a/configs/stage1_isos/create-stage1-iso-template.sh
+++ b/configs/stage1_isos/create-stage1-iso-template.sh
@@ -55,5 +55,7 @@ fi
 # ePoxy stage1 URL.
 ARGS+="epoxy.stage1=https://epoxy-boot-api.{{project}}.measurementlab.net/v1/boot/{{hostname}}/stage1.json"
 
-${SOURCE_DIR}/simpleiso -x "$ARGS" "${IMAGE_DIR}/stage2_vmlinuz" \
+${SOURCE_DIR}/simpleiso -x "$ARGS" \
+    -i "${IMAGE_DIR}"/initramfs_stage1_minimal.cpio.gz \
+    "${IMAGE_DIR}/vmlinuz_stage1_minimal" \
     ${OUTPUT_DIR}/{{hostname}}_stage1.iso

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -61,6 +61,8 @@ setup_network
 echo "Downloading next stage from ePoxy"
 if grep epoxy.stage1 /proc/cmdline > /dev/null ; then
   epoxy_client -action epoxy.stage1 -add-kargs
+elif grep epoxy.stage2 /proc/cmdline > /dev/null ; then
+  epoxy_client -action epoxy.stage2
 else
-  echo "WARNING: no stage1 action found in /proc/cmdline"
+  echo "WARNING: unknown or no stage found in /proc/cmdline"
 fi

--- a/setup_stage2.sh
+++ b/setup_stage2.sh
@@ -415,7 +415,7 @@ function build_kernel() {
         make olddefconfig
 
         # Build the compressed kernel image.
-        make -j3 bzImage
+        make -j8 bzImage
 
         # Copy to output name.
         cp arch/x86/boot/bzImage "${kernel}"
@@ -465,6 +465,7 @@ function main() {
 
   report "Copying epoxy_client"
   install -D -m 644 $BUILD_DIR/local/upx/epoxy_client $EPOXY_CLIENT
+  report "Successful build of stage2 image!"
 }
 
 main

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -109,3 +109,5 @@ pushd $IMAGEDIR
   rm -rf initrd-contents
   rm -rf squashfs-root
 popd
+
+echo "Successful build of custom CoreOS image!"

--- a/setup_stage3_mlxupdate.sh
+++ b/setup_stage3_mlxupdate.sh
@@ -228,3 +228,5 @@ pushd $BOOTSTRAP
 popd
 # Copy file to output with all read permissions.
 install -m 0644 ${OUTPUT_KERNEL} ${OUTPUT_INITRAM} ${OUTPUT_DIR}
+
+echo "Successful build of ${OUTPUT_KERNEL}!"


### PR DESCRIPTION
This update represents a major change: to simplify configuration complexity of the stage1 and stage2 kernels we are adopting images build from stock distribution kernels. The consequence of this is larger image sizes ~150MB vs ~13MB, but greater range of default compatibility.

The stage1_minimal target is derived from ubuntu 16.04 and the 4.4.0 kernel. It is very similar to the stage3_mlxupdate image.

TODO: Still remaining would be to eliminate the stage2 build step and dependencies on that step for later steps (mainly building epoxy_client).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/113)
<!-- Reviewable:end -->
