### PR TITLE
Adds new sysctl config to increase fs.inotify.max_user_watches

### DIFF
--- a/configs/stage3_ubuntu/etc/sysctl.d/99-fs-inotify.conf
+++ b/configs/stage3_ubuntu/etc/sysctl.d/99-fs-inotify.conf
@@ -1,0 +1,6 @@
+# This should resolve error messages that we were seeing on machines like:
+#
+# "Failed to add control inotify watch descriptor for control group
+# /system.slice/mlab-set-quotas.service: No space left on device"
+fs.inotify.max_user_watches=131072
+


### PR DESCRIPTION
Today I noticed this error repeating quite a lot on a couple of machines at BOM02:

```
systemd[1]: mlab-set-quotas.service: Failed to add control inotify watch descriptor for control group /system.slice/mlab-set-quotas.service: No space left on device
```

I spot checked a few other machines on the platform and found that they had it too. Indeed, [we change this setting on platform API cluster nodes](https://github.com/m-lab/k8s-support/blob/35f6deb080d65759f12c324624f28ee6c1edde79/manage-cluster/cloud-config_master.yml#L228), too.

This PR should resolve those errors.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/205)
<!-- Reviewable:end -->
