### PR TITLE
Increases Cloud Build VM disk size from 200GB to 400GB

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -4,7 +4,7 @@ timeout: 10800s
 # The default disk size is 100GB. However, the stage1 ISOs are pretty big these
 # days. 200GB  should give us some breathing room.
 options:
-  diskSizeGb: 200
+  diskSizeGb: 400
 
 ############################################################################
 # BUILD ARTIFACTS


### PR DESCRIPTION
We got another apparent disk space failure building in mlab-oti. Bumps memory, somewhat arbitrarily, to 2x the previous value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/132)
<!-- Reviewable:end -->
