### PR TITLE
Adds a small delay between creating a partition and formatting it.

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -24,6 +24,10 @@ ExecStart=/usr/sbin/parted --align=optimal --script /dev/sda \
     mkpart data xfs 0%% 90%% \
     mkpart docker xfs 90%% 100%%
 
+# There is potentially a delay between parted creating partitions and those
+# partitions devices (e.g., /dev/sda1) showing in in /dev.
+ExecStart=sleep 3
+
 # Format and label each partition.
 # Note: the labels could make the formatting conditional in the future.
 ExecStart=/usr/sbin/mkfs.xfs -f -L cache-data /dev/sda1

--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -26,7 +26,7 @@ ExecStart=/usr/sbin/parted --align=optimal --script /dev/sda \
 
 # There is potentially a delay between parted creating partitions and those
 # partitions devices (e.g., /dev/sda1) showing in in /dev.
-ExecStart=sleep 3
+ExecStart=sleep 1
 
 # Format and label each partition.
 # Note: the labels could make the formatting conditional in the future.


### PR DESCRIPTION
mlab4-gru02 failed to boot fully, the cause being this failure of the `format-cache.service`:

`mkfs.xfs[867]: Error accessing specified device /dev/sda1: No such file or directory`

`mkfs.xfs` gets run immediately after `parted`. Apparently the partition devices did not show up in /dev before `mkfs` was run. This PR adds an arbitrary 3s delay after parted to allow a bit more time for the partition devices to show up. 3s is probably excessive, but likely not too little.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/188)
<!-- Reviewable:end -->
