### PR TITLE
Update templates for siteinfo

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -28,7 +28,7 @@ steps:
    - 'ARTIFACTS=/workspace/output'
    - 'MLXROM_VERSION=3.4.816'
    - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
-   - 'REGEXP_mlab_staging=(mlab4.[a-z]{3}[0-9]{2}|mlab3.(lax02|lga03)).*'
+   - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
    - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
 
 # stage2 kernel.
@@ -73,7 +73,7 @@ steps:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
    - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
-   - 'REGEXP_mlab_staging=(mlab4.[a-z]{3}[0-9]{2}|mlab3.(lax02|lga03)).*'
+   - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
    - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
 
 # stage1 USBs

--- a/configs/stage1_isos/create-stage1-iso-template.sh
+++ b/configs/stage1_isos/create-stage1-iso-template.sh
@@ -15,11 +15,10 @@ SOURCE_DIR=${1:?Please provide the source directory root: $USAGE}
 IMAGE_DIR=${2:?Error: specify input vmlinuz: $USAGE}
 OUTPUT_DIR=${3:?Error: specify directory for output ISO: $USAGE}
 
-if [[ "{{netmask}}" != "255.255.255.192" ]] ; then
-  echo 'Error: Sorry, unsupported netmask: {{netmask}}'
+if [[ "{{ipv4_netmask}}" != "255.255.255.192" ]] ; then
+  echo 'Error: Sorry, unsupported netmask: {{ipv4_netmask}}'
   exit 1
 fi
-mask=26
 
 if [[ ! -f "${IMAGE_DIR}/stage2_vmlinuz" ]] ; then
     echo 'Error: vmlinuz images not found!'
@@ -39,12 +38,12 @@ ARGS="net.ifnames=0 "
 ARGS+="epoxy.project={{project}} "
 
 # TODO: Legacy epoxy.ip= format. Remove once canonical form is supported.
-ARGS+="epoxy.ip={{ip}}::{{gateway}}:255.255.255.192:{{hostname}}:eth0:false:{{dns1}}:8.8.4.4 "
+ARGS+="epoxy.ip={{ipv4_address}}::{{ipv4_gateway}}:255.255.255.192:{{hostname}}:eth0:false:{{ipv4_dns1}}:{{ipv4_dns2}} "
 
 # Canonical epoxy network configuration.
 ARGS+="epoxy.hostname={{hostname}} "
 ARGS+="epoxy.interface=eth0 "
-ARGS+="epoxy.ipv4={{ip}}/${mask},{{gateway}},{{dns1}},8.8.4.4 "
+ARGS+="epoxy.ipv4={{ipv4_address}}/{{ipv4_subnet}},{{ipv4_gateway}},{{ipv4_dns1}},{{ipv4_dns2}} "
 
 if [[ "{{ipv6_enabled}}" == "true" ]] ; then
   ARGS+="epoxy.ipv6={{ipv6_address}}/64,{{ipv6_gateway}},{{ipv6_dns1}},{{ipv6_dns2}} "

--- a/configs/stage1_mlxrom/stage1-template.ipxe
+++ b/configs/stage1_mlxrom/stage1-template.ipxe
@@ -15,17 +15,18 @@ set max_retry_delay_s 480
 set ipv6_enabled {{ipv6_enabled}}
 set ipv6_address {{ipv6_address}}
 set ipv6_gateway {{ipv6_gateway}}
-set ipv6_subnet  64
+set ipv6_subnet  {{ipv6_subnet}}
 set ipv6_dns1    {{ipv6_dns1}}
 set ipv6_dns2    {{ipv6_dns2}}
 
 # IPv4 network configuration.
-set ipv4_address {{ip}}
-set ipv4_gateway {{gateway}}
-set ipv4_subnet  26
-set ipv4_netmask {{netmask}}
-set ipv4_dns1    {{dns1}}
-set ipv4_dns2    {{dns2}}
+set ipv4_enabled {{ipv4_enabled}}
+set ipv4_address {{ipv4_address}}
+set ipv4_gateway {{ipv4_gateway}}
+set ipv4_subnet  {{ipv4_subnet}}
+set ipv4_netmask {{ipv4_netmask}}
+set ipv4_dns1    {{ipv4_dns1}}
+set ipv4_dns2    {{ipv4_dns2}}
 
 # Apply ipxe network settings (IPv4 only).
 ifopen net0

--- a/configs/stage1_usbs/create-stage1-usb-template.sh
+++ b/configs/stage1_usbs/create-stage1-usb-template.sh
@@ -14,11 +14,10 @@ SOURCE_DIR=${1:?Please provide the source directory root: $USAGE}
 IMAGE_DIR=${2:?Error: specify input vmlinuz: $USAGE}
 OUTPUT_DIR=${3:?Error: specify directory for output USB: $USAGE}
 
-if [[ "{{netmask}}" != "255.255.255.192" ]] ; then
-  echo 'Error: Sorry, unsupported netmask: {{netmask}}'
+if [[ "{{ipv4_netmask}}" != "255.255.255.192" ]] ; then
+  echo 'Error: Sorry, unsupported netmask: {{ipv4_netmask}}'
   exit 1
 fi
-mask=26
 
 if [[ ! -f "${IMAGE_DIR}/vmlinuz_stage1_minimal" ]] ; then
     echo 'Error: vmlinuz images not found!'
@@ -38,15 +37,15 @@ ARGS="net.ifnames=0 "
 ARGS+="epoxy.project={{project}} "
 
 # TODO: Legacy epoxy.ip= format. Remove once canonical form is supported.
-ARGS+="epoxy.ip={{ip}}::{{gateway}}:255.255.255.192:{{hostname}}:eth0:false:{{dns1}}:8.8.4.4 "
+ARGS+="epoxy.ip={{ipv4_address}}::{{ipv4_gateway}}:255.255.255.192:{{hostname}}:eth0:false:{{ipv4_dns1}}:{{ipv4_dns2}} "
 
 # Canonical epoxy network configuration.
 ARGS+="epoxy.hostname={{hostname}} "
 ARGS+="epoxy.interface=eth0 "
-ARGS+="epoxy.ipv4={{ip}}/${mask},{{gateway}},{{dns1}},8.8.4.4 "
+ARGS+="epoxy.ipv4={{ipv4_address}}/{{ipv4_subnet}},{{ipv4_gateway}},{{ipv4_dns1}},{{ipv4_dns2}} "
 
 if [[ "{{ipv6_enabled}}" == "true" ]] ; then
-  ARGS+="epoxy.ipv6={{ipv6_address}}/64,{{ipv6_gateway}},{{ipv6_dns1}},{{ipv6_dns2}} "
+  ARGS+="epoxy.ipv6={{ipv6_address}}/{{ipv6_subnet}},{{ipv6_gateway}},{{ipv6_dns1}},{{ipv6_dns2}} "
 else
   ARGS+="epoxy.ipv6= "
 fi

--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -77,6 +77,7 @@ function generate_stage1_ipxe_scripts() {
     pushd operator/plsync
       mkdir -p ${output_dir}
       ./mlabconfig.py --format=server-network-config \
+          --physical \
           --select "${hostname_pattern}" \
           --label "project=${PROJECT}" \
           --template_input "${config_dir}/stage1-template.ipxe" \

--- a/setup_stage1_isos.sh
+++ b/setup_stage1_isos.sh
@@ -26,6 +26,7 @@ pushd ${BUILD_DIR}
   pushd operator/plsync
     mkdir -p ${OUTPUT_DIR}/scripts
     ./mlabconfig.py --format=server-network-config \
+        --physical \
         --select "${HOSTNAMES}" \
         --label "project=${PROJECT}" \
         --template_input "${CONFIG_DIR}/create-stage1-iso-template.sh" \

--- a/setup_stage1_usbs.sh
+++ b/setup_stage1_usbs.sh
@@ -27,6 +27,7 @@ pushd "${BUILD_DIR}"
   pushd operator/plsync
     mkdir -p "${OUTPUT_DIR}/scripts"
     ./mlabconfig.py --format=server-network-config \
+        --physical \
         --select "${HOSTNAMES}" \
         --label "project=${PROJECT}" \
         --template_input "${CONFIG_DIR}/create-stage1-usb-template.sh" \


### PR DESCRIPTION
This change updates the config templates passed to mlabconfig.py to use the new ipv4 and ipv6 variable names. This change also adds the `--physical` flag to mlabconfig.py for all scripts that generate templates to limit to physical sites.

NOTE: only the template values are changed in stage1-template.ipxe not the local variable names. So, the existing stage1to2.ipxe script should continue to work as before.

Part of the siteinfo migration: https://github.com/m-lab/dev-tracker/issues/355

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/121)
<!-- Reviewable:end -->
