### PR TITLE
Updates REGEX_mlab_oti to include den06, which will be the first all-ePoxy site.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -87,7 +87,7 @@ steps:
    - 'ARTIFACTS=/workspace/output'
    - 'REGEXP_mlab_sandbox=mlab[1-4].lga1t.*'
    - 'REGEXP_mlab_staging=mlab4.hnd01.*'
-   - 'REGEXP_mlab_oti=mlab[1-3].hnd01.*'
+   - 'REGEXP_mlab_oti=mlab[1-3].(den06|hnd01).*'
 
 # stage3_coreos images.
 - name: epoxy-images-builder


### PR DESCRIPTION
The legacy PLC site DEN01 is moving a 1g Hurricane Electric circuit to a 10g GTT circuit. Part of this process is retiring DEN01 and renaming it to DEN06. We will use this circumstance to try out our first site which is all ePoxy/k8s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/119)
<!-- Reviewable:end -->
