### PR TITLE
Bumps the default Cloud Build disk from 100GB to 200GB

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@
 #    the target branch matches a supported deployment target.
 
 env:
-- COREOS_VERSION="2023.5.0"
+- COREOS_VERSION="2079.6.0"
 
 services:
 - docker

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ timeout: 10800s
 # The default disk size is 100GB. However, the stage1 ISOs are pretty big these
 # days. 200GB  should give us some breathing room.
 options:
-  diskSizeGB: 200
+  diskSizeGb: 200
 
 ############################################################################
 # BUILD ARTIFACTS

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,11 @@
 # Timeout for complete build. Default is 10m.
 timeout: 10800s
 
+# The default disk size is 100GB. However, the stage1 ISOs are pretty big these
+# days. 200GB  should give us some breathing room.
+options:
+  diskSizeGB: 200
+
 ############################################################################
 # BUILD ARTIFACTS
 ############################################################################


### PR DESCRIPTION
Now that the stage1 images are double the size they once were, we need extra disk space, especially in production where ~400 images are built.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/129)
<!-- Reviewable:end -->
