### PR TITLE
Extracts site name from hostname in a v1-v2-friendly way for the CoreOS

### DIFF
--- a/configs/stage3_coreos/resources/cloud-config.yml
+++ b/configs/stage3_coreos/resources/cloud-config.yml
@@ -227,7 +227,7 @@ write_files:
     owner: root:root
     content: |
       #!/bin/bash
-      SITE=$(dnsdomainname | cut -d. -f1)
+      SITE=${HOSTNAME:6:5}
       SPEED=$(curl --silent --show-error --location \
           https://siteinfo.mlab-oti.measurementlab.net/v1/sites/switches.json \
           | jq -r ".${SITE}.uplink_speed")


### PR DESCRIPTION
This change was done a while back for the Ubuntu stage3 images, but I missed the CoreOS change needed in configure_tc_fq.sh script.

Fixes #176.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/177)
<!-- Reviewable:end -->
