### PR TITLE
Auto load ip6table_filter modules for access envelope

### DIFF
--- a/configs/stage3_ubuntu/etc/modules
+++ b/configs/stage3_ubuntu/etc/modules
@@ -7,3 +7,5 @@ tcp_bbr
 # Support for NICs in older R620 machines.
 tg3
 
+# Support access envelope ip6table operations.
+ip6table_filter


### PR DESCRIPTION
Add the `ip6table_filter` to /etc/modules for the standard ubuntu environment. The iptable_filter modules are loaded automatically by other services. The access envelope uses ip6tables to manage ipv6 addresses. This change ensures that the ip6table_filter module is loaded on startup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/189)
<!-- Reviewable:end -->
