### PR TITLE
Add shim.sh setup to coreos image

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,94 +2,68 @@
 |--------|--------|
 | master | [![Build Status](https://travis-ci.org/m-lab/epoxy-images.svg?branch=master)](https://travis-ci.org/m-lab/epoxy-images) |
 
-# Boot Images for ePoxy Server
+# epoxy-images
 
-This repo supports building Linux kernels, rootfs images, and ROMs for ePoxy
-boot API.
+Support for building Linux kernels, rootfs images, and ROMs for ePoxy
 
 An ePoxy managed system depends on several image types:
 
-* stage1 images are either flashed to NICs or burned to CDs. These don't
-  change very often once installed.
-* stage2 Linux images provide a minimal, consistent network boot environment.
-* stage3 Linux images provide a complete environment, e.g. to flash the
-  iPXE ROMs to NICs, or run CoreOS or another distro.
+ * stage1 images that are either flashed to NICs, or burned to CDs.
+ * stage2 Linux images that provide a minimal network boot environment.
+ * stage3 Linux ROM update images, that (re)flash iPXE ROMs to NICs.
 
-# Initial Setup
+# Building images
 
-Once built, by default images are deployed to a GCS bucket for the current
-project, `gs://epoxy-<project>`. Here `<project>` corresponds to the GCP
-project name.
+## Building stage1 iPXE ROMs
 
-When creating a new bucket, set the default ACL to `public-read` so that
-booting nodes can download the files without authentication.
+TODO(soltesz): add notes for building iPXE ROMs.
 
-```sh
-gsutil defacl set public-read gs://epoxy-mlab-sandbox
-```
+## Building stage2 Linux images
 
-# Building Images
+The ePoxy stage2 image is a single file. It is a Linux kernel with embedded
+initramfs.
 
-Image builds are performed by Google Cloud Build using the `cloudbuild.yaml`
-configuration.
+The `setup_stage2.sh` script creates an initramfs filesystem, a cpio version of
+the initramfs, and the kernel with embedded initramfs.
 
-The first build step is to create a custom docker container that serves as a
-build environment for all subsequent steps.
+    docker build -t epoxy-images-builder  .
+    docker run -v $PWD:/images -it epoxy-images-builder \
+        /images/setup_stage2.sh /buildtmp /images/vendor \
+            /images/configs/stage2 \
+            /images/output/stage2_initramfs.cpio.gz \
+            /images/output/stage2_vmlinuz
 
-The environment variables for each build step are particular to the needs of the
-M-Lab projects. Update them for your own build.
+    docker run -v $PWD:/images -it epoxy-images-builder \
+        /images/simpleiso /images/output/stage2_vmlinuz \
+            /images/output/stage2.iso
 
-## Building Images for Development
+Using this ISO, you should be able to boot the image using VirtualBox or a
+similar tool. If your ssh key is in `configs/stage2/authorized_keys`, and the VM
+is configured to attach to a Host-only network on the 192.168.0.0/24 subnet,
+then you can ssh to the machine at:
 
-Before building with cloudbuild.yaml, it may be helpful to build locally. To
-build images locally, use the same steps as found in cloudbuild.yaml, for
-example:
+    ssh root@192.168.0.2
 
-```sh
-docker build -t epoxy-images-builder .
-docker run -e PROJECT=$PROJECT_ID -e ARTIFACTS=/workspace/output \
-  -it epoxy-images-builder /workspace/builder.sh stage1_minimal
-```
+Alternate network configurations are also possible, using the same format as the
+[nsfroot][nfsroot] `ip=` kernel parameter. The default value is shown below.
 
-Most builds generate two files, the Linux kernel and corresponding initramfs.
-In the case of the stage1_minimal target, the build generates:
+    network=192.168.0.2::192.168.0.1:255.255.255.0:default-net:eth0::8.8.8.8:
+    docker run -v $PWD:/images -it epoxy-images-builder \
+        /images/simpleiso -x epoxy.ip=${network} \
+            /images/output/stage2_vmlinuz \
+            /images/output/stage2.iso
 
-```txt
-$ ls -l output/
--rw-r--r-- 1 root root 158861392 May 13 16:43 initramfs_stage1_minimal.cpio.gz
--rw-r--r-- 1 root root   7013968 May 13 16:43 vmlinuz_stage1_minimal
-```
+[nfsroot]: https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
 
-The initramfs is large because it contains the complete "minimal" root
-filesystem, including kernel modules, binaries and all associated libraries.
+## Building stage3 Linux ROM update images
 
-Using these base images it's possible to create an ISO or USB image for
-booting with VirtualBox. Alternate network configurations are also possible
-by modifying the kernel parameters below:
+TODO(soltesz): add notes for building Linux ROM update images.
 
-```bash
-kargs="net.ifnames=0 autoconf=0 "
-kargs+="epoxy.interface=eth0 "
-kargs+="epoxy.ipv4=192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4 "
-kargs+="epoxy.ipv6= "
-kargs+="epoxy.hostname=localhost "
+# Deploying images
 
-docker run -v $PWD:/workspace -it epoxy-images-builder \
-  /workspace/simpleiso -x "${kargs}" \
-    -i /workspace/output/initramfs_stage1_minimal.cpio.gz \
-    /workspace/output/vmlinuz_stage1_minimal \
-    /workspace/output/stage1_minimal.iso
-```
+TODO(soltesz): outline how ePoxy images are deployed to GCS.
 
-You should be able to boot the ISO image using VirtualBox or any machine.
-If the VM is configured to attach to a Host-only network on the 192.168.0.0/24
-subnet, then you can ssh to the machine at:
-
-```sh
-ssh root@192.168.0.2
-```
-
-# BIOS & UEFI Support
+## BIOS & UEFI Support
 
 The `simpleiso` command creates ISO images that are capable of booting from
 either BIOS or UEFI systems. BIOS systems use isolinux while UEFI systems use
@@ -98,9 +72,9 @@ grub.
 The `simpleusb` command only creates fat16.gpt images capable of booting from
 UEFI systems. While hybrid boot for GPT & MBR may be possible, tools that
 support it warn "Hybrid MBRs are flaky and dangerous!", so `simpleusb` only
-support UEFI systems.
+support UEFI sytems.
 
-## Testing USB images
+### Testing USB images
 
 VirtualBox natively supports boot from ISO images & supports BIOS or UEFI
 boot environments. To support VM boot from USB images we must create a

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,5 +1,5 @@
 # Timeout for complete build. Default is 10m.
-timeout: 7200s
+timeout: 10800s
 
 ############################################################################
 # BUILD ARTIFACTS

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,7 +28,7 @@ steps:
    - 'ARTIFACTS=/workspace/output'
    - 'MLXROM_VERSION=3.4.816'
    - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
-   - 'REGEXP_mlab_staging=(mlab4.[a-z]{3}[0-9]{2}|mlab3.(lax02|lga03)).*'
+   - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
    - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
 
 # stage2 kernel.
@@ -73,7 +73,7 @@ steps:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
    - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
-   - 'REGEXP_mlab_staging=(mlab4.[a-z]{3}[0-9]{2}|mlab3.(lax02|lga03)).*'
+   - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
    - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
 
 # stage1 USBs
@@ -128,7 +128,7 @@ steps:
 # stage1_mlxrom.
 - name: gcr.io/cloud-builders/gsutil
   args: [
-    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
     'cp', '-r', '/workspace/output/stage1_mlxrom/*',
     'gs://epoxy-$PROJECT_ID/stage1_mlxrom/'
   ]
@@ -140,14 +140,14 @@ steps:
   args:
    - -c
    - >
-     gsutil -h "Cache-Control:private, max-age=0, no-transform"
+     gsutil -h "Cache-Control:private, max-age=0, no-transform" -m
      cp -r /workspace/output/stage1_mlxrom/*/*
      gs://epoxy-$PROJECT_ID/stage1_mlxrom/latest/
 
 # stage1_bootstrapfs.
 - name: gcr.io/cloud-builders/gsutil
   args: [
-    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
     'cp', '-r', '/workspace/output/bootstrapfs-MeasurementLabUpdate.tar.bz2*',
     'gs://epoxy-$PROJECT_ID/stage1_bootstrapfs/'
   ]
@@ -155,7 +155,7 @@ steps:
 # stage1_isos.
 - name: gcr.io/cloud-builders/gsutil
   args: [
-    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
     'cp', '-r', '/workspace/output/stage1_isos/*',
     'gs://epoxy-$PROJECT_ID/stage1_isos/'
   ]
@@ -163,7 +163,7 @@ steps:
 # stage1_usbs
 - name: gcr.io/cloud-builders/gsutil
   args: [
-    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
     'cp', '-r', '/workspace/output/stage1_usbs/*',
     'gs://epoxy-$PROJECT_ID/stage1_usbs/'
   ]
@@ -171,7 +171,7 @@ steps:
 # stage3_coreos.
 - name: gcr.io/cloud-builders/gsutil
   args: [
-    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
     'cp', '-r',
     '/workspace/output/stage2_vmlinuz',
     '/workspace/output/vmlinuz_stage1_minimal',
@@ -186,7 +186,7 @@ steps:
 # stage3_mlxupdate.
 - name: gcr.io/cloud-builders/gsutil
   args: [
-    '-h', 'Cache-Control:private, max-age=0, no-transform',
+    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
     'cp', '-r',
     '/workspace/output/stage2_vmlinuz',
     '/workspace/output/vmlinuz_stage1_minimal',

--- a/configs/stage3_coreos/README.md
+++ b/configs/stage3_coreos/README.md
@@ -1,29 +1,4 @@
-## Customize CoreOS images
-
-The `customize_coreos_pxe_image.sh` script will download the latest stable
-CoreOS images and generate a customized version by adding the provided cloud
-config file to /usr/share/oem/cloud-config.yml
-
-You must run as root to guarantee that file permissions are preserved during the
-unpacking and repacking.
-```
-$ sudo ./customize_coreos_pxe_image.sh \
-    build/coreos_custom_pxe_image.cpio.gz
-```
-
-After downloading and generating these images, you should upload the new cpio
-files and the vmlinuz image to gs://epoxy-mlab-staging/coreos-generic/.
-
-The default cache timeout is 1h. If you need to iterate more often than once an
-hour, you must disable caching or you'll get the cached image during boot.
-
-```
-CACHE_CONTROL="Cache-Control:private, max-age=0, no-transform"
-gsutil -h "$CACHE_CONTROL" \
-    cp -r build/coreos_custom_pxe_image.cpio.gz \
-          build/coreos_production_pxe.vmlinuz \
-          gs://epoxy-mlab-staging/coreos-generic/
-```
-
-NOTE: The CoreOS kernel and cpio image must be updated at the same time.
-Mismatched versions may fail to boot or behave incorrectly.
+The `shim.sh` file exists to aid in the debugging of CNI plugins.  It will
+likely be turned on in production for a while, but eventually the kubelet on
+the node should be set up to use the files in `/usr/cni/bin` instead of
+`/usr/shimcni/bin`.

--- a/configs/stage3_coreos/shim.sh
+++ b/configs/stage3_coreos/shim.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# This program acts as a shim between real CNI plugins (as stored in
+# /opt/cni/bin) and the system which calls those plugins.  It is used by putting
+# it in a directory (e.g. /opt/shimcni/bin) and then symlinking this script to
+# the name of every CNI plugin you want to create a shim for.  e.g.
+#   for i in /opt/cni/bin/*; do
+#     ln -s /opt/shimcni/bin/shim.sh /opt/shimcni/bin/$(basename "$i")
+#   done
+#
+# Then, whenever one of the files in /opt/shimcni/bin is invoked, a new
+# directory will appear in /tmp containing all the parameters required to invoke
+# that plugin again (the cmdline, env, stdin) as well as all the output that the
+# plugin produced (stdout, stderr, and the exit code).
+#
+# The hope is that, with this information, it will become easier to debug CNI
+# networking problems.
+
+OUTPUT=$(mktemp -d --tmpdir=/tmp "$(date -Iseconds).$(basename $0).XXXXXXX")
+echo "$0" "$@" > "${OUTPUT}/cmdline"
+env > "${OUTPUT}/env"
+tee "${OUTPUT}/input" \
+  | (/opt/cni/bin/$(basename "$0") "$@" 2> "${OUTPUT}/stderr";
+     echo $? > "${OUTPUT}/exitcode") \
+  | tee "${OUTPUT}/output"
+cd "${OUTPUT}" || exit 1
+cat \
+    <(echo "==CMD==") \
+    cmdline \
+    <(echo "==ENV==") \
+    env \
+    <(echo "==STDIN==") \
+    input \
+    <(echo "==STDOUT==") \
+    output \
+    <(echo "==STDERR==") \
+    stderr \
+    <(echo "==EXITCODE==") \
+    exitcode \
+  > summary
+chmod a+rx "${OUTPUT}"
+chmod a+r "${OUTPUT}"/*

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -66,13 +66,13 @@ pushd $IMAGEDIR
   # Make all the shims so that network plugins can be debugged.
   mkdir -p squashfs-root/shimcni/bin
   pushd squashfs-root/shimcni/bin
-    cp -a ${CONFIG_DIR}/shim.sh .
-    chmod +x shim.sh
     for i in squashfs-root/cni/bin/*; do
       # NOTE: the target path does not exist at this moment, but that's the file
       # the symlink should reference in the final image filesystem.
       ln -s /usr/shimcni/bin/shim.sh $(basename "$i")
     done
+    cp -a ${CONFIG_DIR}/shim.sh .
+    chmod +x shim.sh
   popd
 
   # Install multus and index2ip.

--- a/setup_stage3_coreos.sh
+++ b/setup_stage3_coreos.sh
@@ -63,6 +63,18 @@ pushd $IMAGEDIR
   mkdir -p squashfs-root/cni/bin
   curl --location "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar --directory=squashfs-root/cni/bin -xz
 
+  # Make all the shims so that network plugins can be debugged.
+  mkdir -p squashfs-root/shimcni/bin
+  pushd squashfs-root/shimcni/bin
+    cp -a ${CONFIG_DIR}/shim.sh .
+    chmod +x shim.sh
+    for i in squashfs-root/cni/bin/*; do
+      # NOTE: the target path does not exist at this moment, but that's the file
+      # the symlink should reference in the final image filesystem.
+      ln -s /usr/shimcni/bin/shim.sh $(basename "$i")
+    done
+  popd
+
   # Install multus and index2ip.
   TMPDIR=$(mktemp -d)
   pushd ${TMPDIR}


### PR DESCRIPTION
This change adds the shim.sh script from k8s-support adding it natively to the coreos image.

As well, this change includes updates to the cloudbuild configuration to make deployments a little faster and to allow a longer timeout for long builds -- production took ~2h last time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/116)
<!-- Reviewable:end -->
