### PR TITLE
Attempts to eliminate some systemd unit cyclical dependencies

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system/cache-data.mount
+++ b/configs/stage3_ubuntu/etc/systemd/system/cache-data.mount
@@ -1,7 +1,5 @@
 [Unit]
 Description=Mount Experiment Data Volume
-After=format-cache.service
-Requires=format-cache.service
 
 [Mount]
 What=/dev/disk/by-label/cache-data

--- a/configs/stage3_ubuntu/etc/systemd/system/cache-data.mount
+++ b/configs/stage3_ubuntu/etc/systemd/system/cache-data.mount
@@ -1,6 +1,5 @@
 [Unit]
 Description=Mount Experiment Data Volume
-Before=docker.service
 After=format-cache.service
 Requires=format-cache.service
 

--- a/configs/stage3_ubuntu/etc/systemd/system/cache-docker.mount
+++ b/configs/stage3_ubuntu/etc/systemd/system/cache-docker.mount
@@ -1,6 +1,5 @@
 [Unit]
 Description=Mount Docker Data Volume
-Before=docker.service
 After=format-cache.service
 Requires=format-cache.service
 

--- a/configs/stage3_ubuntu/etc/systemd/system/cache-docker.mount
+++ b/configs/stage3_ubuntu/etc/systemd/system/cache-docker.mount
@@ -1,7 +1,5 @@
 [Unit]
 Description=Mount Docker Data Volume
-After=format-cache.service
-Requires=format-cache.service
 
 [Mount]
 What=/dev/disk/by-label/cache-docker

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,8 +1,8 @@
 [Unit]
 Before=cache-data.mount cache-docker.mount
-RequiredBy=cache-data.mount cache-docker.mount
-ConditionPathExists=!/cache/docker
 ConditionPathExists=!/cache/data
+ConditionPathExists=!/cache/docker
+DefaultDependencies=no
 
 [Service]
 Type=oneshot
@@ -27,5 +27,6 @@ ExecStart=/usr/sbin/mkfs.xfs -f -L cache-data /dev/sda1
 ExecStart=/usr/sbin/mkfs.xfs -f -L cache-docker /dev/sda2
 
 [Install]
+RequiredBy=cache-data.mount cache-docker.mount
 WantedBy=multi-user.target
 

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,4 +1,5 @@
 [Unit]
+# We want this unit to run before we mount to be sure that disk gets formatted first.
 Before=cache-data.mount cache-docker.mount
 ConditionPathExists=!/cache/data
 ConditionPathExists=!/cache/docker
@@ -27,6 +28,7 @@ ExecStart=/usr/sbin/mkfs.xfs -f -L cache-data /dev/sda1
 ExecStart=/usr/sbin/mkfs.xfs -f -L cache-docker /dev/sda2
 
 [Install]
+# This requirement should cause these mounts to fail if this unit fails.
 RequiredBy=cache-data.mount cache-docker.mount
 WantedBy=multi-user.target
 

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,5 +1,5 @@
 [Unit]
-Before=docker.service cache-docker.mount cache-data.mount cache-core.mount
+DefaultDependencies=no
 RequiresMountsFor=/cache
 ConditionPathExists=!/cache/docker
 ConditionPathExists=!/cache/data

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,7 +1,4 @@
 [Unit]
-After=dev-sda.device
-Before=cache-data.mount cache-docker.mount
-DefaultDependencies=no
 RequiresMountsFor=/cache
 ConditionPathExists=!/cache/docker
 ConditionPathExists=!/cache/data

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,8 +1,8 @@
 [Unit]
-RequiresMountsFor=/cache
+Before=cache-data.mount cache-docker.mount
+RequiredBy=cache-data.mount cache-docker.mount
 ConditionPathExists=!/cache/docker
 ConditionPathExists=!/cache/data
-ConditionPathExists=!/cache/core
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,4 +1,5 @@
 [Unit]
+After=local-fs-pre.target
 DefaultDependencies=no
 RequiresMountsFor=/cache
 ConditionPathExists=!/cache/docker

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,5 +1,5 @@
 [Unit]
-After=local-fs-pre.target
+After=dev-sda.device
 DefaultDependencies=no
 RequiresMountsFor=/cache
 ConditionPathExists=!/cache/docker

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,6 +1,5 @@
 [Unit]
 After=dev-sda.device
-Requires=dev-sda.device
 DefaultDependencies=no
 RequiresMountsFor=/cache
 ConditionPathExists=!/cache/docker

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,5 +1,6 @@
 [Unit]
 After=dev-sda.device
+Requires=dev-sda.device
 DefaultDependencies=no
 RequiresMountsFor=/cache
 ConditionPathExists=!/cache/docker

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,5 +1,6 @@
 [Unit]
 After=dev-sda.device
+Before=cache-data.mount cache-docker.mount
 DefaultDependencies=no
 RequiresMountsFor=/cache
 ConditionPathExists=!/cache/docker


### PR DESCRIPTION
While migrating nodes to Ubuntu I witnessed that maybe ~5% of nodes, on the boot that converted the node to Ubuntu, failed to join the cluster because kubeadm failed preflight checks because the `br_netfilter` module was not loaded. In those cases, I also found that systemd had deleted the `docker.socket` unit due to some ordering cycle, and it is the docker service that triggers the `br_netfilter` module to load. In 100% of the cases a reboot fixed this issue, but I can't guarantee that it won't pop up during subsequent reboots.

This PR attempts to generally fix ordering cycle dependencies, which I believe are/were the result of default dependencies applied to all "service" units (including the `format-cache.service` service). 

Additionally, even when apparently booting and running normally, pretty much all productions machines have some variation of errors like the following in the logs. This PR should resolve these.

```
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found ordering cycle on systemd-machine-id-commit.service/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on local-fs.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on cache-data.mount/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on format-cache.service/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on basic.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on sockets.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on docker.socket/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on sysinit.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Job systemd-machine-id-commit.service/start deleted to break ordering cycle starting with sysinit.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found ordering cycle on systemd-tmpfiles-setup.service/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on local-fs.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on cache-data.mount/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on format-cache.service/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on basic.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on sockets.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on docker.socket/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on sysinit.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Job systemd-tmpfiles-setup.service/start deleted to break ordering cycle starting with sysinit.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found ordering cycle on local-fs.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on cache-data.mount/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on format-cache.service/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on basic.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on sockets.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on docker.socket/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Found dependency on sysinit.target/start
Jun 26 22:53:38 45e91a34195b systemd[1]: sysinit.target: Job local-fs.target/start deleted to break ordering cycle starting with sysinit.target/start
```

It should be noted that even with this fix in place, there is still an error message in the logs:

```
Jun 30 19:32:28 da4a7499f109 systemd[1]: format-cache.service: Failed with result 'exit-code'.
Jun 30 19:32:28 da4a7499f109 systemd[1]: Failed to start format-cache.service.
Jun 30 19:32:28 da4a7499f109 systemd[1]: Dependency failed for Mount Experiment Data Volume.
Jun 30 19:32:28 da4a7499f109 systemd[1]: Dependency failed for Docker Application Container Engine.
Jun 30 19:32:28 da4a7499f109 systemd[1]: Dependency failed for Mount Docker Data Volume.
```

It is a scary message, but seems benign, as ultimately systemd does the right thing. The `format-cache.service` unit has these logs:

```
Jun 30 19:32:28 da4a7499f109 parted[427]: Error: Could not stat device /dev/sda - No such file or directory.
Jun 30 19:33:31 mlab2-lga0t.mlab-sandbox.measurement-lab.org systemd[1]: Starting format-cache.service...
<snip>
Jun 30 19:33:43 mlab2-lga0t.mlab-sandbox.measurement-lab.org systemd[1]: format-cache.service: Succeeded.
Jun 30 19:33:43 mlab2-lga0t.mlab-sandbox.measurement-lab.org systemd[1]: Finished format-cache.service.
```

I think we are getting the warning that the service failed because it initially fails to find `/dev/sda` (despite the fact that I've created an explicit dependency on `dev-sda.device`). The service runs normally, and even logs a message that it completed successfully. And all of the units that log a "Dependency failed for.." message start up normally and, seemingly, in the right order.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/181)
<!-- Reviewable:end -->
