### PR TITLE
Split stage1 & stage3 image builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
 # Note: when /build location is internal to container fs, i/o is more efficient.
 #
 # Note: larger sets of per-project images are built by Cloud Builder, outside of travis.
-- travis_wait time docker run -it --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+- travis_wait time docker run --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
     -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
     bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate" || false
 - ls -l $TRAVIS_BUILD_DIR/output

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ script:
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
-#- travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
-#    -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
-#    bash -c "umask 0022; /workspace/builder.sh stage3_coreos" || false
-#- ls -l $TRAVIS_BUILD_DIR/output
+- travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+    -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
+    bash -c "umask 0022; /workspace/builder.sh stage3_coreos" || false
+- ls -l $TRAVIS_BUILD_DIR/output
 
 # Build stage3 mlxupdate image.
 #
@@ -51,7 +51,7 @@ script:
 # Note: when /build location is internal to container fs, i/o is more efficient.
 #
 # Note: larger sets of per-project images are built by Cloud Builder, outside of travis.
-- travis_wait time docker run --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+- travis_wait time docker run -t --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
     -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
     bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate" || (tail -100 /workspace/stage3_mlxupdate.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
@@ -60,8 +60,8 @@ script:
 #
 # Note: because this is only *testing* the build and not deploying the
 # artifacts of the build, the ROM version is fake and does not matter.
-- travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
-    -it -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
+- travis_wait time docker run -t -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+    -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
     bash -c "mkdir -p /build && /workspace/builder.sh stage1_mlxrom" || false
 - ls -l $TRAVIS_BUILD_DIR/output/stage1_mlxrom
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ script:
 # Note: when /build location is internal to container fs, i/o is more efficient.
 #
 # Note: larger sets of per-project images are built by Cloud Builder, outside of travis.
-- travis_wait time docker run --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+- travis_wait time docker run -t --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
     -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
     bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate" || false
 - ls -l $TRAVIS_BUILD_DIR/output

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,9 +51,9 @@ script:
 # Note: when /build location is internal to container fs, i/o is more efficient.
 #
 # Note: larger sets of per-project images are built by Cloud Builder, outside of travis.
-- travis_wait time docker run -t --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+- travis_wait time docker run --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
     -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
-    bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate" || false
+    bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate" || (tail -100 /workspace/stage3_mlxupdate.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Build a stage1 ROM images for a test machine.

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ script:
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
-#- travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
-#    -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
-#    bash -c "umask 0022; /workspace/builder.sh stage3_coreos &> /workspace/coreos.log" || (tail -20 coreos.log && false)
-#- ls -l $TRAVIS_BUILD_DIR/output
+- travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+    -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
+    bash -c "umask 0022; /workspace/builder.sh stage3_coreos" || false
+- ls -l $TRAVIS_BUILD_DIR/output
 
 # Build stage3 mlxupdate image.
 #
@@ -53,8 +53,7 @@ script:
 # Note: larger sets of per-project images are built by Cloud Builder, outside of travis.
 - travis_wait time docker run -it --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
     -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
-    bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate"
-#   bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate &> /workspace/stage3_mlxupdate.log" || (tail -20 stage3_mlxupdate.log && false)
+    bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate" || false
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Build a stage1 ROM images for a test machine.
@@ -63,7 +62,7 @@ script:
 # artifacts of the build, the ROM version is fake and does not matter.
 - travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
     -it -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
-    bash -c "mkdir -p /build && /workspace/builder.sh stage1_mlxrom"
+    bash -c "mkdir -p /build && /workspace/builder.sh stage1_mlxrom" || false
 - ls -l $TRAVIS_BUILD_DIR/output/stage1_mlxrom
 
 # NOTE: Build and deployment is managed by CloudBuilder triggers registered in

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ script:
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
-- travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
-    -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
-    bash -c "umask 0022; /workspace/builder.sh stage3_coreos &> /workspace/coreos.log" || (tail -20 coreos.log && false)
-- ls -l $TRAVIS_BUILD_DIR/output
+#- travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+#    -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
+#    bash -c "umask 0022; /workspace/builder.sh stage3_coreos &> /workspace/coreos.log" || (tail -20 coreos.log && false)
+#- ls -l $TRAVIS_BUILD_DIR/output
 
 # Build stage3 mlxupdate image.
 #
@@ -53,7 +53,8 @@ script:
 # Note: larger sets of per-project images are built by Cloud Builder, outside of travis.
 - travis_wait time docker run -it --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
     -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
-    bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate &> /workspace/stage3_mlxupdate.log" || (tail -20 stage3_mlxupdate.log && false)
+    bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate"
+#   bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate &> /workspace/stage3_mlxupdate.log" || (tail -20 stage3_mlxupdate.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Build a stage1 ROM images for a test machine.

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ script:
 
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
-- travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
-    -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
-    bash -c "umask 0022; /workspace/builder.sh stage3_coreos" || false
-- ls -l $TRAVIS_BUILD_DIR/output
+#- travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+#    -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
+#    bash -c "umask 0022; /workspace/builder.sh stage3_coreos" || false
+#- ls -l $TRAVIS_BUILD_DIR/output
 
 # Build stage3 mlxupdate image.
 #

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,28 +34,12 @@ script:
 
 - mkdir -p $TRAVIS_BUILD_DIR/output
 
-# Build stage2 vmlinuz image.
-# TODO: clean up args to setup_stage2.sh script.
-# TODO: use alternative to travis_wait to allow build with no output for longer
-#       than 10m.
-- time docker run -t -v $TRAVIS_BUILD_DIR:/images epoxy-images-builder
-      bash -c "/images/setup_stage2.sh
-         /buildtmp
-         /images/vendor
-         /images/configs/stage2
-         /images/output/stage2_initramfs.cpio.gz
-         /images/output/stage2_vmlinuz
-         /images/output/epoxy_client /images/stage2.log
-         /images/travis/one_line_per_minute.awk" || (cat stage2.log && false)
-
 # Build coreos custom initram image.
 # Note: set the umask so the travis user can read newly created files.
-- travis_wait time docker run -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
-      bash -c "umask 0022; /images/setup_stage3_coreos.sh /images/configs/stage3_coreos
-        /images/output/epoxy_client
-        http://stable.release.core-os.net/amd64-usr/$COREOS_VERSION/coreos_production_pxe.vmlinuz
-        http://stable.release.core-os.net/amd64-usr/$COREOS_VERSION/coreos_production_pxe_image.cpio.gz
-        /images/output/coreos_custom_pxe_image.cpio.gz &> /images/coreos.log" || (tail -20 coreos.log && false)
+- travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+    -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
+    bash -c "umask 0022; /workspace/builder.sh stage3_coreos &> /workspace/coreos.log" || (tail -20 coreos.log && false)
+- ls -l $TRAVIS_BUILD_DIR/output
 
 # Build stage3 mlxupdate image.
 #
@@ -69,39 +53,21 @@ script:
 # Note: when /build location is internal to container fs, i/o is more efficient.
 #
 # Note: larger sets of per-project images are built by Cloud Builder, outside of travis.
-- time docker run -it --privileged -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
-      bash -c "umask 0022; install -D -m 644 /images/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
+- travis_wait time docker run -it --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+    -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
+    bash -c "umask 0022; install -D -m 644 /workspace/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
         && echo 'Starting stage3_mlxupdate build'
-        && /images/setup_stage3_mlxupdate.sh
-                /build /images/output /images/configs/stage3_mlxupdate
-                /images/output/epoxy_client
-          &> /images/stage3_mlxupdate.log"
-        || (tail stage3_mlxupdate.log && false)
+        && /workspace/builder.sh stage3_mlxupdate &> /workspace/stage3_mlxupdate.log" || (tail -20 stage3_mlxupdate.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Build a stage1 ROM images for a test machine.
 #
 # Note: because this is only *testing* the build and not deploying the
 # artifacts of the build, the ROM version is fake and does not matter.
-- time docker run -it -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
-      bash -c "mkdir -p /build
-        && echo 'Starting stage1_mlxrom build'
-        && /images/setup_stage1.sh mlab-sandbox /build /images/output
-              /images/configs/stage1_mlxrom 'mlab4.lga1t.*' '3.4.111'
-              /images/configs/stage1_mlxrom/gtsgiag3.pem"
-
-# Build a stage1 ISO image for a test machine.
-#- time docker run -it -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
-#      bash -c "mkdir -p /build
-#        && echo 'Starting stage1_isos build'
-#        && /images/setup_stage1_isos.sh mlab-sandbox /build
-#              /images/output /images/configs/stage1_isos 'mlab4.lga1t.*'"
-
-# Build a skeleton bootstrapfs for the modified PlanetLab bootmanager.
-- time docker run -it -v $TRAVIS_BUILD_DIR:/images -w /images epoxy-images-builder
-      bash -c "/images/setup_stage1_bootstrapfs.sh
-        /images/output/epoxy_client
-        /images/output/bootstrapfs-MeasurementLabUpdate.tar.bz2"
+- travis_wait time docker run -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
+    -it -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
+    bash -c "mkdir -p /build && /workspace/builder.sh stage1_mlxrom"
+- ls -l $TRAVIS_BUILD_DIR/output/stage1_mlxrom
 
 # NOTE: Build and deployment is managed by CloudBuilder triggers registered in
 # each GCP project and the steps defined in cloudbuild.yaml.

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,9 +11,6 @@
 #  * on success, deploy the result to the correct Cloud Storage bucket when
 #    the target branch matches a supported deployment target.
 
-env:
-- COREOS_VERSION="2135.6.0"
-
 services:
 - docker
 
@@ -46,7 +43,8 @@ script:
 # Note: download the mellanox firmware tools from cache in private bucket,
 #       since origin (http://www.mellanox.com/downloads/MFT/mft-4.4.0-44.tgz)
 #       is sloooow.
-- gsutil cp gs://vendor-mlab-oti/epoxy-images/mft-4.4.0-44.tgz $TRAVIS_BUILD_DIR/
+- mkdir -p $TRAVIS_BUILD_DIR/vendor/
+- gsutil cp gs://vendor-mlab-oti/epoxy-images/mft-4.4.0-44.tgz $TRAVIS_BUILD_DIR/vendor/
 
 # Note: build must be privileged to mount /proc & /sys during debootstrap build.
 #
@@ -55,9 +53,7 @@ script:
 # Note: larger sets of per-project images are built by Cloud Builder, outside of travis.
 - travis_wait time docker run -it --privileged -e PROJECT=mlab-sandbox -e ARTIFACTS=/workspace/output
     -v $TRAVIS_BUILD_DIR:/workspace -w /workspace epoxy-images-builder
-    bash -c "umask 0022; install -D -m 644 /workspace/mft-4.4.0-44.tgz /build/mft-4.4.0-44.tgz
-        && echo 'Starting stage3_mlxupdate build'
-        && /workspace/builder.sh stage3_mlxupdate &> /workspace/stage3_mlxupdate.log" || (tail -20 stage3_mlxupdate.log && false)
+    bash -c "umask 0022; /workspace/builder.sh stage3_mlxupdate &> /workspace/stage3_mlxupdate.log" || (tail -20 stage3_mlxupdate.log && false)
 - ls -l $TRAVIS_BUILD_DIR/output
 
 # Build a stage1 ROM images for a test machine.

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,12 @@ RUN apt-get install -y unzip python-pip git vim-nox make autoconf gcc mkisofs \
     linux-source-4.4.0=4.4.0-104.127 golang-1.9 xorriso
 ENV PATH /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/lib/go-1.9/bin
 ENV GOROOT /usr/lib/go-1.9
+RUN mkdir /go
+ENV GOPATH /go
+# CGO_ENABLED=0 creates a statically linked binary.
+# The -ldflags drop another 2.5MB from the binary size.
+# -w 	Omit the DWARF symbol table.
+# -s 	Omit the symbol table and debug information.
+RUN CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/epoxy/cmd/epoxy_client
 # TODO: remove pinned version on linux-source-4.4.0.
 #       https://github.com/m-lab/epoxy-images/issues/16

--- a/README.md
+++ b/README.md
@@ -16,19 +16,12 @@ An ePoxy managed system depends on several image types:
 
 The epoxy-images repo is connected to Google Cloud Build.
 
-* mlab-sandbox
-
-  - push to a branch matching `sandbox-*` builds using cloudbuild.yaml
-  - push to a branch matching `stage1-*` builds using cloudbuild-stage1.yaml
-
-* mlab-staging
-
-  - push to master builds both cloudbuild.yaml and cloudbuild-stage1.yaml
-
-* mlab-oti
-
-  - tags matching `v[0-9]+.[0-9]+.[0-9]+` builds using cloudbuild.yaml
-  - tags matching `v[0-9]+.[0-9]+.[0-9]+-stage1` builds using cloudbuild-stage1.yaml
+* mlab-sandbox - push to a branch matching `sandbox-*` builds cloudbuild.yaml &
+  cloudbuild-stage1.yaml.
+* mlab-staging - push to `master` builds both cloudbuild.yaml and
+  cloudbuild-stage1.yaml
+* mlab-oti - tags matching `v[0-9]+.[0-9]+.[0-9]+` builds cloudbuild.yaml &
+  cloudbuild-stage1.yaml
 
 # Building images
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,24 @@ An ePoxy managed system depends on several image types:
  * stage2 Linux images that provide a minimal network boot environment.
  * stage3 Linux ROM update images, that (re)flash iPXE ROMs to NICs.
 
+# Build Automation
+
+The epoxy-images repo is connected to Google Cloud Build.
+
+* mlab-sandbox
+
+  - push to a branch matching `sandbox-*` builds using cloudbuild.yaml
+  - push to a branch matching `stage1-*` builds using cloudbuild-stage1.yaml
+
+* mlab-staging
+
+  - push to master builds both cloudbuild.yaml and cloudbuild-stage1.yaml
+
+* mlab-oti
+
+  - tags matching `v[0-9]+.[0-9]+.[0-9]+` builds using cloudbuild.yaml
+  - tags matching `v[0-9]+.[0-9]+.[0-9]+-stage1` builds using cloudbuild-stage1.yaml
+
 # Building images
 
 ## Building stage1 iPXE ROMs

--- a/builder.sh
+++ b/builder.sh
@@ -113,7 +113,7 @@ function stage1_minimal() {
   echo 'Starting stage1_minimal build'
   ${SOURCE_DIR}/setup_stage1_minimal.sh \
       ${builddir} ${artifacts} ${SOURCE_DIR}/configs/${target} \
-      /go/bin/epoxy_client &> ${SOURCE_DIR}/stage1_minimal.log
+      /go/bin/epoxy_client
 
   rm -rf ${builddir}
 }

--- a/builder.sh
+++ b/builder.sh
@@ -99,7 +99,10 @@ function stage3_mlxupdate() {
   echo 'Starting stage3_mlxupdate build'
   ${SOURCE_DIR}/setup_stage3_mlxupdate.sh \
       ${builddir} ${artifacts} ${SOURCE_DIR}/configs/${target} \
-      /go/bin/epoxy_client &> ${SOURCE_DIR}/stage3_mlxupdate.log
+      /go/bin/epoxy_client &> ${SOURCE_DIR}/stage3_mlxupdate.log \
+  || (
+      tail -100 ${SOURCE_DIR}/stage3_mlxupdate.log && false
+  )
 
   rm -rf ${builddir}
 }

--- a/builder.sh
+++ b/builder.sh
@@ -7,6 +7,8 @@
 set -eu
 SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
 
+source "${SOURCE_DIR}/config.sh"
+
 USAGE="$0 <target>"
 TARGET=${1:?Please provide a build target: $USAGE}
 
@@ -15,7 +17,7 @@ function stage1_mlxrom() {
   local project=${PROJECT:?Please specify the PROJECT}
   local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
   local version=${MLXROM_VERSION:?Please define the MLXROM_VERSION to build}
-  local regex_name="REGEXP_${PROJECT//-/_}"
+  local regex_name="MLXROM_REGEXP_${PROJECT//-/_}"
 
   local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
 
@@ -38,7 +40,7 @@ function stage1_bootstrapfs() {
   local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
 
   ${SOURCE_DIR}/setup_stage1_bootstrapfs.sh \
-      ${artifacts}/epoxy_client \
+      /go/bin/epoxy_client \
       ${artifacts}/bootstrapfs-MeasurementLabUpdate.tar.bz2
 
   rm -rf "${builddir}"
@@ -54,7 +56,7 @@ function stage2() {
      "${SOURCE_DIR}/configs/${target}" \
      "${artifacts}/stage2_initramfs.cpio.gz" \
      "${artifacts}/stage2_vmlinuz" \
-     "${artifacts}/epoxy_client" \
+      /go/bin/epoxy_client \
      "${SOURCE_DIR}/stage2.log" \
      "${SOURCE_DIR}/travis/one_line_per_minute.awk" \
   || (
@@ -74,7 +76,7 @@ function stage3_coreos() {
   umask 0022
   ${SOURCE_DIR}/setup_stage3_coreos.sh \
       "${SOURCE_DIR}/configs/${target}" \
-      "${artifacts}/epoxy_client" \
+      /go/bin/epoxy_client \
       http://stable.release.core-os.net/amd64-usr/${version}/coreos_production_pxe.vmlinuz \
       http://stable.release.core-os.net/amd64-usr/${version}/coreos_production_pxe_image.cpio.gz \
       "${artifacts}/coreos_custom_pxe_image.cpio.gz" &> ${SOURCE_DIR}/coreos.log \
@@ -97,7 +99,7 @@ function stage3_mlxupdate() {
   echo 'Starting stage3_mlxupdate build'
   ${SOURCE_DIR}/setup_stage3_mlxupdate.sh \
       ${builddir} ${artifacts} ${SOURCE_DIR}/configs/${target} \
-      ${artifacts}/epoxy_client &> ${SOURCE_DIR}/stage3_mlxupdate.log
+      /go/bin/epoxy_client &> ${SOURCE_DIR}/stage3_mlxupdate.log
 
   rm -rf ${builddir}
 }
@@ -111,7 +113,7 @@ function stage1_minimal() {
   echo 'Starting stage1_minimal build'
   ${SOURCE_DIR}/setup_stage1_minimal.sh \
       ${builddir} ${artifacts} ${SOURCE_DIR}/configs/${target} \
-      ${artifacts}/epoxy_client &> ${SOURCE_DIR}/stage1_minimal.log
+      /go/bin/epoxy_client &> ${SOURCE_DIR}/stage1_minimal.log
 
   rm -rf ${builddir}
 }
@@ -120,7 +122,7 @@ function stage1_isos() {
   local target=${TARGET:?Please specify a target configuration name}
   local project=${PROJECT:?Please specify the PROJECT}
   local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
-  local regex_name="REGEXP_${PROJECT//-/_}"
+  local regex_name="ISO_REGEXP_${PROJECT//-/_}"
 
   local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
 
@@ -135,7 +137,7 @@ function stage1_usbs() {
   local target=${TARGET:?Please specify a target configuration name}
   local project=${PROJECT:?Please specify the PROJECT}
   local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
-  local regex_name="REGEXP_${PROJECT//-/_}"
+  local regex_name="USB_REGEXP_${PROJECT//-/_}"
 
   local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
 

--- a/builder.sh
+++ b/builder.sh
@@ -148,6 +148,7 @@ function stage1_usbs() {
   return
 }
 
+mkdir -p ${ARTIFACTS}
 case "${TARGET}" in
   stage1_mlxrom)
       stage1_mlxrom

--- a/builder.sh
+++ b/builder.sh
@@ -99,10 +99,10 @@ function stage3_mlxupdate() {
   echo 'Starting stage3_mlxupdate build'
   ${SOURCE_DIR}/setup_stage3_mlxupdate.sh \
       ${builddir} ${artifacts} ${SOURCE_DIR}/configs/${target} \
-      /go/bin/epoxy_client &> ${SOURCE_DIR}/stage3_mlxupdate.log \
-  || (
-      tail -100 ${SOURCE_DIR}/stage3_mlxupdate.log && false
-  )
+      /go/bin/epoxy_client #&> ${SOURCE_DIR}/stage3_mlxupdate.log \
+  #|| (
+  #    tail -100 ${SOURCE_DIR}/stage3_mlxupdate.log && false
+  #)
 
   rm -rf ${builddir}
 }

--- a/builder.sh
+++ b/builder.sh
@@ -4,6 +4,11 @@
 # parameter (target) and multiple parameters from the environment. builder.sh
 # transalates these into calls to specific build scripts.
 
+# Kill background wait loop on exit.
+trap 'kill $(jobs -p)' EXIT
+# Print periodic messages for travis.
+while true ; do echo "waiting 300 sec";  sleep 300 ; done &
+
 set -eu
 SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
 
@@ -99,10 +104,10 @@ function stage3_mlxupdate() {
   echo 'Starting stage3_mlxupdate build'
   ${SOURCE_DIR}/setup_stage3_mlxupdate.sh \
       ${builddir} ${artifacts} ${SOURCE_DIR}/configs/${target} \
-      /go/bin/epoxy_client #&> ${SOURCE_DIR}/stage3_mlxupdate.log \
-  #|| (
-  #    tail -100 ${SOURCE_DIR}/stage3_mlxupdate.log && false
-  #)
+      /go/bin/epoxy_client &> ${SOURCE_DIR}/stage3_mlxupdate.log \
+  || (
+      tail -100 ${SOURCE_DIR}/stage3_mlxupdate.log && false
+  )
 
   rm -rf ${builddir}
 }

--- a/cloudbuild-stage1.yaml
+++ b/cloudbuild-stage1.yaml
@@ -2,9 +2,12 @@
 timeout: 10800s
 
 # The default disk size is 100GB. However, the stage1 ISOs are pretty big these
-# days. 200GB  should give us some breathing room.
+# days. 400GB  should give us some breathing room.
 options:
   diskSizeGb: 400
+  env:
+    - 'PROJECT=$PROJECT_ID'
+    - 'ARTIFACTS=/workspace/output'
 
 ############################################################################
 # BUILD ARTIFACTS
@@ -28,18 +31,12 @@ steps:
   args: [
     '/workspace/builder.sh', 'stage1_minimal'
   ]
-  env:
-   - 'PROJECT=$PROJECT_ID'
-   - 'ARTIFACTS=/workspace/output'
 
 # stage1 ROMs.
 - name: epoxy-images-builder
   args: [
     '/workspace/builder.sh', 'stage1_mlxrom'
   ]
-  env:
-   - 'PROJECT=$PROJECT_ID'  # One of: mlab-sandbox, mlab-staging, or mlab-oti.
-   - 'ARTIFACTS=/workspace/output'
 
 # stage1 ISOs
 # NOTE: must run after stage1_minimal so that kernel & initram are available.
@@ -47,25 +44,6 @@ steps:
   args: [
     '/workspace/builder.sh', 'stage1_isos'
   ]
-  env:
-   - 'PROJECT=$PROJECT_ID'
-   - 'ARTIFACTS=/workspace/output'
-   - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
-   - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
-   - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
-
-# stage1 USBs
-# NOTE: must run after stage1_minimal so that kernel & initram are available.
-- name: epoxy-images-builder
-  args: [
-    '/workspace/builder.sh', 'stage1_usbs'
-  ]
-  env:
-   - 'PROJECT=$PROJECT_ID'
-   - 'ARTIFACTS=/workspace/output'
-   - 'REGEXP_mlab_sandbox=mlab[1-4].lga1t.*'
-   - 'REGEXP_mlab_staging=mlab4.hnd01.*'
-   - 'REGEXP_mlab_oti=mlab[1-3].hnd01.*'
 
 ############################################################################
 # DEPLOY ARTIFACTS

--- a/cloudbuild-stage1.yaml
+++ b/cloudbuild-stage1.yaml
@@ -12,10 +12,10 @@ options:
 
 steps:
 # Fetch all submodules.
-#- name: gcr.io/cloud-builders/git
-#  args: [
-#    'submodule', 'update', '--init', '--recursive'
-#  ]
+- name: gcr.io/cloud-builders/git
+  args: [
+    'submodule', 'update', '--init', '--recursive'
+  ]
 
 # Create the image builder for later steps.
 - name: gcr.io/cloud-builders/docker

--- a/cloudbuild-stage1.yaml
+++ b/cloudbuild-stage1.yaml
@@ -1,0 +1,111 @@
+# Timeout for complete build. Default is 10m.
+timeout: 10800s
+
+# The default disk size is 100GB. However, the stage1 ISOs are pretty big these
+# days. 200GB  should give us some breathing room.
+options:
+  diskSizeGb: 400
+
+############################################################################
+# BUILD ARTIFACTS
+############################################################################
+
+steps:
+# Fetch all submodules.
+#- name: gcr.io/cloud-builders/git
+#  args: [
+#    'submodule', 'update', '--init', '--recursive'
+#  ]
+
+# Create the image builder for later steps.
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build', '-t', 'epoxy-images-builder', '.'
+  ]
+
+# stage1 minimal kernel & initram using stock ubuntu kernel.
+- name: epoxy-images-builder
+  args: [
+    '/workspace/builder.sh', 'stage1_minimal'
+  ]
+  env:
+   - 'PROJECT=$PROJECT_ID'
+   - 'ARTIFACTS=/workspace/output'
+
+# stage1 ROMs.
+- name: epoxy-images-builder
+  args: [
+    '/workspace/builder.sh', 'stage1_mlxrom'
+  ]
+  env:
+   - 'PROJECT=$PROJECT_ID'  # One of: mlab-sandbox, mlab-staging, or mlab-oti.
+   - 'ARTIFACTS=/workspace/output'
+
+# stage1 ISOs
+# NOTE: must run after stage1_minimal so that kernel & initram are available.
+- name: epoxy-images-builder
+  args: [
+    '/workspace/builder.sh', 'stage1_isos'
+  ]
+  env:
+   - 'PROJECT=$PROJECT_ID'
+   - 'ARTIFACTS=/workspace/output'
+   - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
+   - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
+   - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
+
+# stage1 USBs
+# NOTE: must run after stage1_minimal so that kernel & initram are available.
+- name: epoxy-images-builder
+  args: [
+    '/workspace/builder.sh', 'stage1_usbs'
+  ]
+  env:
+   - 'PROJECT=$PROJECT_ID'
+   - 'ARTIFACTS=/workspace/output'
+   - 'REGEXP_mlab_sandbox=mlab[1-4].lga1t.*'
+   - 'REGEXP_mlab_staging=mlab4.hnd01.*'
+   - 'REGEXP_mlab_oti=mlab[1-3].hnd01.*'
+
+############################################################################
+# DEPLOY ARTIFACTS
+#
+# Note: the artifacts built above need to be copied to specific locations in
+# the target bucket. Currently, the cloudbuilder 'artifacts' directive does
+# not support multiple target locations. So, the steps below are explicit.
+############################################################################
+
+# stage1_mlxrom.
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
+    'cp', '-r', '/workspace/output/stage1_mlxrom/*',
+    'gs://epoxy-$PROJECT_ID/stage1_mlxrom/'
+  ]
+
+# Deploy stage1_mlxrom images again to the 'latest' directory (without version).
+- name: gcr.io/cloud-builders/gsutil
+  # NOTE: use bash as the entry point to take advantage of bash file globbing.
+  entrypoint: bash
+  args:
+   - -c
+   - >
+     gsutil -h "Cache-Control:private, max-age=0, no-transform" -m
+     cp -r /workspace/output/stage1_mlxrom/*/*
+     gs://epoxy-$PROJECT_ID/stage1_mlxrom/latest/
+
+# stage1_isos.
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
+    'cp', '-r', '/workspace/output/stage1_isos/*',
+    'gs://epoxy-$PROJECT_ID/stage1_isos/'
+  ]
+
+# stage1_usbs
+- name: gcr.io/cloud-builders/gsutil
+  args: [
+    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
+    'cp', '-r', '/workspace/output/stage1_usbs/*',
+    'gs://epoxy-$PROJECT_ID/stage1_usbs/'
+  ]

--- a/cloudbuild-stage1.yaml
+++ b/cloudbuild-stage1.yaml
@@ -79,11 +79,3 @@ steps:
     'cp', '-r', '/workspace/output/stage1_isos/*',
     'gs://epoxy-$PROJECT_ID/stage1_isos/'
   ]
-
-# stage1_usbs
-- name: gcr.io/cloud-builders/gsutil
-  args: [
-    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
-    'cp', '-r', '/workspace/output/stage1_usbs/*',
-    'gs://epoxy-$PROJECT_ID/stage1_usbs/'
-  ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -23,32 +23,6 @@ steps:
     'build', '-t', 'epoxy-images-builder', '.'
   ]
 
-# stage1 ROMs.
-- name: epoxy-images-builder
-  args: [
-    '/workspace/builder.sh', 'stage1_mlxrom'
-  ]
-  env:
-   - 'PROJECT=$PROJECT_ID'  # One of: mlab-sandbox, mlab-staging, or mlab-oti.
-   - 'ARTIFACTS=/workspace/output'
-   - 'MLXROM_VERSION=3.4.816'
-   - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
-   - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
-   - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
-
-# stage2 kernel.
-#
-# TODO: retire stage2 kernel in favor of stage1 minimal. We must keep it
-# temporarily because it builds the epoxy_client embedded in other images
-# below.
-- name: epoxy-images-builder
-  args: [
-    '/workspace/builder.sh', 'stage2'
-  ]
-  env:
-   - 'PROJECT=$PROJECT_ID'
-   - 'ARTIFACTS=/workspace/output'
-
 # stage1 minimal kernel & initram using stock ubuntu kernel.
 - name: epoxy-images-builder
   args: [
@@ -68,32 +42,6 @@ steps:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
 
-# stage1 ISOs
-# NOTE: must run after stage1_minimal so that kernel & initram are available.
-- name: epoxy-images-builder
-  args: [
-    '/workspace/builder.sh', 'stage1_isos'
-  ]
-  env:
-   - 'PROJECT=$PROJECT_ID'
-   - 'ARTIFACTS=/workspace/output'
-   - 'REGEXP_mlab_sandbox=mlab[1-4].[a-z]{3}[0-9]t.*'
-   - 'REGEXP_mlab_staging=mlab4.[a-z]{3}[0-9]{2}.*'
-   - 'REGEXP_mlab_oti=mlab[1-3].[a-z]{3}[0-9]{2}.*'
-
-# stage1 USBs
-# NOTE: must run after stage1_minimal so that kernel & initram are available.
-- name: epoxy-images-builder
-  args: [
-    '/workspace/builder.sh', 'stage1_usbs'
-  ]
-  env:
-   - 'PROJECT=$PROJECT_ID'
-   - 'ARTIFACTS=/workspace/output'
-   - 'REGEXP_mlab_sandbox=mlab[1-4].lga1t.*'
-   - 'REGEXP_mlab_staging=mlab4.hnd01.*'
-   - 'REGEXP_mlab_oti=mlab[1-3].hnd01.*'
-
 # stage3_coreos images.
 - name: epoxy-images-builder
   args: [
@@ -102,10 +50,6 @@ steps:
   env:
    - 'PROJECT=$PROJECT_ID'
    - 'ARTIFACTS=/workspace/output'
-   - 'COREOS_VERSION=2135.6.0'
-   - 'K8S_VERSION=v1.13.5'
-   - 'CRI_VERSION=v1.13.0'
-   - 'CNI_VERSION=v0.7.5'
 
 # stage3_mlxupdate images.
 # NOTE: all project cloudbuild service accounts must be granted READ access to
@@ -130,25 +74,6 @@ steps:
 # not support multiple target locations. So, the steps below are explicit.
 ############################################################################
 
-# stage1_mlxrom.
-- name: gcr.io/cloud-builders/gsutil
-  args: [
-    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
-    'cp', '-r', '/workspace/output/stage1_mlxrom/*',
-    'gs://epoxy-$PROJECT_ID/stage1_mlxrom/'
-  ]
-
-# Deploy stage1_mlxrom images again to the 'latest' directory (without version).
-- name: gcr.io/cloud-builders/gsutil
-  # NOTE: use bash as the entry point to take advantage of bash file globbing.
-  entrypoint: bash
-  args:
-   - -c
-   - >
-     gsutil -h "Cache-Control:private, max-age=0, no-transform" -m
-     cp -r /workspace/output/stage1_mlxrom/*/*
-     gs://epoxy-$PROJECT_ID/stage1_mlxrom/latest/
-
 # stage1_bootstrapfs.
 - name: gcr.io/cloud-builders/gsutil
   args: [
@@ -157,28 +82,11 @@ steps:
     'gs://epoxy-$PROJECT_ID/stage1_bootstrapfs/'
   ]
 
-# stage1_isos.
-- name: gcr.io/cloud-builders/gsutil
-  args: [
-    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
-    'cp', '-r', '/workspace/output/stage1_isos/*',
-    'gs://epoxy-$PROJECT_ID/stage1_isos/'
-  ]
-
-# stage1_usbs
-- name: gcr.io/cloud-builders/gsutil
-  args: [
-    '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
-    'cp', '-r', '/workspace/output/stage1_usbs/*',
-    'gs://epoxy-$PROJECT_ID/stage1_usbs/'
-  ]
-
 # stage3_coreos.
 - name: gcr.io/cloud-builders/gsutil
   args: [
     '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
     'cp', '-r',
-    '/workspace/output/stage2_vmlinuz',
     '/workspace/output/vmlinuz_stage1_minimal',
     '/workspace/output/initramfs_stage1_minimal.cpio.gz',
     '/workspace/output/coreos_custom_pxe_image.cpio.gz',
@@ -193,7 +101,6 @@ steps:
   args: [
     '-h', 'Cache-Control:private, max-age=0, no-transform', '-m',
     'cp', '-r',
-    '/workspace/output/stage2_vmlinuz',
     '/workspace/output/vmlinuz_stage1_minimal',
     '/workspace/output/initramfs_stage1_minimal.cpio.gz',
     '/workspace/output/vmlinuz_stage3_mlxupdate',

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -2,9 +2,12 @@
 timeout: 10800s
 
 # The default disk size is 100GB. However, the stage1 ISOs are pretty big these
-# days. 200GB  should give us some breathing room.
+# days. 400GB  should give us some breathing room.
 options:
   diskSizeGb: 400
+  env:
+    - 'PROJECT=$PROJECT_ID'
+    - 'ARTIFACTS=/workspace/output'
 
 ############################################################################
 # BUILD ARTIFACTS
@@ -28,9 +31,6 @@ steps:
   args: [
     '/workspace/builder.sh', 'stage1_minimal'
   ]
-  env:
-   - 'PROJECT=$PROJECT_ID'
-   - 'ARTIFACTS=/workspace/output'
 
 # stage1 bootstrapfs for PlanetLab updates.
 # NOTE: this must run after stage2 so that the epoxy_client is available.
@@ -38,18 +38,12 @@ steps:
   args: [
     '/workspace/builder.sh', 'stage1_bootstrapfs'
   ]
-  env:
-   - 'PROJECT=$PROJECT_ID'
-   - 'ARTIFACTS=/workspace/output'
 
 # stage3_coreos images.
 - name: epoxy-images-builder
   args: [
     '/workspace/builder.sh', 'stage3_coreos'
   ]
-  env:
-   - 'PROJECT=$PROJECT_ID'
-   - 'ARTIFACTS=/workspace/output'
 
 # stage3_mlxupdate images.
 # NOTE: all project cloudbuild service accounts must be granted READ access to
@@ -62,9 +56,6 @@ steps:
   args: [
     '/workspace/builder.sh', 'stage3_mlxupdate'
   ]
-  env:
-   - 'PROJECT=$PROJECT_ID'
-   - 'ARTIFACTS=/workspace/output'
 
 ############################################################################
 # DEPLOY ARTIFACTS

--- a/config.sh
+++ b/config.sh
@@ -1,0 +1,24 @@
+# Common configuration for epoxy image builds. All builds source this file for
+# relevant settings.
+
+# stage3 coreos
+COREOS_VERSION=2135.6.0
+K8S_VERSION=v1.13.5
+CRI_VERSION=v1.13.0
+CNI_VERSION=v0.7.5
+
+# stage1 mlxrom
+MLXROM_VERSION=3.4.816
+MLXROM_REGEXP_mlab_sandbox='mlab[1-4].[a-z]{3}[0-9]t.*'
+MLXROM_REGEXP_mlab_staging='mlab4.[a-z]{3}[0-9]{2}.*'
+MLXROM_REGEXP_mlab_oti='mlab[1-3].[a-z]{3}[0-9]{2}.*'
+
+# stage1 isos
+ISO_REGEXP_mlab_sandbox='mlab[1-4].[a-z]{3}[0-9]t.*'
+ISO_REGEXP_mlab_staging='mlab4.[a-z]{3}[0-9]{2}.*'
+ISO_REGEXP_mlab_oti='mlab[1-3].[a-z]{3}[0-9]{2}.*'
+
+# stage1 usbs
+USB_REGEXP_mlab_sandbox='mlab[1-4].lga1t.*'
+USB_REGEXP_mlab_staging='mlab4.hnd01.*'
+USB_REGEXP_mlab_oti='mlab[1-3].hnd01.*'

--- a/config.sh
+++ b/config.sh
@@ -17,8 +17,3 @@ MLXROM_REGEXP_mlab_oti='mlab[1-3].[a-z]{3}[0-9]{2}.*'
 ISO_REGEXP_mlab_sandbox='mlab[1-4].[a-z]{3}[0-9]t.*'
 ISO_REGEXP_mlab_staging='mlab4.[a-z]{3}[0-9]{2}.*'
 ISO_REGEXP_mlab_oti='mlab[1-3].[a-z]{3}[0-9]{2}.*'
-
-# stage1 usbs
-USB_REGEXP_mlab_sandbox='mlab[1-4].lga1t.*'
-USB_REGEXP_mlab_staging='mlab4.hnd01.*'
-USB_REGEXP_mlab_oti='mlab[1-3].hnd01.*'

--- a/configs/stage1_isos/create-stage1-iso-template.sh
+++ b/configs/stage1_isos/create-stage1-iso-template.sh
@@ -20,7 +20,7 @@ if [[ "{{ipv4_netmask}}" != "255.255.255.192" ]] ; then
   exit 1
 fi
 
-if [[ ! -f "${IMAGE_DIR}/stage2_vmlinuz" ]] ; then
+if [[ ! -f "${IMAGE_DIR}/vmlinuz_stage1_minimal" ]] ; then
     echo 'Error: vmlinuz images not found!'
     echo "Expected: stage2_vmlinuz"
     exit 1


### PR DESCRIPTION
The principle reason for this change is to split the stage1 & stage3 image builds by creating two cloudbuild.yaml (fast, generic, & default) and cloudbuild-stage1.yaml (slower, per-machine, and special tags).

At the same time, this change updates .travis.yml to invoke builder.sh, which now reads a single config source to fix https://github.com/m-lab/epoxy-images/issues/130

This change also removes stage2 by placing the build of epoxy_client in the epoxy-image-builder.

Part of https://github.com/m-lab/epoxy-images/issues/141

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/143)
<!-- Reviewable:end -->
