### PR TITLE
Set tc qdisc for eth0 to "fq"

### DIFF
--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -194,3 +194,4 @@ users:
     groups: ["sudo"]
     ssh-authorized-keys:
       - "command=\"sudo /usr/bin/systemctl reboot -i\" ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd/MjyFiDvvw9IR6crFgFnLtZT4pQw6Pjv9jSs7XKasgsnr8dTjLSb91sYPqKpz2CHpcHJfYtqFZvNePR44BEQ/Pf9DcS9ico1OXOunkqC3L9mw6MaPE5b5GjatP0eXGPcDUdKhDCsL43PjEs8hJ+/hTrDrv1qE/dDYpfsnIVcSj3Zd+uOd+c+RY8MPzaRytYlaFytT/R8R4X8aC9xYCLzcPQ8XIgVUGscwI6WhiFCCiU2sffeeNPzcoRJ9T+P2j6LQSbS1P8Clg89BdYucRCcKWED3lVQ9v6tC6Y8xaGeaEEyB7+B5p8EoIYRu90idrPVSjSsjBYP1UUdo2h7R+VH reboot-api@"
+

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -1,5 +1,4 @@
 #cloud-config
-
 coreos:
   # TODO: during the image customization process, consider adding custom
   # network handling units directly instead of this approach.
@@ -188,3 +187,9 @@ users:
     ssh-authorized-keys:
       - "command=\"sudo /usr/bin/systemctl reboot -i\" ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd/MjyFiDvvw9IR6crFgFnLtZT4pQw6Pjv9jSs7XKasgsnr8dTjLSb91sYPqKpz2CHpcHJfYtqFZvNePR44BEQ/Pf9DcS9ico1OXOunkqC3L9mw6MaPE5b5GjatP0eXGPcDUdKhDCsL43PjEs8hJ+/hTrDrv1qE/dDYpfsnIVcSj3Zd+uOd+c+RY8MPzaRytYlaFytT/R8R4X8aC9xYCLzcPQ8XIgVUGscwI6WhiFCCiU2sffeeNPzcoRJ9T+P2j6LQSbS1P8Clg89BdYucRCcKWED3lVQ9v6tC6Y8xaGeaEEyB7+B5p8EoIYRu90idrPVSjSsjBYP1UUdo2h7R+VH reboot-api@"
 
+write_files:
+  - path: /etc/sysctl.d/default_qdisc.conf
+    permissions: 0644
+    owner: root
+    content: |
+        net.core.default_qdisc=fq

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -24,6 +24,14 @@ coreos:
         Type=oneshot
         ExecStart=/usr/share/oem/generate_network_config.sh /etc/systemd/network/00-eth0.network
 
+    # Replaces eth0's qdisc with fq.
+    - name: set-tc-qdisc.service
+      command: start
+      content: |
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/sbin/tc qdisc replace dev eth0 root fq
+
     # Restarts the networkd service using our new config.
     - name: systemd-networkd.service
       command: restart
@@ -186,10 +194,3 @@ users:
     groups: ["sudo"]
     ssh-authorized-keys:
       - "command=\"sudo /usr/bin/systemctl reboot -i\" ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDd/MjyFiDvvw9IR6crFgFnLtZT4pQw6Pjv9jSs7XKasgsnr8dTjLSb91sYPqKpz2CHpcHJfYtqFZvNePR44BEQ/Pf9DcS9ico1OXOunkqC3L9mw6MaPE5b5GjatP0eXGPcDUdKhDCsL43PjEs8hJ+/hTrDrv1qE/dDYpfsnIVcSj3Zd+uOd+c+RY8MPzaRytYlaFytT/R8R4X8aC9xYCLzcPQ8XIgVUGscwI6WhiFCCiU2sffeeNPzcoRJ9T+P2j6LQSbS1P8Clg89BdYucRCcKWED3lVQ9v6tC6Y8xaGeaEEyB7+B5p8EoIYRu90idrPVSjSsjBYP1UUdo2h7R+VH reboot-api@"
-
-write_files:
-  - path: /etc/sysctl.d/default_qdisc.conf
-    permissions: 0644
-    owner: root
-    content: |
-        net.core.default_qdisc=fq


### PR DESCRIPTION
This PR sets the default scheduler for `eth0` to `fq`, implementing the [recommended configuration](https://docs.google.com/document/d/128e27XB5GcuOef04yU6pNRGhWQ_ekKMAgDgyqSyFrGk/edit#).

I've tried an approach based on creating a file under `/etc/sysctl.d` with a `write_files` directive in `cloud-config.yml` but I found out that's loaded too late during the boot process, and then we'd need to both 1. run `sysctl --system` 2. apply the configuration to `eth0` manually anyway (as in this PR).

Just setting the right scheduler at boot seemed easier, but please let me know if you think we should handle this differently.

Closes https://github.com/m-lab/ops-tracker/issues/733

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/122)
<!-- Reviewable:end -->
