### PR TITLE
Bumps stage1 build timeout from 3h to 4h.

### DIFF
--- a/cloudbuild-stage1.yaml
+++ b/cloudbuild-stage1.yaml
@@ -1,5 +1,5 @@
-# Timeout for complete build. Default is 10m.
-timeout: 10800s
+# Timeout for complete build: 4h. Default is 10m.
+timeout: 14400s
 
 # The default disk size is 100GB. However, the stage1 ISOs are pretty big these
 # days. 400GB  should give us some breathing room.


### PR DESCRIPTION
A build in mlab-oti failed a while ago because it timed out at 3h. This sets the timeout to 4h. The most recent successful stage1 build in mlab-oti took ~2h. I'm not sure what would have changed between then and now, other than a handful of new sites have been added (bru05, prg06, mex01, mty01, etc.) which may have added  enough new nodes to build images for that it's just taking longer now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/180)
<!-- Reviewable:end -->
