### PR TITLE
Re-enable TSO.

### DIFF
--- a/configs/stage3_coreos/resources/generate_network_config.sh
+++ b/configs/stage3_coreos/resources/generate_network_config.sh
@@ -64,11 +64,6 @@ DNS2_IPv6=$( echo $FIELDS_IPv6 | awk -F, '{print $4}' )
 # Note, we cannot set the hostname via networkd. Use hostnamectl instead.
 hostnamectl set-hostname ${HOSTNAME}
 
-# According to https://systemd.network/systemd.link.html, TSO can only be
-# enabled or set to the kernel default when using networkd. We need to disable
-# it, thus we use ethtool instead.
-ethtool -K eth0 tso off
-
 # TODO: do not hardcode /26.
 # TODO: do not hardcode eth0.
 cat > ${OUTPUT} <<EOF


### PR DESCRIPTION
This PR removes the command that disables TSO, restoring the default (enabled). This follows a conversation we've had at the Ops Tactical meeting today and seems to be a fix for https://github.com/m-lab/ndt-server/issues/37 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/156)
<!-- Reviewable:end -->
