### PR TITLE
Change --initrd <filename> to be a single argument

### DIFF
--- a/actions/stage3_coreos/stage1to2.json
+++ b/actions/stage3_coreos/stage1to2.json
@@ -33,8 +33,7 @@
             "/sbin/kexec",
             "--force",
             "--command-line={{.vars.kargs}} {{.vars.cmdline}}",
-            "--initrd",
-            "{{.files.initram.name}}",
+            "--initrd={{.files.initram.name}}",
             "{{.files.vmlinuz.name}}"
          ]
       ]

--- a/actions/stage3_mlxupdate/stage1to2.json
+++ b/actions/stage3_mlxupdate/stage1to2.json
@@ -33,8 +33,7 @@
             "/sbin/kexec",
             "--force",
             "--command-line={{.vars.kargs}} {{.vars.cmdline}}",
-            "--initrd",
-            "{{.files.initram.name}}",
+            "--initrd={{.files.initram.name}}",
             "{{.files.vmlinuz.name}}"
          ]
       ]


### PR DESCRIPTION
Apparently the `--initrd <filename>` syntax does not work on the PLC
SafeBoot system, likely due to an older kexec version.

`--initrd=<filename>` worked when run manually in SafeBoot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/128)
<!-- Reviewable:end -->
