### PR TITLE
Uses curl to fetch mlabconfig.py from the m-lab/siteinfo repo

### DIFF
--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -73,6 +73,7 @@ function generate_stage1_ipxe_scripts() {
   # Create all stage1.ipxe scripts.
   pushd ${build_dir}
     # TODO: replace host set with metadata service.
+    # TODO: Replace curl with a native go-get once mlabconfig is rewritten in Go.
     curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py"
     mkdir -p ${output_dir}
     ./mlabconfig.py --format=server-network-config \

--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -77,7 +77,7 @@ function generate_stage1_ipxe_scripts() {
     curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py" > \
         ./mlabconfig.py
     mkdir -p ${output_dir}
-    bash ./mlabconfig.py --format=server-network-config \
+    python ./mlabconfig.py --format=server-network-config \
         --physical \
         --select "${hostname_pattern}" \
         --label "project=${PROJECT}" \

--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -77,7 +77,7 @@ function generate_stage1_ipxe_scripts() {
     curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py" > \
         ./mlabconfig.py
     mkdir -p ${output_dir}
-    ./mlabconfig.py --format=server-network-config \
+    bash ./mlabconfig.py --format=server-network-config \
         --physical \
         --select "${hostname_pattern}" \
         --label "project=${PROJECT}" \

--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -73,16 +73,14 @@ function generate_stage1_ipxe_scripts() {
   # Create all stage1.ipxe scripts.
   pushd ${build_dir}
     # TODO: replace host set with metadata service.
-    test -d operator || git clone https://github.com/m-lab/operator
-    pushd operator/plsync
-      mkdir -p ${output_dir}
-      ./mlabconfig.py --format=server-network-config \
-          --physical \
-          --select "${hostname_pattern}" \
-          --label "project=${PROJECT}" \
-          --template_input "${config_dir}/stage1-template.ipxe" \
-          --template_output "${output_dir}/stage1-{{hostname}}.ipxe"
-    popd
+    curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py"
+    mkdir -p ${output_dir}
+    ./mlabconfig.py --format=server-network-config \
+        --physical \
+        --select "${hostname_pattern}" \
+        --label "project=${PROJECT}" \
+        --template_input "${config_dir}/stage1-template.ipxe" \
+        --template_output "${output_dir}/stage1-{{hostname}}.ipxe"
   popd
 }
 

--- a/setup_stage1.sh
+++ b/setup_stage1.sh
@@ -74,7 +74,8 @@ function generate_stage1_ipxe_scripts() {
   pushd ${build_dir}
     # TODO: replace host set with metadata service.
     # TODO: Replace curl with a native go-get once mlabconfig is rewritten in Go.
-    curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py"
+    curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py" > \
+        ./mlabconfig.py
     mkdir -p ${output_dir}
     ./mlabconfig.py --format=server-network-config \
         --physical \

--- a/setup_stage1_isos.sh
+++ b/setup_stage1_isos.sh
@@ -23,7 +23,8 @@ set -xuo pipefail
 # HOSTNAMES pattern.
 pushd ${BUILD_DIR}
   # TODO: Replace curl with a native go-get once mlabconfig is rewritten in Go.
-  curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py"
+  curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py" > \
+      ./mlabconfig.py
   mkdir -p ${OUTPUT_DIR}/scripts
   ./mlabconfig.py --format=server-network-config \
       --physical \

--- a/setup_stage1_isos.sh
+++ b/setup_stage1_isos.sh
@@ -26,7 +26,7 @@ pushd ${BUILD_DIR}
   curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py" > \
       ./mlabconfig.py
   mkdir -p ${OUTPUT_DIR}/scripts
-  ./mlabconfig.py --format=server-network-config \
+  bash ./mlabconfig.py --format=server-network-config \
       --physical \
       --select "${HOSTNAMES}" \
       --label "project=${PROJECT}" \

--- a/setup_stage1_isos.sh
+++ b/setup_stage1_isos.sh
@@ -22,17 +22,14 @@ set -xuo pipefail
 # Use mlabconfig to fill in the template for every machine matching the given
 # HOSTNAMES pattern.
 pushd ${BUILD_DIR}
-  test -d operator || git clone https://github.com/m-lab/operator
-  pushd operator/plsync
-    mkdir -p ${OUTPUT_DIR}/scripts
-    ./mlabconfig.py --format=server-network-config \
-        --physical \
-        --select "${HOSTNAMES}" \
-        --label "project=${PROJECT}" \
-        --template_input "${CONFIG_DIR}/create-stage1-iso-template.sh" \
-        --template_output "${BUILD_DIR}/create-stage1-iso-{{hostname}}.sh"
-  popd
-popd
+  curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py"
+  mkdir -p ${OUTPUT_DIR}/scripts
+  ./mlabconfig.py --format=server-network-config \
+      --physical \
+      --select "${HOSTNAMES}" \
+      --label "project=${PROJECT}" \
+      --template_input "${CONFIG_DIR}/create-stage1-iso-template.sh" \
+      --template_output "${BUILD_DIR}/create-stage1-iso-{{hostname}}.sh"
 
 # Check whether there are any files in the glob pattern.
 if ! compgen -G ${BUILD_DIR}/create-stage1-iso-*.sh ; then

--- a/setup_stage1_isos.sh
+++ b/setup_stage1_isos.sh
@@ -22,6 +22,7 @@ set -xuo pipefail
 # Use mlabconfig to fill in the template for every machine matching the given
 # HOSTNAMES pattern.
 pushd ${BUILD_DIR}
+  # TODO: Replace curl with a native go-get once mlabconfig is rewritten in Go.
   curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py"
   mkdir -p ${OUTPUT_DIR}/scripts
   ./mlabconfig.py --format=server-network-config \

--- a/setup_stage1_isos.sh
+++ b/setup_stage1_isos.sh
@@ -26,7 +26,7 @@ pushd ${BUILD_DIR}
   curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py" > \
       ./mlabconfig.py
   mkdir -p ${OUTPUT_DIR}/scripts
-  bash ./mlabconfig.py --format=server-network-config \
+  python ./mlabconfig.py --format=server-network-config \
       --physical \
       --select "${HOSTNAMES}" \
       --label "project=${PROJECT}" \

--- a/setup_stage1_usbs.sh
+++ b/setup_stage1_usbs.sh
@@ -27,7 +27,7 @@ pushd "${BUILD_DIR}"
   curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py" > \
       .mlabconfig.py
   mkdir -p "${OUTPUT_DIR}/scripts"
-  ./mlabconfig.py --format=server-network-config \
+  bash ./mlabconfig.py --format=server-network-config \
       --physical \
       --select "${HOSTNAMES}" \
       --label "project=${PROJECT}" \

--- a/setup_stage1_usbs.sh
+++ b/setup_stage1_usbs.sh
@@ -24,7 +24,8 @@ set -xuo pipefail
 # HOSTNAMES pattern.
 pushd "${BUILD_DIR}"
   # TODO: Replace curl with a native go-get once mlabconfig is rewritten in Go.
-  curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py"
+  curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py" > \
+      .mlabconfig.py
   mkdir -p "${OUTPUT_DIR}/scripts"
   ./mlabconfig.py --format=server-network-config \
       --physical \

--- a/setup_stage1_usbs.sh
+++ b/setup_stage1_usbs.sh
@@ -23,16 +23,14 @@ set -xuo pipefail
 # Use mlabconfig to fill in the template for every machine matching the given
 # HOSTNAMES pattern.
 pushd "${BUILD_DIR}"
-  test -d operator || git clone https://github.com/m-lab/operator
-  pushd operator/plsync
-    mkdir -p "${OUTPUT_DIR}/scripts"
-    ./mlabconfig.py --format=server-network-config \
-        --physical \
-        --select "${HOSTNAMES}" \
-        --label "project=${PROJECT}" \
-        --template_input "${CONFIG_DIR}/create-stage1-usb-template.sh" \
-        --template_output "${BUILD_DIR}/create-stage1-usb-{{hostname}}.sh"
-  popd
+  curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py"
+  mkdir -p "${OUTPUT_DIR}/scripts"
+  ./mlabconfig.py --format=server-network-config \
+      --physical \
+      --select "${HOSTNAMES}" \
+      --label "project=${PROJECT}" \
+      --template_input "${CONFIG_DIR}/create-stage1-usb-template.sh" \
+     --template_output "${BUILD_DIR}/create-stage1-usb-{{hostname}}.sh"
 popd
 
 # Check whether there are any files in the glob pattern.

--- a/setup_stage1_usbs.sh
+++ b/setup_stage1_usbs.sh
@@ -23,6 +23,7 @@ set -xuo pipefail
 # Use mlabconfig to fill in the template for every machine matching the given
 # HOSTNAMES pattern.
 pushd "${BUILD_DIR}"
+  # TODO: Replace curl with a native go-get once mlabconfig is rewritten in Go.
   curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py"
   mkdir -p "${OUTPUT_DIR}/scripts"
   ./mlabconfig.py --format=server-network-config \

--- a/setup_stage1_usbs.sh
+++ b/setup_stage1_usbs.sh
@@ -25,7 +25,7 @@ set -xuo pipefail
 pushd "${BUILD_DIR}"
   # TODO: Replace curl with a native go-get once mlabconfig is rewritten in Go.
   curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py" > \
-      .mlabconfig.py
+      ./mlabconfig.py
   mkdir -p "${OUTPUT_DIR}/scripts"
   python ./mlabconfig.py --format=server-network-config \
       --physical \

--- a/setup_stage1_usbs.sh
+++ b/setup_stage1_usbs.sh
@@ -27,7 +27,7 @@ pushd "${BUILD_DIR}"
   curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py" > \
       .mlabconfig.py
   mkdir -p "${OUTPUT_DIR}/scripts"
-  bash ./mlabconfig.py --format=server-network-config \
+  python ./mlabconfig.py --format=server-network-config \
       --physical \
       --select "${HOSTNAMES}" \
       --label "project=${PROJECT}" \


### PR DESCRIPTION
mlabconfig.py moved from the operator repo to the siteinfo repo as part of the push to remove all platform cluster dependencies on the legacy operator repo.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/131)
<!-- Reviewable:end -->
