### PR TITLE
Changes to make the boot_from_nic scripts more robust and to work with k8s.

### DIFF
--- a/manual/Dockerfile
+++ b/manual/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos
+FROM centos:7
 
 RUN yum -y update && yum -y install openssl openssl-devel pciutils wget
 # Latest as of 2018-06-12:


### PR DESCRIPTION
There is a small functional challenge with using these scripts, since we block access to DRACs based on IP, yet these changes expect certain kubectl contexts to exists. They must be run from mlab-eb, which has access to DRACs. In order for this work kubectl must be installed on eb, and an operator's `.kube/config` must also be there. A little bit of a pain, but doable. In any case, these scripts should only be needed for 20 or 30 more machines in production which don't currently have the NIC set as the first boot device as we convert production to v2 names. After that, these will likely never be used again by us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/173)
<!-- Reviewable:end -->
