### PR TITLE
Add isohybrid to simpleiso to make the ISO compatible with USB drives 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get install -y unzip python-pip git vim-nox make autoconf gcc mkisofs \
     isolinux bc texinfo libncurses5-dev linux-source debootstrap gcc-4.8 \
     strace cpio squashfs-tools curl lsb-release gawk \
     mtools dosfstools syslinux syslinux-utils parted kpartx grub-efi \
-    linux-source-4.4.0=4.4.0-104.127 golang-1.9
+    linux-source-4.4.0=4.4.0-104.127 golang-1.9 xorriso
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/go-1.9/bin
 ENV GOROOT /usr/lib/go-1.9
 # TODO: remove pinned version on linux-source-4.4.0.

--- a/simpleiso
+++ b/simpleiso
@@ -170,7 +170,7 @@ function main() {
 
   # Run isohybrid on the generated ISO. This makes it bootable regardless of
   # the media (CD or USB drive).
-  isohybrid ${ISO_NAME}
+  isohybrid --uefi ${ISO_NAME}
 
   # Clean up temporary directory.
   rm -fr ${isodir}

--- a/simpleiso
+++ b/simpleiso
@@ -168,6 +168,8 @@ function main() {
       -efi-boot efiboot.img \
       -no-emul-boot ${isodir}
 
+  isohybrid ${ISO_NAME}
+
   # Clean up temporary directory.
   rm -fr ${isodir}
 }

--- a/simpleiso
+++ b/simpleiso
@@ -97,7 +97,7 @@ menuentry 'linux: ${ISO_NAME}' {
 }
 EOF
 
-  make_bootefi_img ${efiboot_img}
+  make_bootefi_img ${efiboot_img} ${isofs_dir}
 
   # Copy isolinux bootloader.
   install -D -m 644 ${ISOLINUX_BIN} ${isofs_dir}/isolinux/isolinux.bin
@@ -109,6 +109,7 @@ EOF
 
 function make_bootefi_img() {
   local bootefi_img=$1
+  local isofs_dir=$2
   local tmp=$( mktemp --directory )
 
   # Make the grub efi boot loader image.
@@ -134,6 +135,9 @@ function make_bootefi_img() {
   # Creates the necessary subdirectories.
   mmd -i ${tmp}/data.fat16 ::/efi ::/efi/boot
   mcopy -bsQ -i ${tmp}/data.fat16 ${tmp}/bootx64.efi ::/efi/boot
+  mcopy -bsQ -i ${tmp}/data.fat16 ${isofs_dir}/grub.cfg ::/
+  mcopy -bsQ -i ${tmp}/data.fat16 ${isofs_dir}/vmlinuz ::/
+  mcopy -bsQ -i ${tmp}/data.fat16 ${isofs_dir}/initramfs ::/
 
   # Copy the fat16 formatted data as the complete bootefi img file.
   cp ${tmp}/data.fat16 ${bootefi_img}
@@ -162,10 +166,6 @@ function main() {
       -isohybrid-gpt-basdat \
       -output ${ISO_NAME} \
       ${isodir}
-
-  # Run isohybrid on the generated ISO. This makes it bootable regardless of
-  # the media (CD or USB drive).
-  isohybrid --uefi ${ISO_NAME}
 
   # Clean up temporary directory.
   rm -fr ${isodir}

--- a/simpleiso
+++ b/simpleiso
@@ -112,18 +112,19 @@ function make_bootefi_img() {
   local isofs_dir=$2
   local tmp=$( mktemp --directory )
 
+  local raw_size_k=$(
+    du --dereference --summarize --block-size=1K ${isofs_dir} \
+      | awk '{ print $1; }'
+  )
+
+  local size=$(( $raw_size_k + 4096 ))
+
   # Make the grub efi boot loader image.
   grub-mkimage -o ${tmp}/bootx64.efi -p / -O x86_64-efi fat iso9660 part_gpt \
       part_msdos normal boot linux linuxefi efinet lsefi lsefisystab lsefimmap \
       configfile loopback chain efifwsetup efi_gop efi_uga ls search \
       search_label search_fs_uuid search_fs_file gfxterm gfxterm_background \
       gfxterm_menu test all_video loadenv exfat ext2 ntfs udf
-
-  local raw_size_k=$(
-    du --dereference --summarize --block-size=1K ${tmp}/bootx64.efi \
-      | awk '{ print $1; }'
-  )
-  local size=$(( $raw_size_k + 4096 ))
 
   # Ignore meaningless sector alignment failures.
   export MTOOLS_SKIP_CHECK=1

--- a/simpleiso
+++ b/simpleiso
@@ -168,6 +168,8 @@ function main() {
       -efi-boot efiboot.img \
       -no-emul-boot ${isodir}
 
+  # Run isohybrid on the generated ISO. This makes it bootable regardless of
+  # the media (CD or USB drive).
   isohybrid ${ISO_NAME}
 
   # Clean up temporary directory.

--- a/simpleiso
+++ b/simpleiso
@@ -158,7 +158,8 @@ function main() {
       -boot-info-table \
       -eltorito-alt-boot \
       -e efiboot.img \
-      -isohybrid-gpt-basdat
+      -no-emul-boot \
+      -isohybrid-gpt-basdat \
       -output ${ISO_NAME} \
       ${isodir}
 

--- a/simpleiso
+++ b/simpleiso
@@ -9,8 +9,8 @@ set -euxo pipefail
 INITRAMFS=
 BOOT_PARAMS=
 
-# From genisoimage package.
-MKISOFS=/usr/bin/mkisofs
+# From xorriso package.
+MKISOFS=/usr/bin/xorriso
 # From the isolinux package.
 ISOLINUX_BIN=/usr/lib/ISOLINUX/isolinux.bin
 # From the syslinux-common package.
@@ -149,24 +149,18 @@ function main() {
   setup_isofs $isodir ${isodir}/efiboot.img "$VMLINUZ" "$INITRAMFS" "${BOOT_PARAMS}"
 
   # Generate the ISO image. File paths are relative to the ${isodir}.
-  ${MKISOFS} -untranslated-filenames \
-      -publisher "M-Lab" \
-      -appid "ePoxy" \
-      -volid "Dual ISO x86_64" \
-      -joliet \
-      -joliet-long \
-      -rational-rock \
-      -verbose \
-      -translation-table \
-      -output ${ISO_NAME} \
-      -eltorito-boot isolinux/isolinux.bin \
-      -eltorito-catalog isolinux/boot.cat \
+  ${MKISOFS} -as mkisofs \
+      -isohybrid-mbr /usr/lib/ISOLINUX/isohdpfx.bin \
+      -c isolinux/boot.cat \
+      -b isolinux/isolinux.bin \
       -no-emul-boot \
       -boot-load-size 4 \
       -boot-info-table \
       -eltorito-alt-boot \
-      -efi-boot efiboot.img \
-      -no-emul-boot ${isodir}
+      -e efiboot.img \
+      -isohybrid-gpt-basdat
+      -output ${ISO_NAME} \
+      ${isodir}
 
   # Run isohybrid on the generated ISO. This makes it bootable regardless of
   # the media (CD or USB drive).


### PR DESCRIPTION
This PR adds `isohybrid` to the `simpleiso` script so that the generated ISO should be compatible with both CDs and USB sticks. From my tests, both Dell R630 and R620 servers were able to boot the hybrid stage1_isos from USB and in BIOS mode.

Please note that I was unable to verify that the resulting ISO still works when burned on a CD-ROM, not having physical access to the servers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/126)
<!-- Reviewable:end -->
