### PR TITLE
Add drac.ipv4 to the stage1 kernel arguments

### DIFF
--- a/configs/stage1_isos/create-stage1-iso-template.sh
+++ b/configs/stage1_isos/create-stage1-iso-template.sh
@@ -52,7 +52,10 @@ else
 fi
 
 # ePoxy stage1 URL.
-ARGS+="epoxy.stage1=https://epoxy-boot-api.{{project}}.measurementlab.net/v1/boot/{{hostname}}/stage1.json"
+ARGS+="epoxy.stage1=https://epoxy-boot-api.{{project}}.measurementlab.net/v1/boot/{{hostname}}/stage1.json "
+
+# DRAC IPv4 address.
+ARGS+="drac.ipv4={{drac_ipv4_address}}"
 
 ${SOURCE_DIR}/simpleiso -x "$ARGS" \
     -i "${IMAGE_DIR}"/initramfs_stage1_minimal.cpio.gz \


### PR DESCRIPTION
This PR adds `drac.ipv4` to the kernel arguments so DRAC can be configured during this stage. The subnet mask and gateway are the same as epoxy.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/148)
<!-- Reviewable:end -->
