### PR TITLE
Create /etc/systemd/journald.conf

### DIFF
--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -217,6 +217,10 @@ coreos:
         ExecStart=install -D --mode=0755 --owner=root --group=root \
           --target-directory=/etc/periodic/15min/ /usr/share/oem/fix-hung-shim.sh
 
+    # Restart systemd-journald so the new journald.conf is used.
+    - name: systemd-journald.service
+      command: restart
+
 write_files:
   - path: /opt/bin/configure_tc_fq.sh
     permissions: 0755

--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -247,6 +247,16 @@ write_files:
       Place executable scripts in this directory and a systemd timer will
       execute them every 15min.
 
+  # No configuration for journald is included by default. By explicitly setting
+  # Storage=persistent here, we make sure /var/log/journal is created and used.
+  # This folder is needed by fluentd to read the journald logs.
+  - path: /etc/systemd/journald.conf
+    permissions: 0644
+    owner: root:root
+    content: |
+      [Journal]
+      Storage=persistent
+
 # TODO: collect list of ssh keys from a metadata service during post-boot setup.
 ssh_authorized_keys:
  - "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCvIKeMHcEO1xnTmEdMY6E9Y4pBdGBCDXZnuQC5ZPjNQr9IG3ytw0OxwyCObAzSr+WOymYv6Cwm4Ckz2jc/bWygzWJH+DMdldZe7HVQu4YxuegqahIkB0D1OzaZGNctBgTp9bmpWGxyek7U8ff7GTiFqhcms4Oer4rdd0gqUhmv3LnRWQqrIDblrBosHBED/zXgjbOj3beWCA3xHDCaui/gkbmp0J2jzCnlsc7eSI0d6Jro2UhbiS2ssxVQsLViLh5okJJeb2JyzbLbcpselUg9DSwSk0pFH/wHL0usjvBisF/fEP8eQ1svq6N6gncvPlgoJaSvtACmDvIFkU4baA2v pboothe@pboothe3.nyc.corp.google.com"


### PR DESCRIPTION
This PR creates `/etc/systemd/journald.conf` with `Storage=persistent`. This is needed so that `/var/log/journal` is created and log files are flushed from memory. Also, fluentd only reads the logs from that folder.

Since this file is created after the basic systemd units (including systemd-journald) have started, we also need to restart systemd-journald.

Tested on mlab1.lga0t by rebooting after deleting the fluentd DaemonSet (that would otherwise create `/var/log/journal`)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/158)
<!-- Reviewable:end -->
