### PR TITLE
Disable TCP Segmentation Offload via ethtool

### DIFF
--- a/configs/stage3_coreos/resources/generate_network_config.sh
+++ b/configs/stage3_coreos/resources/generate_network_config.sh
@@ -39,6 +39,11 @@ DNS2=$( echo $FIELDS | awk -F: '{print $9}' )
 # Note, we cannot set the hostname via networkd. Use hostnamectl instead.
 hostnamectl set-hostname ${HOSTNAME}
 
+# According to https://systemd.network/systemd.link.html, TSO can only be
+# enabled or set to the kernel default when using networkd. We need to disable
+# it, thus we use ethtool instead.
+ethtool -K eth0 tso off
+
 # TODO: do not hardcode /26.
 # TODO: do not hardcode eth0.
 cat > ${OUTPUT} <<EOF


### PR DESCRIPTION
This PR disables TCP segmentation offload via ethtool as part of the `generate_network_config.sh` script.

I have experimented with the networkd-specific way of disabling TCP Segmentation Offload but according to the [documentation](https://systemd.network/systemd.link.html) and to my tests, it seems that networkd can either enable TSO or set it to the "kernel default" but there's no option to explicitly disable it.

There are a few missing things to fully comply with the configuration outlined in https://docs.google.com/document/d/128e27XB5GcuOef04yU6pNRGhWQ_ekKMAgDgyqSyFrGk/edit# but they need to be configured via `tc`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/124)
<!-- Reviewable:end -->
