### PR TITLE
Provide patterns so gsutil cp works unconditionally

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -86,8 +86,8 @@ steps:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
    - 'REGEXP_mlab_sandbox=mlab[1-4].lga1t.*'
-   - 'REGEXP_mlab_staging=mlab4.hnd.*'
-   - 'REGEXP_mlab_oti=mlab[1-3].hnd.*'
+   - 'REGEXP_mlab_staging=mlab4.hnd01.*'
+   - 'REGEXP_mlab_oti=mlab[1-3].hnd01.*'
 
 # stage3_coreos images.
 - name: epoxy-images-builder

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -86,8 +86,8 @@ steps:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
    - 'REGEXP_mlab_sandbox=mlab[1-4].lga1t.*'
-   - 'REGEXP_mlab_staging=NOMATCH'
-   - 'REGEXP_mlab_oti=NOMATCH'
+   - 'REGEXP_mlab_staging=mlab4.hnd.*'
+   - 'REGEXP_mlab_oti=mlab[1-3].hnd.*'
 
 # stage3_coreos images.
 - name: epoxy-images-builder


### PR DESCRIPTION
This change guarantees that the deploy steps later in the cloudbuild succeed by generating some usb images for each project. Previously, the gsutil cp would fail if the glob pattern did not match any files. While we do not need these USB images yet, it is a simpler solution that building a conditional gsutil cp step.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/115)
<!-- Reviewable:end -->
