### PR TITLE
Uses v2 sites.json in sandbox only

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -22,7 +22,6 @@ function stage1_mlxrom() {
   local project=${PROJECT:?Please specify the PROJECT}
   local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
   local version=${MLXROM_VERSION:?Please define the MLXROM_VERSION to build}
-  local regex_name="MLXROM_REGEXP_${PROJECT//-/_}"
 
   local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
 
@@ -34,8 +33,7 @@ function stage1_mlxrom() {
   TRUSTED_CERTS+=",${SOURCE_DIR}/configs/${target}/gtsgiag3.pem"
 
   ${SOURCE_DIR}/setup_stage1_mlxrom.sh "${project}" "${builddir}" "${artifacts}" \
-      "${SOURCE_DIR}/configs/${target}" "${!regex_name}" "${version}" \
-      "${TRUSTED_CERTS}"
+      "${SOURCE_DIR}/configs/${target}" "${version}" "${TRUSTED_CERTS}"
 
   rm -rf "${builddir}"
 }

--- a/builder.sh
+++ b/builder.sh
@@ -97,12 +97,11 @@ function stage1_isos() {
   local target=${TARGET:?Please specify a target configuration name}
   local project=${PROJECT:?Please specify the PROJECT}
   local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
-  local regex_name="ISO_REGEXP_${PROJECT//-/_}"
 
   local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
 
   ${SOURCE_DIR}/setup_stage1_isos.sh "${project}" "${builddir}" "${artifacts}" \
-      "${SOURCE_DIR}/configs/${target}" "${!regex_name}"
+      "${SOURCE_DIR}/configs/${target}"
 
   rm -rf "${builddir}"
   return

--- a/config.sh
+++ b/config.sh
@@ -2,7 +2,7 @@
 # relevant settings.
 
 # Use v2 sites.json for everything except mlab-oti.
-if [[ "${PROJECT}" != "mlab-oti" ]]; then
+if [[ "${PROJECT}" == "mlab-sandbox" ]]; then
   export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
 else
   export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v1/sites/sites.json"

--- a/config.sh
+++ b/config.sh
@@ -16,11 +16,3 @@ export CNI_VERSION=v0.8.5
 
 # stage1 mlxrom
 export MLXROM_VERSION=3.4.816
-export MLXROM_REGEXP_mlab_sandbox='mlab[1-4].[a-z]{3}[0-9]t.*'
-export MLXROM_REGEXP_mlab_staging='mlab4.[a-z]{3}[0-9]{2}.*'
-export MLXROM_REGEXP_mlab_oti='mlab[1-3].[a-z]{3}[0-9]{2}.*'
-
-# stage1 isos
-export ISO_REGEXP_mlab_sandbox='mlab[1-4].[a-z]{3}[0-9]t.*'
-export ISO_REGEXP_mlab_staging='mlab4.[a-z]{3}[0-9]{2}.*'
-export ISO_REGEXP_mlab_oti='mlab[1-3].[a-z]{3}[0-9]{2}.*'

--- a/config.sh
+++ b/config.sh
@@ -1,6 +1,13 @@
 # Common configuration for epoxy image builds. All builds source this file for
 # relevant settings.
 
+# Use v2 sites.json for everything except mlab-oti.
+if [[ "${PROJECT}" != "mlab-oti" ]]; then
+  export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
+else
+  export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v1/sites/sites.json"
+fi
+
 # stage3 coreos
 export COREOS_VERSION=2303.4.0
 export K8S_VERSION=v1.15.10

--- a/setup_stage1_isos.sh
+++ b/setup_stage1_isos.sh
@@ -14,7 +14,6 @@ PROJECT=${1:?Please provide the GCP Project: $USAGE}
 BUILD_DIR=${2:?Please specify a build directory: $USAGE}
 OUTPUT_DIR=${3:?Please provide an output directory: $USAGE}
 CONFIG_DIR=${4:?Please specify a config directory: $USAGE}
-HOSTNAMES=${5:?Please specify a hostname pattern: $USAGE}
 
 # Report all commands to log file (set -x writes to stderr).
 set -xuo pipefail
@@ -27,8 +26,9 @@ pushd ${BUILD_DIR}
       ./mlabconfig.py
   mkdir -p ${OUTPUT_DIR}/scripts
   python ./mlabconfig.py --format=server-network-config \
+      --sites "${SITES}" \
       --physical \
-      --select "${HOSTNAMES}" \
+      --project "${PROJECT}" \
       --label "project=${PROJECT}" \
       --template_input "${CONFIG_DIR}/create-stage1-iso-template.sh" \
       --template_output "${BUILD_DIR}/create-stage1-iso-{{hostname}}.sh"

--- a/setup_stage1_mlxrom.sh
+++ b/setup_stage1_mlxrom.sh
@@ -66,7 +66,7 @@ function prepare_flexboot_source() {
 function generate_stage1_ipxe_scripts() {
   local build_dir=$1
   local config_dir=$2
-  local output_dir=$4
+  local output_dir=$3
 
   # Create all stage1.ipxe scripts.
   pushd ${build_dir}

--- a/setup_stage1_mlxrom.sh
+++ b/setup_stage1_mlxrom.sh
@@ -15,8 +15,8 @@ PROJECT=${1:?Please specify the GCP project to contact: $USAGE}
 BUILD_DIR=${2:?Please specify a build directory: $USAGE}
 OUTPUT_DIR=${3:?Please specify an output directory: $USAGE}
 CONFIG_DIR=${4:?Please specify a configuration directory: $USAGE}
-ROM_VERSION=${6:?Please specify the ROM version as "3.4.800": $USAGE}
-CERTS=${7:?Please specify trusted certs to embed in ROM: $USAGE}
+ROM_VERSION=${5:?Please specify the ROM version as "3.4.800": $USAGE}
+CERTS=${6:?Please specify trusted certs to embed in ROM: $USAGE}
 
 # unpack checks whether the given directory exists and if it does not unpacks
 # the given tar archive (which should create the directory).

--- a/setup_stage1_mlxrom.sh
+++ b/setup_stage1_mlxrom.sh
@@ -15,7 +15,6 @@ PROJECT=${1:?Please specify the GCP project to contact: $USAGE}
 BUILD_DIR=${2:?Please specify a build directory: $USAGE}
 OUTPUT_DIR=${3:?Please specify an output directory: $USAGE}
 CONFIG_DIR=${4:?Please specify a configuration directory: $USAGE}
-HOSTNAMES=${5:?Please specify a hostname pattern: $USAGE}
 ROM_VERSION=${6:?Please specify the ROM version as "3.4.800": $USAGE}
 CERTS=${7:?Please specify trusted certs to embed in ROM: $USAGE}
 
@@ -67,7 +66,6 @@ function prepare_flexboot_source() {
 function generate_stage1_ipxe_scripts() {
   local build_dir=$1
   local config_dir=$2
-  local hostname_pattern=$3
   local output_dir=$4
 
   # Create all stage1.ipxe scripts.
@@ -78,8 +76,9 @@ function generate_stage1_ipxe_scripts() {
         ./mlabconfig.py
     mkdir -p ${output_dir}
     python ./mlabconfig.py --format=server-network-config \
+        --sites "${SITES}" \
         --physical \
-        --select "${hostname_pattern}" \
+        --project "${PROJECT}" \
         --label "project=${PROJECT}" \
         --template_input "${config_dir}/stage1-template.ipxe" \
         --template_output "${output_dir}/stage1-{{hostname}}.ipxe"
@@ -234,7 +233,6 @@ prepare_flexboot_source \
 generate_stage1_ipxe_scripts \
     ${BUILD_DIR} \
     ${CONFIG_DIR} \
-    "${HOSTNAMES}" \
     "${SCRIPTDIR}"
 
 build_roms \

--- a/setup_stage1_usbs.sh
+++ b/setup_stage1_usbs.sh
@@ -15,21 +15,21 @@ PROJECT=${1:?Please provide the GCP Project: $USAGE}
 BUILD_DIR=${2:?Please specify a build directory: $USAGE}
 OUTPUT_DIR=${3:?Please provide an output directory: $USAGE}
 CONFIG_DIR=${4:?Please specify a config directory: $USAGE}
-HOSTNAMES=${5:?Please specify a hostname pattern: $USAGE}
 
 # Report all commands to log file (set -x writes to stderr).
 set -xuo pipefail
 
-# Use mlabconfig to fill in the template for every machine matching the given
-# HOSTNAMES pattern.
+# Use mlabconfig to fill in the template for every machine in the given
+# PROJECT name.
 pushd "${BUILD_DIR}"
   # TODO: Replace curl with a native go-get once mlabconfig is rewritten in Go.
   curl --location "https://raw.githubusercontent.com/m-lab/siteinfo/master/cmd/mlabconfig.py" > \
       ./mlabconfig.py
   mkdir -p "${OUTPUT_DIR}/scripts"
   python ./mlabconfig.py --format=server-network-config \
+      --sites "${SITES}" \
       --physical \
-      --select "${HOSTNAMES}" \
+      --project "${PROJECT}" \
       --label "project=${PROJECT}" \
       --template_input "${CONFIG_DIR}/create-stage1-usb-template.sh" \
      --template_output "${BUILD_DIR}/create-stage1-usb-{{hostname}}.sh"


### PR DESCRIPTION
This PR attempts to implement the necessary changes to start using v2 siteinfo outputs when building artifacts. This principally means that image names and node names will be project-decorated and flattened.

This PR also changes calls to mlabconfig.py to use the new `--project` flag instead of a `--select` regexp.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/166)
<!-- Reviewable:end -->
