### PR TITLE
Adds a new karg epoxy.uplink_speed

### DIFF
--- a/actions/stage2/stage1to2.ipxe
+++ b/actions/stage2/stage1to2.ipxe
@@ -77,6 +77,7 @@ set kargs ${kargs} epoxy.report=${report_url}
 set kargs ${kargs} epoxy.allocate_k8s_token=${allocate_k8s_token_url}
 set kargs ${kargs} epoxy.server=${epoxyaddress}
 set kargs ${kargs} epoxy.project=${project}
+set kargs ${kargs} epoxy.uplink_speed=${uplink_speed}
 
 boot vmlinuz ${kargs} || shell
 

--- a/actions/stage3_coreos/stage1to2.json
+++ b/actions/stage3_coreos/stage1to2.json
@@ -23,7 +23,8 @@
             "epoxy.report={{kargs `epoxy.report`}}",
             "epoxy.allocate_k8s_token={{kargs `epoxy.allocate_k8s_token`}}",
             "epoxy.server={{kargs `epoxy.server`}}",
-            "epoxy.project={{kargs `epoxy.project`}}"
+            "epoxy.project={{kargs `epoxy.project`}}",
+            "epoxy.uplink_speed={{kargs `epoxy.uplink_speed`}}"
          ],
          "cmdline" : "net.ifnames=0 coreos.autologin=tty1 autoconf=0"
       },

--- a/actions/stage3_coreos/stage2to3.json
+++ b/actions/stage3_coreos/stage2to3.json
@@ -22,7 +22,8 @@
             "epoxy.report={{kargs `epoxy.report`}}",
             "epoxy.allocate_k8s_token={{kargs `epoxy.allocate_k8s_token`}}",
             "epoxy.server={{kargs `epoxy.server`}}",
-            "epoxy.project={{kargs `epoxy.project`}}"
+            "epoxy.project={{kargs `epoxy.project`}}",
+            "epoxy.uplink_speed={{kargs `epoxy.uplink_speed`}}"
          ],
          "cmdline" : "net.ifnames=0 coreos.autologin=tty1 autoconf=0"
       },

--- a/actions/stage3_mlxupdate/stage1to2.json
+++ b/actions/stage3_mlxupdate/stage1to2.json
@@ -23,7 +23,8 @@
             "epoxy.report={{kargs `epoxy.report`}}",
             "epoxy.allocate_k8s_token={{kargs `epoxy.allocate_k8s_token`}}",
             "epoxy.server={{kargs `epoxy.server`}}",
-            "epoxy.project={{kargs `epoxy.project`}}"
+            "epoxy.project={{kargs `epoxy.project`}}",
+            "epoxy.uplink_speed={{kargs `epoxy.uplink_speed`}}"
          ],
          "cmdline" : "net.ifnames=0 coreos.autologin=tty1 autoconf=0"
       },

--- a/actions/stage3_mlxupdate/stage2to3.json
+++ b/actions/stage3_mlxupdate/stage2to3.json
@@ -22,6 +22,7 @@
             "epoxy.report={{kargs `epoxy.report`}}",
             "epoxy.server={{kargs `epoxy.server`}}",
             "epoxy.project={{kargs `epoxy.project`}}",
+            "epoxy.uplink_speed={{kargs `epoxy.uplink_speed`}}",
             "epoxy.mrom=https://storage.googleapis.com/epoxy-{{kargs `epoxy.project`}}/stage1_mlxrom/latest"
          ],
          "cmdline" : "net.ifnames=0 coreos.autologin=tty1 autoconf=0"

--- a/configs/stage1_isos/create-stage1-iso-template.sh
+++ b/configs/stage1_isos/create-stage1-iso-template.sh
@@ -37,6 +37,9 @@ ARGS="net.ifnames=0 "
 # ePoxy server & project.
 ARGS+="epoxy.project={{project}} "
 
+# Site's uplink speed.
+ARGS+="epoxy.uplink_speed={{uplink_speed}}"
+
 # TODO: Legacy epoxy.ip= format. Remove once canonical form is supported.
 ARGS+="epoxy.ip={{ipv4_address}}::{{ipv4_gateway}}:255.255.255.192:{{hostname}}:eth0:false:{{ipv4_dns1}}:{{ipv4_dns2}} "
 

--- a/configs/stage1_isos/create-stage1-iso-template.sh
+++ b/configs/stage1_isos/create-stage1-iso-template.sh
@@ -38,7 +38,7 @@ ARGS="net.ifnames=0 "
 ARGS+="epoxy.project={{project}} "
 
 # Site's uplink speed.
-ARGS+="epoxy.uplink_speed={{uplink_speed}}"
+ARGS+="epoxy.uplink_speed={{uplink_speed}} "
 
 # TODO: Legacy epoxy.ip= format. Remove once canonical form is supported.
 ARGS+="epoxy.ip={{ipv4_address}}::{{ipv4_gateway}}:255.255.255.192:{{hostname}}:eth0:false:{{ipv4_dns1}}:{{ipv4_dns2}} "

--- a/configs/stage1_mlxrom/stage1-template.ipxe
+++ b/configs/stage1_mlxrom/stage1-template.ipxe
@@ -39,6 +39,9 @@ set hostname {{hostname}}
 # Save the GCP project name.
 set project {{project}}
 
+# Save the site's uplink speed.
+set uplink_speed {{uplink_speed}}
+
 # The ePoxy stage1 URL.
 set stage1_url https://${epoxyaddress}/v1/boot/${hostname}/stage1.ipxe
 

--- a/configs/stage1_usbs/create-stage1-usb-template.sh
+++ b/configs/stage1_usbs/create-stage1-usb-template.sh
@@ -37,7 +37,7 @@ ARGS="net.ifnames=0 "
 ARGS+="epoxy.project={{project}} "
 
 # Site uplink speed.
-ARGS+="epoxy.uplink_speed={{uplink_speed}}"
+ARGS+="epoxy.uplink_speed={{uplink_speed}} "
 
 # TODO: Legacy epoxy.ip= format. Remove once canonical form is supported.
 ARGS+="epoxy.ip={{ipv4_address}}::{{ipv4_gateway}}:255.255.255.192:{{hostname}}:eth0:false:{{ipv4_dns1}}:{{ipv4_dns2}} "

--- a/configs/stage1_usbs/create-stage1-usb-template.sh
+++ b/configs/stage1_usbs/create-stage1-usb-template.sh
@@ -36,6 +36,9 @@ ARGS="net.ifnames=0 "
 # ePoxy server & project.
 ARGS+="epoxy.project={{project}} "
 
+# Site uplink speed.
+ARGS+="epoxy.uplink_speed={{uplink_speed}}"
+
 # TODO: Legacy epoxy.ip= format. Remove once canonical form is supported.
 ARGS+="epoxy.ip={{ipv4_address}}::{{ipv4_gateway}}:255.255.255.192:{{hostname}}:eth0:false:{{ipv4_dns1}}:{{ipv4_dns2}} "
 


### PR DESCRIPTION
As we continue to migrate machines to the k8s platform cluster, it will be important for machines to be aware of the uplink speed at the site where they are deployed so that TCP pacing can be configured correctly, among other possible uses. To achieve this, this PR adds a new `epoxy.uplink_speed` kernel arg, which can later be used the node to configure itself.

These changes have been tested again mlab2.lga0t. You can login there and look at `/proc/cmdlind` to see the result.

This PR should resolve part of #136 . This PR depends on merged PR https://github.com/m-lab/siteinfo/pull/41.

**NOTE**: I believe that in order for this PR to take effect on existing platform cluster nodes, we will need to use `epoxy_admin update` to enable reflashing the NIC, and the reboot every node. @stephen-soltesz, could you confirm whether you believe this to be true as well?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/137)
<!-- Reviewable:end -->
