### PR TITLE
Loads ipmi modules _before_ first use of ipmitool.

### DIFF
--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -165,7 +165,7 @@ function setup_drac_stage2() {
       return 1
     fi
 
-    if [[ -z bmc_store_password_url ]]; then
+    if [[ -z $bmc_store_password_url ]]; then
       echo "No kernel param named epoxy.bmc_store_password."
       return 1
     fi

--- a/configs/stage1_minimal/rc.local
+++ b/configs/stage1_minimal/rc.local
@@ -85,14 +85,14 @@ function setup_drac_stage1() {
       return 1
     fi
 
-    ipmi_ipv4=$( ipmitool lan print 1 | awk -F: '/^IP Address  /{print $2}' | tr -d '[:space:]' )
-    if [ $? -ne 0 ] || [ -z "$ipmi_ipv4" ]; then
-      echo "Cannot read current IPv4 address via ipmitool."
+    load_ipmi_modules
+    if [[ $? -ne 0 ]]; then
       return 1
     fi
 
-    load_ipmi_modules
-    if [[ $? -ne 0 ]]; then
+    ipmi_ipv4=$( ipmitool lan print 1 | awk -F: '/^IP Address  /{print $2}' | tr -d '[:space:]' )
+    if [ $? -ne 0 ] || [ -z "$ipmi_ipv4" ]; then
+      echo "Cannot read current IPv4 address via ipmitool."
       return 1
     fi
 
@@ -136,6 +136,11 @@ function setup_drac_stage2() {
     local bmc_store_password_url=$( get_cmdline epoxy.bmc_store_password "" )
     local password
 
+    load_ipmi_modules
+    if [[ $? -ne 0 ]]; then
+      return 1
+    fi
+
     ipmi_user=$( ipmitool user list 1 | grep '^2' | awk '{print $2}' | tr -d '[:space:]' )
     if [ $? -ne 0 ] || [ -z "$ipmi_user" ]; then
       echo "Cannot read current DRAC username via ipmitool."
@@ -162,11 +167,6 @@ function setup_drac_stage2() {
 
     if [[ -z bmc_store_password_url ]]; then
       echo "No kernel param named epoxy.bmc_store_password."
-      return 1
-    fi
-
-    load_ipmi_modules
-    if [[ $? -ne 0 ]]; then
       return 1
     fi
 


### PR DESCRIPTION
In a previous PR, I inadvertently moved loading of the IPMI modules _after_ the first use of `impitool`. This PR fixed that for both stage1 and stage2 DRAC configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/194)
<!-- Reviewable:end -->
