### PR TITLE
Order configure-tc-fq.service after nss-lookup.target.

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system/cache-data.mount
+++ b/configs/stage3_ubuntu/etc/systemd/system/cache-data.mount
@@ -1,5 +1,6 @@
 [Unit]
 Description=Mount Experiment Data Volume
+DefaultDependencies=no
 
 [Mount]
 What=/dev/disk/by-label/cache-data

--- a/configs/stage3_ubuntu/etc/systemd/system/cache-docker.mount
+++ b/configs/stage3_ubuntu/etc/systemd/system/cache-docker.mount
@@ -1,5 +1,6 @@
 [Unit]
 Description=Mount Docker Data Volume
+DefaultDependencies=no
 
 [Mount]
 What=/dev/disk/by-label/cache-docker

--- a/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
@@ -1,7 +1,9 @@
 [Unit]
 Description=Configures TCP pacing properly depending on the site's uplink speed
-Requires=network-online.target
-After=systemd-networkd-wait-online.service systemd-resolved.service format-cache.service
+# The script that configures fair queueing has to do a name lookup, and will
+# fail if name resolution is not 100% functional.
+# https://www.freedesktop.org/software/systemd/man/systemd.special.html#nss-lookup.target
+After=nss-lookup.target
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Configures TCP pacing properly depending on the site's uplink speed
-Wants=network-online.target
-After=systemd-networkd-wait-online.service systemd-resolved.service
+Requires=network-online.target
+After=systemd-networkd-wait-online.service systemd-resolved.service format-cache.service
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Configures TCP pacing properly depending on the site's uplink speed
-After=network-online.target
-Wants=network-online.target
+After=systemd-networkd-wait-online.service
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Configures TCP pacing properly depending on the site's uplink speed
-Requires=network-online.target
+Wants=network-online.target
 After=systemd-networkd-wait-online.service systemd-resolved.service
 
 [Service]

--- a/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Configures TCP pacing properly depending on the site's uplink speed
-After=systemd-networkd-wait-online.service
+Requires=network-online.target
+After=systemd-networkd-wait-online.service systemd-resolved.service
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Configures TCP pacing properly depending on the site's uplink speed
 Requires=network-online.target
-After=systemd-networkd-wait-online.service systemd-resolved.service format-cache.service
+After=network-online.target
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Configures TCP pacing properly depending on the site's uplink speed
-Requires=network-online.target
-After=network-online.target
+After=multi-user.target
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
@@ -1,9 +1,7 @@
 [Unit]
 Description=Configures TCP pacing properly depending on the site's uplink speed
-# The script that configures fair queueing has to do a name lookup, and will
-# fail if name resolution is not 100% functional.
-# https://www.freedesktop.org/software/systemd/man/systemd.special.html#nss-lookup.target
-After=nss-lookup.target
+After=network-online.target
+Wants=network-online.target
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,6 +1,7 @@
 [Unit]
 # We want this unit to run before we mount to be sure that disk gets formatted first.
 Before=cache-data.mount cache-docker.mount
+After=local-fs.target
 ConditionPathExists=!/cache/data
 ConditionPathExists=!/cache/docker
 DefaultDependencies=no

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,7 +1,8 @@
 [Unit]
 # We want this unit to run before we mount to be sure that disk gets formatted first.
 Before=cache-data.mount cache-docker.mount
-After=local-fs.target
+BindsTo=dev-sda.device
+After=dev-sda.device
 ConditionPathExists=!/cache/data
 ConditionPathExists=!/cache/docker
 DefaultDependencies=no

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,6 +1,7 @@
 [Unit]
 # We want this unit to run before we mount to be sure that disk gets formatted first.
 Before=cache-data.mount cache-docker.mount
+After=dev-sda.device
 ConditionPathExists=!/cache/data
 ConditionPathExists=!/cache/docker
 DefaultDependencies=no

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,7 +1,6 @@
 [Unit]
 # We want this unit to run before we mount to be sure that disk gets formatted first.
 Before=cache-data.mount cache-docker.mount
-After=dev-sda.device
 ConditionPathExists=!/cache/data
 ConditionPathExists=!/cache/docker
 DefaultDependencies=no


### PR DESCRIPTION
During a rolling reboot in staging it was observed that multiple nodes were reporting this error:

```
configure_tc_fq.sh[686]: curl: (6) Could not resolve host: siteinfo.mlab-oti.measurementlab.net
```

It would appear that the ordering/dependency chain on this service was not enough to be 100% sure that name resolution would be functional. The timing appeared tight in the logs:

```
Jul 23 06:53:01 mlab4-atl02.mlab-staging.measurement-lab.org systemd[1]: Reached target Network.
Jul 23 06:53:01 mlab4-atl02.mlab-staging.measurement-lab.org systemd[1]: Reached target Network is Online.
Jul 23 06:53:01 mlab4-atl02.mlab-staging.measurement-lab.org systemd[1]: Reached target Host and Network Name Lookups.
Jul 23 06:53:01 mlab4-atl02.mlab-staging.measurement-lab.org systemd[1]: Starting Configures TCP pacing properly depending on the site's uplink speed...
Jul 23 06:53:01 mlab4-atl02.mlab-staging.measurement-lab.org configure_tc_fq.sh[686]: curl: (6) Could not resolve host: siteinfo.mlab-oti.measurementlab.net
```

"Name Looks" was reported started during the same second as the failure.

This PR attempts to resolve this by ordering the `configure-tc-fq.service` after the [nss-lookup.target](https://www.freedesktop.org/software/systemd/man/systemd.special.html#nss-lookup.target).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/187)
<!-- Reviewable:end -->
