### PR TITLE
Update CoreOS image to version 2079.6.0

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -97,7 +97,7 @@ steps:
   env:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
-   - 'COREOS_VERSION=2023.5.0'
+   - 'COREOS_VERSION=2079.6.0'
    - 'K8S_VERSION=v1.13.5'
    - 'CRI_VERSION=v1.13.0'
    - 'CNI_VERSION=v0.7.5'

--- a/manual/manually_generate_images.sh
+++ b/manual/manually_generate_images.sh
@@ -3,7 +3,7 @@
 # A script to create ePoxy images manually.
 
 # Edit the following variable to suit your needs, most importantly PROJECT and NODE_REGEXP.
-COREOS_VERSION="2023.5.0"
+COREOS_VERSION="2079.6.0"
 PROJECT="mlab-staging"
 NODE_REGEXP="mlab4.(bru02|lax02|syd02)"
 GCS_BUCKET="gs://epoxy-${PROJECT}"


### PR DESCRIPTION
This release addresses the SACK vulnerability:
https://coreos.com/releases/#2079.6.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/127)
<!-- Reviewable:end -->
