### PR TITLE
Add periodic job and timer for cron-like jobs

### DIFF
--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -203,6 +203,20 @@ coreos:
         Type=oneshot
         ExecStart=/opt/bin/configure_tc_fq.sh
 
+    # TODO(https://github.com/m-lab/k8s-support/issues/230): Delete this script
+    # once issue is fixed.
+    - name: copy-fix-hung-shim.service
+      command: start
+      enable: true
+      content: |
+        [Unit]
+        Description=Copy fix-hung-shim script to /etc/periodic/15min
+
+        [Service]
+        Type=oneshot
+        ExecStart=install -D --mode=0755 --owner=root --group=root \
+          --target-directory=/etc/periodic/15min/ /usr/share/oem/fix-hung-shim.sh
+
 write_files:
   - path: /opt/bin/configure_tc_fq.sh
     permissions: 0755
@@ -224,6 +238,8 @@ write_files:
       /sbin/tc qdisc replace dev eth0 root fq maxrate "${MAXRATE}"
       echo "Set maxrate for qdisc fq on dev eth0 to: ${MAXRATE}"
 
+  # TODO(https://github.com/m-lab/k8s-support/issues/230): Delete this script
+  # once issue is fixed.
   - path: /etc/periodic/15min/README
     permissions: 0644
     owner: root:root

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -205,7 +205,7 @@ coreos:
 
 write_files:
   - path: /opt/bin/configure_tc_fq.sh
-    permissions: 0744
+    permissions: 0755
     owner: root:root
     content: |
       #!/bin/bash
@@ -224,12 +224,12 @@ write_files:
       /sbin/tc qdisc replace dev eth0 root fq maxrate "${MAXRATE}"
       echo "Set maxrate for qdisc fq on dev eth0 to: ${MAXRATE}"
 
-  - path: /etc/periodic/15min/cleanup-shim.sh
-    permissions: 0744
+  - path: /etc/periodic/15min/README
+    permissions: 0644
     owner: root:root
     content: |
-      #!/bin/bash
-      echo "OKAY"
+      Place executable scripts in this directory and a systemd timer will
+      execute them every 15min.
 
 # TODO: collect list of ssh keys from a metadata service during post-boot setup.
 ssh_authorized_keys:

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -42,6 +42,29 @@ coreos:
             Requires=cache-docker.mount
             After=cache-docker.mount
 
+    # TODO: can we use systemd template variables to add other times?
+    - name: mlab-periodic-job.service
+      content: |
+        [Unit]
+        Description=Runs periodic jobs.
+        Requires=network-online.target
+
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/share/oem/run-parts /etc/periodic/15min
+
+    - name: mlab-periodic-job.timer
+      command: "start"
+      content: |
+        [Unit]
+        Description=Runs mlab-periodic-job.service every 15 minutes.
+
+        [Timer]
+        OnCalendar=*:0/15
+
+        [Install]
+        WantedBy=multi-user.target
+
     - name: mlab-set-quotas.service
       content: |
         [Unit]
@@ -200,6 +223,13 @@ write_files:
       fi
       /sbin/tc qdisc replace dev eth0 root fq maxrate "${MAXRATE}"
       echo "Set maxrate for qdisc fq on dev eth0 to: ${MAXRATE}"
+
+  - path: /etc/periodic/15min/cleanup-shim.sh
+    permissions: 0744
+    owner: root:root
+    content: |
+      #!/bin/bash
+      echo "OKAY"
 
 # TODO: collect list of ssh keys from a metadata service during post-boot setup.
 ssh_authorized_keys:

--- a/configs/stage3_coreos/resources/fix-hung-shim.sh
+++ b/configs/stage3_coreos/resources/fix-hung-shim.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+#
+# fix-hung-shim.sh checks whether the host container appears to be hung during
+# shutdown. Before fix-hung-shim kills any current processes, it must observe
+# the hung process twice with at least 15min between checks.
+#
+# TODO(https://github.com/m-lab/k8s-support/issues/230): Delete this script once
+# issue is fixed.
+
+set -e
+
+# Persistent files.
+STATEDIR=/var/cache/fix-hung-shim
+mkdir --parents "${STATEDIR}"
+
+# Temp files.
+TEMPDIR=$( mktemp -d )
+
+# Count the current number of host containers.
+docker ps > $TEMPDIR/host.log
+# If this is the very first time, copy the log file and exit.
+if [[ ! -f ${STATEDIR}/host.log ]] ; then
+  mv --force $TEMPDIR/host.log $STATEDIR/host.log
+  rm -rf $TEMPDIR
+  exit 0
+fi
+
+# The temporary and previous host.log files should both exist.
+CURR_COUNT=$( cat $TEMPDIR/host.log | grep host | wc --lines )
+PREV_COUNT=$( cat $STATEDIR/host.log | grep host | wc --lines )
+
+# Runtimes.
+CURR_TIME=$( date +%s )
+PREV_TIME=$( stat --format=%Y ${STATEDIR}/host.log )
+
+# The last two checks counted 1 process, and it's been at least 15min.
+if [[ $PREV_COUNT -eq 1 ]] && \
+   [[ $CURR_COUNT -eq 1 ]] && \
+   [[ $(( $CURR_TIME - $PREV_TIME )) -ge 900 ]] ; then
+
+  # Lookup container id for hung shim process.
+  container_id=$( cat $TEMPDIR/host.log | grep host | awk '{print $1}' )
+  if [[ -z "$container_id" ]] ; then
+    echo "Failed to extract host container id"
+    exit 1
+  fi
+  # Kill all process ids for commands matching container_id.
+  pgrep --full $container_id | xargs kill -9
+
+  # Remove old state.
+  rm -f $STATEDIR/host.log
+fi
+
+# Only rotate the host log every 15min.
+if [[ $(( $CURR_TIME - $PREV_TIME )) -ge 900 ]] ; then
+  mv --force $TEMPDIR/host.log $STATEDIR/host.log
+fi
+
+# Clean up tempdir.
+rm -rf $TEMPDIR

--- a/configs/stage3_coreos/resources/run-parts
+++ b/configs/stage3_coreos/resources/run-parts
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# run-parts executes every executable file in a given directory.
+
+set -e
+
+DIR=${1:?Please provide a directory}
+
+if [[ ! -d $DIR ]] ; then
+  # It's missing or not a dir, so do nothing.
+  exit 0
+fi
+
+# Dir exits, check every file in given dir.
+for file in $DIR/* ; do
+  if [[ -x $file ]] ; then
+    $file || :  # Ignore execution errors.
+  fi
+done
+exit 0

--- a/configs/stage3_coreos/resources/run-parts
+++ b/configs/stage3_coreos/resources/run-parts
@@ -11,7 +11,7 @@ if [[ ! -d $DIR ]] ; then
   exit 0
 fi
 
-# Dir exits, check every file in given dir.
+# Dir exists, check every file in given dir.
 for file in $DIR/* ; do
   if [[ -x $file ]] ; then
     $file || :  # Ignore execution errors.


### PR DESCRIPTION
This change adds two new systemd units to the cloud-config.yml in CoreOS. Taken together this change runs all executable commands in /etc/periodic/15min every 15min. It is the responsibility of the administrator or other k8s jobs to place files in that directory.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/149)
<!-- Reviewable:end -->
