### PR TITLE
Breaks DRAC configuration into stage1 and stage2

### DIFF
--- a/actions/stage2/stage1to2.ipxe
+++ b/actions/stage2/stage1to2.ipxe
@@ -71,6 +71,7 @@ set kargs ${kargs} epoxy.stage2=${stage2_url}
 set kargs ${kargs} epoxy.stage3=${stage3_url}
 set kargs ${kargs} epoxy.report=${report_url}
 set kargs ${kargs} epoxy.allocate_k8s_token=${allocate_k8s_token_url}
+set kargs ${kargs} epoxy.bmc_store_password=${bmc_store_password_url}
 set kargs ${kargs} epoxy.server=${epoxyaddress}
 set kargs ${kargs} epoxy.project=${project}
 

--- a/actions/stage3_ubuntu/stage1to2.json
+++ b/actions/stage3_ubuntu/stage1to2.json
@@ -22,6 +22,7 @@
             "epoxy.stage3={{kargs `epoxy.stage3`}}",
             "epoxy.report={{kargs `epoxy.report`}}",
             "epoxy.allocate_k8s_token={{kargs `epoxy.allocate_k8s_token`}}",
+            "epoxy.bmc_store_password={{kargs `epoxy.bmc_store_password`}}",
             "epoxy.server={{kargs `epoxy.server`}}",
             "epoxy.project={{kargs `epoxy.project`}}"
          ],

--- a/actions/stage3_update/stage1to2.json
+++ b/actions/stage3_update/stage1to2.json
@@ -22,6 +22,7 @@
             "epoxy.stage3={{kargs `epoxy.stage3`}}",
             "epoxy.report={{kargs `epoxy.report`}}",
             "epoxy.allocate_k8s_token={{kargs `epoxy.allocate_k8s_token`}}",
+            "epoxy.bmc_store_password={{kargs `epoxy.bmc_store_password`}}",
             "epoxy.server={{kargs `epoxy.server`}}",
             "epoxy.project={{kargs `epoxy.project`}}"
          ],

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -78,6 +78,8 @@ function setup_drac_stage1() {
     local epoxy_ipv4=$( get_cmdline epoxy.ipv4 "192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4" )
     local ipmi_ipv4
 
+    echo "Checking if stage1 DRAC configuration is needed..."
+
     if [ -z "$drac_ipv4" ]; then
       echo "Cannot read DRAC's IPv4 from /proc/cmdline."
       return 1
@@ -134,6 +136,8 @@ function setup_drac_stage2() {
     local bmc_store_password_url=$( get_cmdline epoxy.bmc_store_password "" )
     local password
 
+    echo "Configuring DRAC default user..."
+
     ipmi_user=$( ipmitool user list 1 | grep '^2' | awk '{print $2}' | tr -d '[:space:]' )
     if [ $? -ne 0 ] || [ -z "$ipmi_user" ]; then
       echo "Cannot read current DRAC username via ipmitool."
@@ -144,8 +148,6 @@ function setup_drac_stage2() {
     if [[ $? -ne 0 ]]; then
       return 1
     fi
-
-    echo "Configuring DRAC default user..."
 
     # Generate a semi-random password for the DRAC. Read plenty of chars from
     # urandom to be 100% sure we get enough desired chars for the password.
@@ -183,12 +185,12 @@ setup_network
 
 echo "Downloading next stage from ePoxy"
 if grep epoxy.stage1 /proc/cmdline > /dev/null ; then
-  echo "Checking if stage1 DRAC configuration is needed..."
   setup_drac_stage1
   epoxy_client -action epoxy.stage1 -add-kargs
 elif grep epoxy.stage2 /proc/cmdline > /dev/null ; then
   # If the user name is _not_ the default/final one, then we presume that we
   # need to configure the user name and password.
+  echo "Checking if stage2 DRAC configuration is needed..."
   if [[ $ipmi_user != $BMC_DEFAULT_USERNAME ]]; then
     setup_drac_stage2
   else

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -61,7 +61,7 @@ function setup_drac() {
     local bmc_store_password_url=$( get_cmdline epoxy.bmc_store_password "" )
     local drac_ipv4=$( get_cmdline drac.ipv4 "" )
     local epoxy_ipv4=$( get_cmdline epoxy.ipv4 "192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4" )
-    local ipmi_ipv4=$( ipmitool lan print 1 | awk -F: '/^IP Address  /{print $2}' | tr -d '[:space:]' )
+    local ipmi_ipv4
     local password
     local password_length="20"
 
@@ -79,6 +79,7 @@ function setup_drac() {
       return 1
     fi
 
+    ipmi_ipv4=$( ipmitool lan print 1 | awk -F: '/^IP Address  /{print $2}' | tr -d '[:space:]' )
     if [ $? -ne 0 ] || [ -z "$ipmi_ipv4" ]; then
       echo "Cannot read current IPv4 address via ipmitool."
       return 1

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -91,7 +91,10 @@ function setup_drac() {
       echo "Configuring DRAC..."
 
       # Generate a semi-random password for the DRAC.
+      # Temporarily disable pipefail for read of urandom.
+      set +o pipefail
       password=$( tr -dc A-Z-a-z-0-9 < /dev/urandom | head -c "$password_length" )
+      set -o pipefail
       if [[ -z $password ]]; then
         echo "Failed to generate a random password for the BMC."
         return 1

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -170,7 +170,6 @@ function setup_drac_stage2() {
       return 1
     fi
 
-
     logrun ipmitool user set name 2 admin
     logrun ipmitool user set password 2 "$password" 20
 

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -169,8 +169,9 @@ function setup_drac_stage2() {
         --write-out "%{http_code}" "${bmc_store_password_url}?p=${password}"
       )
       if [[ $bmc_store_password_status != "200" ]]; then
-        # If the return code was not 200, attempt to set the BMC password back
-        # to known preset.
+        # If the return code was not 200, attempt to set the BMC user/password
+        # back to known presets.
+        logrun ipmitool user set name 2 "$BMC_STAGE1_USERNAME"
         logrun ipmitool user set password 2 "$BMC_DEFAULT_PASSWORD" 20
         echo "Failed to store BMC password in GCD. Got HTTP status code: ${bmc_store_password_status}"
         return 1

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+BMC_STAGE1_USERNAME="stageone"
+BMC_DEFAULT_USERNAME="admin"
 BMC_DEFAULT_PASSWORD="me@sur3m3nt"
 
 function logrun() {
@@ -96,7 +98,7 @@ function setup_drac_stage1() {
 
       echo $epoxy_ipv4 | tr ',' ' ' | (
         read _ gateway _
-        logrun ipmitool user set name 2 stage1
+        logrun ipmitool user set name 2 "$BMC_STAGE1_USERNAME"
         logrun ipmitool user set password 2 "$BMC_DEFAULT_PASSWORD" 20
         logrun ipmitool lan set 1 ipsrc static
         logrun ipmitool lan set 1 ipaddr $drac_ipv4
@@ -134,7 +136,7 @@ function setup_drac_stage2() {
       return 1
     fi
 
-    if [ "$ipmi_user" != "admin" ]; then
+    if [[ $ipmi_user != $BMC_DEFAULT_USERNAME ]]; then
       echo "Configuring DRAC default user..."
 
       # Generate a semi-random password for the DRAC. Read plenty of chars from

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -156,13 +156,13 @@ function setup_drac_stage2() {
         return 1
       fi
 
-      logrun ipmitool user set name 2 admin
-      logrun ipmitool user set password 2 "$password" 20
-
       if [[ -z bmc_store_password_url ]]; then
         echo "No kernel param named epoxy.bmc_store_password."
         return 1
       fi
+
+      logrun ipmitool user set name 2 admin
+      logrun ipmitool user set password 2 "$password" 20
 
       bmc_store_password_status=$(
         curl --fail --silent --show-error -XPOST --data-binary "{}" \

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -78,11 +78,6 @@ function setup_drac_stage1() {
     local epoxy_ipv4=$( get_cmdline epoxy.ipv4 "192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4" )
     local ipmi_ipv4
 
-    load_ipmi_modules
-    if [[ $? -ne 0 ]]; then
-      return 1
-    fi
-
     if [ -z "$drac_ipv4" ]; then
       echo "Cannot read DRAC's IPv4 from /proc/cmdline."
       return 1
@@ -91,6 +86,11 @@ function setup_drac_stage1() {
     ipmi_ipv4=$( ipmitool lan print 1 | awk -F: '/^IP Address  /{print $2}' | tr -d '[:space:]' )
     if [ $? -ne 0 ] || [ -z "$ipmi_ipv4" ]; then
       echo "Cannot read current IPv4 address via ipmitool."
+      return 1
+    fi
+
+    load_ipmi_modules
+    if [[ $? -ne 0 ]]; then
       return 1
     fi
 
@@ -131,14 +131,14 @@ function setup_drac_stage2() {
     local bmc_store_password_url=$( get_cmdline epoxy.bmc_store_password "" )
     local password
 
-    load_ipmi_modules
-    if [[ $? -ne 0 ]]; then
-      return 1
-    fi
-
     ipmi_user=$( ipmitool user list 1 | grep '^2' | awk '{print $2}' | tr -d '[:space:]' )
     if [ $? -ne 0 ] || [ -z "$ipmi_user" ]; then
       echo "Cannot read current DRAC username via ipmitool."
+      return 1
+    fi
+
+    load_ipmi_modules
+    if [[ $? -ne 0 ]]; then
       return 1
     fi
 

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+BMC_DEFAULT_PASSWORD="me@sur3m3nt"
+
 function logrun() {
     echo $@
     $@
@@ -53,26 +55,28 @@ function setup_network() {
   ip address show ${interface}
 }
 
-function setup_drac() {
-  (
-    set -o pipefail
-
-    local bmc_store_password_status
-    local bmc_store_password_url=$( get_cmdline epoxy.bmc_store_password "" )
-    local drac_ipv4=$( get_cmdline drac.ipv4 "" )
-    local epoxy_ipv4=$( get_cmdline epoxy.ipv4 "192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4" )
-    local ipmi_ipv4
-    local password
-    local password_length="20"
-
+function load_ipmi_modules() {
     # These can fail if there is no IPMI device.
     if ! modprobe ipmi_si; then
+      echo "Failed to load kernel module ipmi_si."
       return 1
     fi
 
     if ! modprobe ipmi_devintf; then
+      echo "Failed to load kernel module ipmi_devintf."
       return 1
     fi
+}
+
+function setup_drac_stage1() {
+  (
+    set -o pipefail
+
+    local drac_ipv4=$( get_cmdline drac.ipv4 "" )
+    local epoxy_ipv4=$( get_cmdline epoxy.ipv4 "192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4" )
+    local ipmi_ipv4
+
+    load_ipmi_modules
 
     if [ -z "$drac_ipv4" ]; then
       echo "Cannot read DRAC's IPv4 from /proc/cmdline."
@@ -90,19 +94,10 @@ function setup_drac() {
     if [ "$ipmi_ipv4" != "$drac_ipv4" ]; then
       echo "Configuring DRAC..."
 
-      # Generate a semi-random password for the DRAC.
-      # Read plenty of chars from urandom to be 100% sure we get enough desired
-      # chars to fulfill $password_length.
-      password=$( head -c 250 /dev/urandom | tr -dc A-Z-a-z-0-9 | head -c "$password_length" )
-      if [[ -z $password ]]; then
-        echo "Failed to generate a random password for the BMC."
-        return 1
-      fi
-
       echo $epoxy_ipv4 | tr ',' ' ' | (
         read _ gateway _
-        logrun ipmitool user set name 2 admin
-        logrun ipmitool user set password 2 "$password" "$password_length"
+        logrun ipmitool user set name 2 stage1
+        logrun ipmitool user set password 2 "$BMC_DEFAULT_PASSWORD" 20
         logrun ipmitool lan set 1 ipsrc static
         logrun ipmitool lan set 1 ipaddr $drac_ipv4
         # On Dell R640 and iDRAC 9, setting the IP address takes longer than
@@ -117,6 +112,41 @@ function setup_drac() {
         logrun ipmitool lan set 1 netmask 255.255.255.192
         logrun ipmitool lan set 1 defgw ipaddr $gateway
       )
+    else
+      echo "DRAC is configured already. Skipping configuration."
+    fi
+  )
+}
+
+function setup_drac_stage2() {
+  (
+    set -o pipefail
+
+    local bmc_store_password_status
+    local bmc_store_password_url=$( get_cmdline epoxy.bmc_store_password "" )
+    local password
+
+    load_ipmi_modules
+
+    ipmi_user=$( ipmitool user list 1 | grep '^2' | awk '{print $2}' | tr -d '[:space:]' )
+    if [ $? -ne 0 ] || [ -z "$ipmi_user" ]; then
+      echo "Cannot read current DRAC username via ipmitool."
+      return 1
+    fi
+
+    if [ "$ipmi_user" != "admin" ]; then
+      echo "Configuring DRAC default user..."
+
+      # Generate a semi-random password for the DRAC. Read plenty of chars from
+      # urandom to be 100% sure we get enough desired chars for the password.
+      password=$( head -c 250 /dev/urandom | tr -dc A-Z-a-z-0-9 | head -c 20 )
+      if [[ -z $password ]]; then
+        echo "Failed to generate a random password for the BMC."
+        return 1
+      fi
+
+      logrun ipmitool user set name 2 admin
+      logrun ipmitool user set password 2 "$password" 20
 
       if [[ -z bmc_store_password_url ]]; then
         echo "No kernel param named epoxy.bmc_store_password."
@@ -128,11 +158,14 @@ function setup_drac() {
         --write-out "%{http_code}" "${bmc_store_password_url}?q=${password}"
       )
       if [[ $bmc_store_password_status != "200" ]]; then
+        # If the return code was not 200, attempt to set the BMC password back
+        # to known preset.
+        logrun ipmitool user set password 2 "$BMC_DEFAULT_PASSWORD" 20
         echo "Failed to store BMC password in GCD. Got HTTP status code: ${bmc_store_password_status}"
         return 1
       fi
     else
-      echo "DRAC is configured already. Skipping configuration."
+      echo "DRAC default user is already named admin. Doing nothing..."
     fi
   )
 }
@@ -140,13 +173,14 @@ function setup_drac() {
 echo "Configuring network..."
 setup_network
 
-echo "Checking if DRAC needs to be configured..."
-setup_drac
-
 echo "Downloading next stage from ePoxy"
 if grep epoxy.stage1 /proc/cmdline > /dev/null ; then
+  echo "Checking if stage1 DRAC configuration is needed..."
+  setup_drac_stage1
   epoxy_client -action epoxy.stage1 -add-kargs
 elif grep epoxy.stage2 /proc/cmdline > /dev/null ; then
+  echo "Checking if stage2 DRAC configuration is needed..."
+  setup_drac_stage2
   epoxy_client -action epoxy.stage2
 else
   echo "WARNING: unknown or no stage found in /proc/cmdline"

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -79,6 +79,9 @@ function setup_drac_stage1() {
     local ipmi_ipv4
 
     load_ipmi_modules
+    if [[ $? -ne 0 ]]; then
+      return 1
+    fi
 
     if [ -z "$drac_ipv4" ]; then
       echo "Cannot read DRAC's IPv4 from /proc/cmdline."
@@ -129,6 +132,9 @@ function setup_drac_stage2() {
     local password
 
     load_ipmi_modules
+    if [[ $? -ne 0 ]]; then
+      return 1
+    fi
 
     ipmi_user=$( ipmitool user list 1 | grep '^2' | awk '{print $2}' | tr -d '[:space:]' )
     if [ $? -ne 0 ] || [ -z "$ipmi_user" ]; then

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 BMC_STAGE1_USERNAME="stageone"
-BMC_DEFAULT_USERNAME="admin"
-BMC_DEFAULT_PASSWORD="me@sur3m3nt"
+BMC_STAGE1_PASSWORD="me@sur3m3nt"
+BMC_FINAL_USERNAME="admin"
 
 function logrun() {
     echo $@
@@ -103,11 +103,11 @@ function setup_drac_stage1() {
 
       echo $epoxy_ipv4 | tr ',' ' ' | (
         read _ gateway _
-        # Here we set the default user name to something unique for stage1 DRAC
-        # configuration, this becomes a flag to the stage2 configuration to
-        # modify the change the user name and set final password.
+        # Here we set the user name to something unique for stage1 DRAC
+        # configuration. This stage1 name becomes a flag to the stage2
+        # configuration process to set the final user name and password.
         logrun ipmitool user set name 2 "$BMC_STAGE1_USERNAME"
-        logrun ipmitool user set password 2 "$BMC_DEFAULT_PASSWORD" 20
+        logrun ipmitool user set password 2 "$BMC_STAGE1_PASSWORD" 20
         logrun ipmitool lan set 1 ipsrc static
         logrun ipmitool lan set 1 ipaddr $drac_ipv4
         # On Dell R640 and iDRAC 9, setting the IP address takes longer than
@@ -145,8 +145,8 @@ function setup_drac_stage2() {
     # If the user name is _not_ the default/final one, then we presume that we
     # need to configure the user name and password.
     echo "Checking if stage2 DRAC configuration is needed..."
-    if [[ $ipmi_user == $BMC_DEFAULT_USERNAME ]]; then
-      echo "DRAC default user is already named $BMC_DEFAULT_USERNAME. Doing nothing..."
+    if [[ $ipmi_user == $BMC_FINAL_USERNAME ]]; then
+      echo "DRAC user is already named $BMC_FINAL_USERNAME. Doing nothing..."
       return 0
     fi
 
@@ -170,7 +170,7 @@ function setup_drac_stage2() {
       return 1
     fi
 
-    logrun ipmitool user set name 2 admin
+    logrun ipmitool user set name 2 "$BMC_FINAL_USERNAME"
     logrun ipmitool user set password 2 "$password" 20
 
     bmc_store_password_status=$(
@@ -179,9 +179,10 @@ function setup_drac_stage2() {
     )
     if [[ $bmc_store_password_status != "200" ]]; then
       # If the return code was not 200, attempt to set the BMC user/password
-      # back to known presets.
+      # back to the stage1 values so that configuration will be reattemped on
+      # the next boot.
       logrun ipmitool user set name 2 "$BMC_STAGE1_USERNAME"
-      logrun ipmitool user set password 2 "$BMC_DEFAULT_PASSWORD" 20
+      logrun ipmitool user set password 2 "$BMC_STAGE1_PASSWORD" 20
       echo "Failed to store BMC password in GCD. Got HTTP status code: ${bmc_store_password_status}"
       return 1
     fi

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -91,10 +91,9 @@ function setup_drac() {
       echo "Configuring DRAC..."
 
       # Generate a semi-random password for the DRAC.
-      # Temporarily disable pipefail for read of urandom.
-      set +o pipefail
-      password=$( tr -dc A-Z-a-z-0-9 < /dev/urandom | head -c "$password_length" )
-      set -o pipefail
+      # Read plenty of chars from urandom to be 100% sure we get enough desired
+      # chars to fulfill $password_length.
+      password=$( head -c 250 /dev/urandom | tr -dc A-Z-a-z-0-9 | head -c "$password_length" )
       if [[ -z $password ]]; then
         echo "Failed to generate a random password for the BMC."
         return 1

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -136,18 +136,21 @@ function setup_drac_stage2() {
     local bmc_store_password_url=$( get_cmdline epoxy.bmc_store_password "" )
     local password
 
-    echo "Configuring DRAC default user..."
-
     ipmi_user=$( ipmitool user list 1 | grep '^2' | awk '{print $2}' | tr -d '[:space:]' )
     if [ $? -ne 0 ] || [ -z "$ipmi_user" ]; then
       echo "Cannot read current DRAC username via ipmitool."
       return 1
     fi
 
-    load_ipmi_modules
-    if [[ $? -ne 0 ]]; then
-      return 1
+    # If the user name is _not_ the default/final one, then we presume that we
+    # need to configure the user name and password.
+    echo "Checking if stage2 DRAC configuration is needed..."
+    if [[ $ipmi_user == $BMC_DEFAULT_USERNAME ]]; then
+      echo "DRAC default user is already named $BMC_DEFAULT_USERNAME. Doing nothing..."
+      return 0
     fi
+
+    echo "Configuring DRAC default user..."
 
     # Generate a semi-random password for the DRAC. Read plenty of chars from
     # urandom to be 100% sure we get enough desired chars for the password.
@@ -161,6 +164,12 @@ function setup_drac_stage2() {
       echo "No kernel param named epoxy.bmc_store_password."
       return 1
     fi
+
+    load_ipmi_modules
+    if [[ $? -ne 0 ]]; then
+      return 1
+    fi
+
 
     logrun ipmitool user set name 2 admin
     logrun ipmitool user set password 2 "$password" 20
@@ -188,14 +197,7 @@ if grep epoxy.stage1 /proc/cmdline > /dev/null ; then
   setup_drac_stage1
   epoxy_client -action epoxy.stage1 -add-kargs
 elif grep epoxy.stage2 /proc/cmdline > /dev/null ; then
-  # If the user name is _not_ the default/final one, then we presume that we
-  # need to configure the user name and password.
-  echo "Checking if stage2 DRAC configuration is needed..."
-  if [[ $ipmi_user != $BMC_DEFAULT_USERNAME ]]; then
-    setup_drac_stage2
-  else
-    echo "DRAC default user is already named $BMC_DEFAULT_USERNAME. Doing nothing..."
-  fi
+  setup_drac_stage2
   epoxy_client -action epoxy.stage2
 else
   echo "WARNING: unknown or no stage found in /proc/cmdline"

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -101,6 +101,9 @@ function setup_drac_stage1() {
 
       echo $epoxy_ipv4 | tr ',' ' ' | (
         read _ gateway _
+        # Here we set the default user name to something unique for stage1 DRAC
+        # configuration, this becomes a flag to the stage2 configuration to
+        # modify the change the user name and set final password.
         logrun ipmitool user set name 2 "$BMC_STAGE1_USERNAME"
         logrun ipmitool user set password 2 "$BMC_DEFAULT_PASSWORD" 20
         logrun ipmitool lan set 1 ipsrc static

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -157,7 +157,7 @@ function setup_drac_stage2() {
 
       bmc_store_password_status=$(
         curl --fail --silent --show-error -XPOST --data-binary "{}" \
-        --write-out "%{http_code}" "${bmc_store_password_url}?q=${password}"
+        --write-out "%{http_code}" "${bmc_store_password_url}?p=${password}"
       )
       if [[ $bmc_store_password_status != "200" ]]; then
         # If the return code was not 200, attempt to set the BMC password back

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -145,39 +145,35 @@ function setup_drac_stage2() {
       return 1
     fi
 
-    if [[ $ipmi_user != $BMC_DEFAULT_USERNAME ]]; then
-      echo "Configuring DRAC default user..."
+    echo "Configuring DRAC default user..."
 
-      # Generate a semi-random password for the DRAC. Read plenty of chars from
-      # urandom to be 100% sure we get enough desired chars for the password.
-      password=$( head -c 250 /dev/urandom | tr -dc A-Za-z0-9 | head -c 20 )
-      if [[ -z $password ]]; then
-        echo "Failed to generate a random password for the BMC."
-        return 1
-      fi
+    # Generate a semi-random password for the DRAC. Read plenty of chars from
+    # urandom to be 100% sure we get enough desired chars for the password.
+    password=$( head -c 250 /dev/urandom | tr -dc A-Za-z0-9 | head -c 20 )
+    if [[ -z $password ]]; then
+      echo "Failed to generate a random password for the BMC."
+      return 1
+    fi
 
-      if [[ -z bmc_store_password_url ]]; then
-        echo "No kernel param named epoxy.bmc_store_password."
-        return 1
-      fi
+    if [[ -z bmc_store_password_url ]]; then
+      echo "No kernel param named epoxy.bmc_store_password."
+      return 1
+    fi
 
-      logrun ipmitool user set name 2 admin
-      logrun ipmitool user set password 2 "$password" 20
+    logrun ipmitool user set name 2 admin
+    logrun ipmitool user set password 2 "$password" 20
 
-      bmc_store_password_status=$(
-        curl --fail --silent --show-error -XPOST --data-binary "{}" \
-        --write-out "%{http_code}" "${bmc_store_password_url}?p=${password}"
-      )
-      if [[ $bmc_store_password_status != "200" ]]; then
-        # If the return code was not 200, attempt to set the BMC user/password
-        # back to known presets.
-        logrun ipmitool user set name 2 "$BMC_STAGE1_USERNAME"
-        logrun ipmitool user set password 2 "$BMC_DEFAULT_PASSWORD" 20
-        echo "Failed to store BMC password in GCD. Got HTTP status code: ${bmc_store_password_status}"
-        return 1
-      fi
-    else
-      echo "DRAC default user is already named $BMC_DEFAULT_USERNAME. Doing nothing..."
+    bmc_store_password_status=$(
+      curl --fail --silent --show-error -XPOST --data-binary "{}" \
+      --write-out "%{http_code}" "${bmc_store_password_url}?p=${password}"
+    )
+    if [[ $bmc_store_password_status != "200" ]]; then
+      # If the return code was not 200, attempt to set the BMC user/password
+      # back to known presets.
+      logrun ipmitool user set name 2 "$BMC_STAGE1_USERNAME"
+      logrun ipmitool user set password 2 "$BMC_DEFAULT_PASSWORD" 20
+      echo "Failed to store BMC password in GCD. Got HTTP status code: ${bmc_store_password_status}"
+      return 1
     fi
   )
 }
@@ -191,8 +187,13 @@ if grep epoxy.stage1 /proc/cmdline > /dev/null ; then
   setup_drac_stage1
   epoxy_client -action epoxy.stage1 -add-kargs
 elif grep epoxy.stage2 /proc/cmdline > /dev/null ; then
-  echo "Checking if stage2 DRAC configuration is needed..."
-  setup_drac_stage2
+  # If the user name is _not_ the default/final one, then we presume that we
+  # need to configure the user name and password.
+  if [[ $ipmi_user != $BMC_DEFAULT_USERNAME ]]; then
+    setup_drac_stage2
+  else
+    echo "DRAC default user is already named $BMC_DEFAULT_USERNAME. Doing nothing..."
+  fi
   epoxy_client -action epoxy.stage2
 else
   echo "WARNING: unknown or no stage found in /proc/cmdline"

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -57,6 +57,14 @@ function setup_drac() {
   (
     set -o pipefail
 
+    local bmc_store_password_status
+    local bmc_store_password_url=$( get_cmdline epoxy.bmc_store_password "" )
+    local drac_ipv4=$( get_cmdline drac.ipv4 "" )
+    local epoxy_ipv4=$( get_cmdline epoxy.ipv4 "192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4" )
+    local ipmi_ipv4=$( ipmitool lan print 1 | awk -F: '/^IP Address  /{print $2}' | tr -d '[:space:]' )
+    local password
+    local password_length="20"
+
     # These can fail if there is no IPMI device.
     if ! modprobe ipmi_si; then
       return 1
@@ -66,13 +74,11 @@ function setup_drac() {
       return 1
     fi
 
-    local drac_ipv4=$( get_cmdline drac.ipv4 "" )
     if [ -z "$drac_ipv4" ]; then
       echo "Cannot read DRAC's IPv4 from /proc/cmdline."
       return 1
     fi
 
-    local ipmi_ipv4=$( ipmitool lan print 1 | awk -F: '/^IP Address  /{print $2}' | tr -d '[:space:]' )
     if [ $? -ne 0 ] || [ -z "$ipmi_ipv4" ]; then
       echo "Cannot read current IPv4 address via ipmitool."
       return 1
@@ -82,12 +88,18 @@ function setup_drac() {
     echo "Current IPv4 address: $ipmi_ipv4"
     if [ "$ipmi_ipv4" != "$drac_ipv4" ]; then
       echo "Configuring DRAC..."
-      local epoxy_ipv4=$( get_cmdline epoxy.ipv4 "192.168.0.2/24,192.168.0.1,8.8.8.8,8.8.4.4" )
+
+      # Generate a semi-random password for the DRAC.
+      password=$( tr -dc A-Z-a-z-0-9 < /dev/urandom | head -c "$password_length" )
+      if [[ -z $password ]]; then
+        echo "Failed to generate a random password for the BMC."
+        return 1
+      fi
 
       echo $epoxy_ipv4 | tr ',' ' ' | (
         read _ gateway _
         logrun ipmitool user set name 2 admin
-        logrun ipmitool user set password 2 "m3@sur3m3nt" 20
+        logrun ipmitool user set password 2 "$password" "$password_length"
         logrun ipmitool lan set 1 ipsrc static
         logrun ipmitool lan set 1 ipaddr $drac_ipv4
         # On Dell R640 and iDRAC 9, setting the IP address takes longer than
@@ -102,6 +114,20 @@ function setup_drac() {
         logrun ipmitool lan set 1 netmask 255.255.255.192
         logrun ipmitool lan set 1 defgw ipaddr $gateway
       )
+
+      if [[ -z bmc_store_password_url ]]; then
+        echo "No kernel param named epoxy.bmc_store_password."
+        return 1
+      fi
+
+      bmc_store_password_status=$(
+        curl --fail --silent --show-error -XPOST --data-binary "{}" \
+        --write-out "%{http_code}" "${bmc_store_password_url}?q=${password}"
+      )
+      if [[ $bmc_store_password_status != "200" ]]; then
+        echo "Failed to store BMC password in GCD. Got HTTP status code: ${bmc_store_password_status}"
+        return 1
+      fi
     else
       echo "DRAC is configured already. Skipping configuration."
     fi

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -141,7 +141,7 @@ function setup_drac_stage2() {
 
       # Generate a semi-random password for the DRAC. Read plenty of chars from
       # urandom to be 100% sure we get enough desired chars for the password.
-      password=$( head -c 250 /dev/urandom | tr -dc A-Z-a-z-0-9 | head -c 20 )
+      password=$( head -c 250 /dev/urandom | tr -dc A-Za-z0-9 | head -c 20 )
       if [[ -z $password ]]; then
         echo "Failed to generate a random password for the BMC."
         return 1
@@ -167,7 +167,7 @@ function setup_drac_stage2() {
         return 1
       fi
     else
-      echo "DRAC default user is already named admin. Doing nothing..."
+      echo "DRAC default user is already named $BMC_DEFAULT_USERNAME. Doing nothing..."
     fi
   )
 }


### PR DESCRIPTION
A new ePoxy extension was created to assist in creating GCD entities for BMCs on boot. The extension (bmc-store-password) URL is only available as a kernel parameter during the stage2 boot. Since stage2 is actually just a repurposed stage1 kernel and initramfs, this PR breaks DRAC configuration into two separate functions. One will be run during stage1 is is responsible for setting up the DRACs network configurations. Another will run during stage2 and is responsible for setting up login credentials for the BMC, and then storing those credentials in a GCD entity for the node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/192)
<!-- Reviewable:end -->
