### PR TITLE
Removes the 2nd IPv6 DNS nameserver entry.

### DIFF
--- a/configs/stage3_coreos/resources/generate_network_config.sh
+++ b/configs/stage3_coreos/resources/generate_network_config.sh
@@ -86,6 +86,5 @@ DNS=$DNS2_IPv4
 Address=$ADDR_IPv6
 Gateway=$GATEWAY_IPv6
 DNS=$DNS1_IPv6
-DNS=$DNS2_IPv6
 IPv6AcceptRA=no
 EOF


### PR DESCRIPTION
systemd is complaining about too many configured nameserver (more than 3) in /etc/resolv.conf:

```
nameserver 8.8.8.8
nameserver 8.8.4.4
nameserver 2001:4860:4860::8888
# Too many DNS servers configured, the following entries may be ignored.
nameserver 2001:4860:4860::8844
```
And kubelet is constantly complaining too:

```
dns.go:132] Nameserver limits were exceeded, some nameservers have been omitted, the applied nameserver line is: 8.8.8.8 8.8.4.4 2001:4860:4860::8888
```

This PR should stop these warnings, which are polluting logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/144)
<!-- Reviewable:end -->
