### PR TITLE
Moves k8s cluster version check to its own script and own build step

### DIFF
--- a/check_cluster_k8s_version.sh
+++ b/check_cluster_k8s_version.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euxo pipefail
+
 source ./config.sh
 
 # Check k8s cluster version to be sure that it is equal to the configured k8s

--- a/check_cluster_k8s_version.sh
+++ b/check_cluster_k8s_version.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+source ./config.sh
+
+# Check k8s cluster version to be sure that it is equal to the configured k8s
+# version in this repo (config.sh) before continuing.
+CLUSTER_VERSION=$(
+  curl --insecure --silent \
+    https://api-platform-cluster.$PROJECT.measurementlab.net:6443/version \
+    | jq -r '.gitVersion'
+)
+if [[ $CLUSTER_VERSION != $K8S_VERSION ]]; then
+  echo "Cluster k8s version is ${CLUSTER_VERSION}, but configured k8s version in this repo is ${K8S_VERSION}. Exiting..."
+  exit 1
+fi
+

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -14,6 +14,13 @@ options:
 ############################################################################
 
 steps:
+# Verify that cluster k8s version is the same as configured version in this
+# repo.
+- name: gcr.io/$PROJECT_ID/epoxy-images
+  args: [
+    '/workspace/check_cluster_k8s_version.sh'
+  ]
+
 # stage1 minimal kernel & initram using stock ubuntu kernel.
 - name: gcr.io/$PROJECT_ID/epoxy-images
   args: [

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -49,18 +49,6 @@ function umount_proc_and_sys() {
 # Main script
 ##############################################################################
 
-# Check k8s cluster version to be sure that it is equal to the configured k8s
-# version in this repo before continuing.
-CLUSTER_VERSION=$(
-  curl --insecure --silent \
-    https://api-platform-cluster.$PROJECT.measurementlab.net:6443/version \
-    | jq -r '.gitVersion'
-)
-if [[ $CLUSTER_VERSION != $K8S_VERSION ]]; then
-  echo "Cluster k8s version is ${CLUSTER_VERSION}, but configured k8s version in this repo is ${K8S_VERSION}. Exiting..."
-  exit 1
-fi
-
 # Note: this step cannot be performed by docker build because it requires
 # --privileged mode to mount /proc.
 if ! test -f $BOOTSTRAP/build.date ; then


### PR DESCRIPTION
To keep our image build scripts as generic and reusable as possible, this PR moves the cluster version check step into its own Cloud Build step, step #0 (fail early), and the shell script into its own file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/203)
<!-- Reviewable:end -->
