### PR TITLE
Upgrades k8s components on nodes to v1.18.15

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -4,9 +4,9 @@
 export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
 
 # K8S component versions
-export K8S_VERSION=v1.17.8
+export K8S_VERSION=v1.18.5
 export CRI_VERSION=v1.18.0
-export CNI_VERSION=v0.8.6
+export CNI_VERSION=v0.9.0
 
 # stage3 mlxupdate
 export MFT_VERSION=4.14.0-105

--- a/config.sh
+++ b/config.sh
@@ -4,7 +4,7 @@
 export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
 
 # K8S component versions
-export K8S_VERSION=v1.18.5
+export K8S_VERSION=v1.18.15
 export CRI_VERSION=v1.18.0
 export CNI_VERSION=v0.9.0
 

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -157,13 +157,13 @@ done
 
 # Install the kubelet.service unit file.
 curl --silent --show-error --location \
-    "https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/debs/kubelet.service" \
+    "https://raw.githubusercontent.com/kubernetes/release/master/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service" \
     > $BOOTSTRAP/etc/systemd/system/kubelet.service
 
 # Install kubelet.service config overrides.
 mkdir --parents $BOOTSTRAP/etc/systemd/system/kubelet.service.d
 curl --silent --show-error --location \
-    "https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/debs/10-kubeadm.conf" \
+    "https://raw.githubusercontent.com/kubernetes/release/master/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" \
      > $BOOTSTRAP/etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
 # Enable various services.

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -58,10 +58,10 @@ if ! test -f $BOOTSTRAP/build.date ; then
     export DEBIAN_FRONTEND=noninteractive
 
     # A comma-separated list of additional packages we want installed.
-    PACKAGES="busybox,ca-certificates,curl,dbus,dmsetup,docker.io,ethtool,iproute2,"
-    PACKAGES+="jq,kexec-tools,less,linux-base,linux-generic,net-tools,openssh-server,"
-    PACKAGES+="parted,pciutils,socat,sudo,systemd-sysv,udev,unattended-upgrades,"
-    PACKAGES+="usbutils,vim,wget,xfsprogs"
+    PACKAGES="busybox,ca-certificates,conntrack,curl,dbus,dmsetup,docker.io,ethtool,"
+    PACKAGES+="iproute2,jq,kexec-tools,less,linux-base,linux-generic,net-tools,"
+    PACKAGES+="openssh-server,parted,pciutils,socat,sudo,systemd-sysv,udev,"
+    PACKAGES+="unattended-upgrades,usbutils,vim,wget,xfsprogs"
 
     # Create 'minbase' bootstrap fs.
     debootstrap --variant=minbase --include "${PACKAGES}" \

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -157,13 +157,13 @@ done
 
 # Install the kubelet.service unit file.
 curl --silent --show-error --location \
-    "https://raw.githubusercontent.com/kubernetes/release/master/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service" \
+    "https://raw.githubusercontent.com/kubernetes/release/v0.7.0/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service" \
     > $BOOTSTRAP/etc/systemd/system/kubelet.service
 
 # Install kubelet.service config overrides.
 mkdir --parents $BOOTSTRAP/etc/systemd/system/kubelet.service.d
 curl --silent --show-error --location \
-    "https://raw.githubusercontent.com/kubernetes/release/master/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" \
+    "https://raw.githubusercontent.com/kubernetes/release/v0.7.0/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" \
      > $BOOTSTRAP/etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
 # Enable various services.


### PR DESCRIPTION
These are the changes necessary to get nodes updated to k8s v1.18.15.

The static locations for `kubelet.service` and `10-kubeadm.conf` have changed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/198)
<!-- Reviewable:end -->
