### PR TITLE
Files to allow CLUO to minimally continue to work on Ubuntu

### DIFF
--- a/configs/stage3_ubuntu/usr/share/coreos/README
+++ b/configs/stage3_ubuntu/usr/share/coreos/README
@@ -1,0 +1,11 @@
+This directory and its contents are here as a way to temporarily shoehorn
+Container Linux Update Operator (CLUO) into an Ubuntu environment. This
+directory gets mounted into the filesystem of the update-agent pods, as it
+expects to find these files and will not work without them.
+
+The os-release file was sourced from an existing CoreOS platform node at the
+time of this writing, and the same for the update.conf file, with the
+exception that I updated the SERVER variable to point to a Flatcar Linux
+update server, since eventually Redhat will shut down the CoreOS update
+servers.
+

--- a/configs/stage3_ubuntu/usr/share/coreos/README
+++ b/configs/stage3_ubuntu/usr/share/coreos/README
@@ -9,3 +9,5 @@ exception that I updated the SERVER variable to point to a Flatcar Linux
 update server, since eventually Redhat will shut down the CoreOS update
 servers.
 
+https://github.com/m-lab/k8s-support/issues/418
+

--- a/configs/stage3_ubuntu/usr/share/coreos/os-release
+++ b/configs/stage3_ubuntu/usr/share/coreos/os-release
@@ -1,0 +1,11 @@
+NAME="Container Linux by CoreOS"
+ID=coreos
+VERSION=2303.4.0
+VERSION_ID=2303.4.0
+BUILD_ID=2020-02-06-1305
+PRETTY_NAME="Container Linux by CoreOS 2303.4.0 (Rhyolite)"
+ANSI_COLOR="38;5;75"
+HOME_URL="https://coreos.com/"
+BUG_REPORT_URL="https://issues.coreos.com"
+COREOS_BOARD="amd64-usr"
+

--- a/configs/stage3_ubuntu/usr/share/coreos/update.conf
+++ b/configs/stage3_ubuntu/usr/share/coreos/update.conf
@@ -1,0 +1,3 @@
+SERVER=https://public.update.flatcar-linux.net/v1/update/
+GROUP=stable
+


### PR DESCRIPTION
**Container Linux** Update Operate is designed for running on Container Linux systems. In order to get CLUO to function on Ubuntu we have to slightly trick it into thinking it is running on a CoreOS system. These files lay the foundation for modifications to the update-agent DaemonSet so that it can continue working.

`os-release` was copied from one of our current running CoreOS machines. It is somewhat arbitrary.

`update.conf` is a file the update-agent looks for. 

These files will be mounted into the pods filesystem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/171)
<!-- Reviewable:end -->
