### PR TITLE
Loads tg3 module to support NICs in older R620s

### DIFF
--- a/configs/stage1_minimal/modules
+++ b/configs/stage1_minimal/modules
@@ -7,3 +7,7 @@ usbhid
 mlx4_en
 mlx5_core
 mlxfw
+
+# Load tg3 module to support NICs in the few remaining R620s.
+tg3
+

--- a/configs/stage3_ubuntu/etc/modules
+++ b/configs/stage3_ubuntu/etc/modules
@@ -1,3 +1,9 @@
+# SATA support
 ahci
+
+# BBR for ndt7
 tcp_bbr
+
+# Support for NICs in older R620 machines.
+tg3
 

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,5 +1,4 @@
 [Unit]
-After=dev-sda1.device
 Before=docker.service cache-docker.mount cache-data.mount cache-core.mount
 RequiresMountsFor=/cache
 ConditionPathExists=!/cache/docker

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -30,3 +30,4 @@ ExecStart=/usr/sbin/mkfs.xfs -f -L cache-docker /dev/sda2
 
 [Install]
 WantedBy=multi-user.target
+

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,4 +1,5 @@
 [Unit]
+After=dev-sda1.device
 Before=docker.service cache-docker.mount cache-data.mount cache-core.mount
 RequiresMountsFor=/cache
 ConditionPathExists=!/cache/docker
@@ -29,4 +30,3 @@ ExecStart=/usr/sbin/mkfs.xfs -f -L cache-docker /dev/sda2
 
 [Install]
 WantedBy=multi-user.target
-


### PR DESCRIPTION
HND01 still uses R620s, and require the tg3 module to discover the NIC.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/174)
<!-- Reviewable:end -->
