### PR TITLE
Adds a default systemd TimeoutStopSec of 180s.

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system.conf.d/10-timeoutstopsec.conf
+++ b/configs/stage3_ubuntu/etc/systemd/system.conf.d/10-timeoutstopsec.conf
@@ -1,0 +1,3 @@
+[Manager]
+DefaultTimeoutStopSec=180
+


### PR DESCRIPTION
All of our experiment pods are configured with a [`terminationGracePeriodSeconds` of 180](https://github.com/m-lab/k8s-support/blob/master/k8s/daemonsets/templates.jsonnet#L4). When deleting a pod, this gives the experiment time to flag itself as being in lame-duck mode, for prometheus to notice this, and then for mlab-ns to also notice this and stop sending production traffic to a site, before ultimately the pod and its containers are killed. However, currently, systemd will kill all processes after just 90s, since the default `TimeoutStopSec` is 90s.  When we reboot a machine, we need systemd to not kill containers before mlab-ns has stopped sending traffic there. This PR changes the `DefaultTimeoutStopSec` for systemd to 180s, which is then propagated too all processes which don't explicitly set this value.  This change should make it safe to login to a machine and issue a reboot, with no other actions. It is intended to resolve issue https://github.com/m-lab/k8s-support/issues/529, making it safe to use Kured as a mechanism for rolling reboots on the platform.

The caveat about this PR is that we are essentially hardcoding a variable value into our system configurations. I don't see this as much of a problem, because this setting does not prevent processes from exiting gracefully immediately (or very shortly after) systemd issues a SIGTERM. It just gives processes, where it may matter, another 90s to finish up. Even if we later move to another scheme where the locate service polls services directly, rather than getting status from Prometheus, the fallout from the config change is that machine _may_ take 90s longer to reboot and become available again. But that change is likely pretty far off.

To test this, before the changes in the PR were implemented, I ran the following loop on my local machine coincident with issuing a reboot command on mlab2-lga0t.

```
while nc -z ndt-iupui-mlab2-lga0t.mlab-sandbox.measurement-lab.org 443; do
    echo $(date) && sleep 1
done
```

... the loop only lasted for 90s, the default systemd `TimeoutStopSec`. I then implemented the changes in this PR and the same loop lasted for 180s (give or take some fraction of a second).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/197)
<!-- Reviewable:end -->
