### PR TITLE
Adds ability for fix-hung-shim.sh script to handle more than one stuck shim process.

### DIFF
--- a/configs/stage3_coreos/resources/fix-hung-shim.sh
+++ b/configs/stage3_coreos/resources/fix-hung-shim.sh
@@ -33,10 +33,10 @@ PREV_COUNT=$( cat $STATEDIR/host.log | grep host | wc --lines )
 CURR_TIME=$( date +%s )
 PREV_TIME=$( stat --format=%Y ${STATEDIR}/host.log )
 
-# The last two checks counted less than 3 processes, and it's been at least
+# The last two checks counted less than 4 processes, and it's been at least
 # 15min. There will generally be 10+ host pod processes.
-if [[ $PREV_COUNT -lt 3 ]] && \
-   [[ $CURR_COUNT -lt 3 ]] && \
+if [[ $PREV_COUNT -lt 4 ]] && \
+   [[ $CURR_COUNT -lt 4 ]] && \
    [[ $(( $CURR_TIME - $PREV_TIME )) -ge 900 ]] ; then
 
   # Only proceed if the previous count is equivalent to the current count.

--- a/configs/stage3_coreos/resources/fix-hung-shim.sh
+++ b/configs/stage3_coreos/resources/fix-hung-shim.sh
@@ -33,20 +33,24 @@ PREV_COUNT=$( cat $STATEDIR/host.log | grep host | wc --lines )
 CURR_TIME=$( date +%s )
 PREV_TIME=$( stat --format=%Y ${STATEDIR}/host.log )
 
-# The last two checks counted 1 process, and it's been at least 15min.
-if [[ $PREV_COUNT -eq 1 ]] && \
-   [[ $CURR_COUNT -eq 1 ]] && \
+# The last two checks counted less than 3 processes, and it's been at least
+# 15min. There will generally be 10+ host pod processes.
+if [[ $PREV_COUNT -lt 3 ]] && \
+   [[ $CURR_COUNT -lt 3 ]] && \
    [[ $(( $CURR_TIME - $PREV_TIME )) -ge 900 ]] ; then
 
-  # Lookup container id for hung shim process.
-  container_id=$( cat $TEMPDIR/host.log | grep host | awk '{print $1}' )
-  if [[ -z "$container_id" ]] ; then
-    echo "Failed to extract host container id"
-    exit 1
+  # Only proceed if the previous count is equivalent to the current count.
+  if [[ $PREV_COUNT -eq $CURR_COUNT ]] ; then
+    # Lookup container ids for any hung shim processes.
+    for container_id in $( cat $TEMPDIR/host.log | grep host | awk '{print $1}') ; do
+      if [[ -z "$container_id" ]] ; then
+        echo "Failed to extract host container id"
+        exit 1
+      fi
+      # Kill the process ids for the command matching container_id.
+      pgrep --full $container_id | xargs kill -9
+    done
   fi
-  # Kill all process ids for commands matching container_id.
-  pgrep --full $container_id | xargs kill -9
-
   # Remove old state.
   rm -f $STATEDIR/host.log
 fi


### PR DESCRIPTION
This PR is intended to resolve issue #159.

Currently, we have had the notion that when a containerd-shim process gets stuck, that it will never be more than one process, which, in fairness, matched our previous observations and was a conservative approach. We have now found that it is possible for multiple containerd-shim processes to get stuck. I have only personally witnessed 2 stuck processes at a time, but this PR extends the possibility to 3 hung processes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/160)
<!-- Reviewable:end -->
