### PR TITLE
Renames k8s vars + documents upgrading k8s components on platform nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ small shell command like the following:
 
 ```
 $ for node in $(kubectl --context <project> get nodes | grep '^mlab[1-4]' | awk '{print $1}'); do \
-    ssh $node 'touch /var/run/mlab-reboot'; \
+    ssh $node 'sudo touch /var/run/mlab-reboot'; \
   done
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,3 +77,75 @@ VBoxManage convertdd boot.fat16.gpt.img boot.vdi --format VDI
 ```
 
 Then select that image in the VM configuration.
+
+# Upgrading Kubernetes components
+
+Upgrading Kubernetes components on platform nodes is a separate process from
+[upgrading them in the API
+cluster](https://github.com/m-lab/k8s-support/#upgrading-the-api-cluster).
+Upgrading Kubernetes on platform nodes should _always_ occur _after_ the API
+cluster has been upgraded for a given project. The script
+./setup\_stage3\_ubuntu.sh has logic which is designed to enforce this
+requirement, but it is still worth mentioning here.
+
+Upgrading Kubernetes components on platform nodes should be as simple as
+copying the values for the [identially named config
+variables](https://github.com/m-lab/k8s-support/blob/master/manage-cluster/k8s_deploy.conf#L31)
+from the k8s-support repository to the ones in ./config.sh in this repository:
+
+* K8S\_VERSION
+* K8S\_CNI\_VERSION
+* K8S\_CRICTL\_VERSION
+
+Once the version strings are updated, and match those in the k8s-support
+repository, just follow the usual deployment path for epoxy-images i.e., push
+to sandbox, create PR, merge to master, tag repository. The Cloud Builds for
+this repository will generate new boot images with the updated Kubernetes
+components. In mlab-sandbox and mlab-staging, the newly built images will be
+automatically deployed to a node upon reboot. However, in production (mlab-oti)
+they will not be automatically deployed without further action.
+
+In order to deploy the new boot images to production you will need modify the
+`ImagesVersion` property of every ePoxy Host GCD entity to match the tag name
+of the production release for this repository. This can be done using the
+`epoxy_admin` tool. If you don't already have it installed, then install it
+with:
+
+```
+$ go get github.com/m-lab/epoxy/cmd/epoxy_admin
+```
+
+Once installed, you can update the ePoxy Host GCD entities in the mlab-oti
+project with a command like the following. **NOTE**: do not run this command
+against the mlab-sandbox or mlab-staging projects, as `ImagesVersion` is a
+static value in those projects and should always be "latest":
+
+```
+$ epoxy_admin update --project mlab-oti --images-version <tag> --hostname "^mlab[1-3]"
+```
+
+None of the nodes in any project will be running the updated images until they
+are rebooted. You can trigger a rolling reboot of all nodes in a cluster with a
+small shell command like the following:
+
+```
+$ for node in $(kubectl --context <project> get nodes | grep '^mlab[1-4]' | awk '{print $1}'); do \
+    ssh $node 'touch /var/run/mlab-reboot'; \
+  done
+```
+
+The former command assumes you have ssh access to every platform node. It
+leverages the [Kured
+DaemonSet](https://github.com/m-lab/k8s-support/blob/master/k8s/daemonsets/core/kured.jsonnet)
+running on the platform by creating the "reboot sentinel" file
+(/var/run/mlab-reboot) on every node, which tells Kured that a reboot is
+required. From there, Kured handles rebooting all flagged nodes in a safe way
+(one node a time).
+
+You can check the progress and/or completion of the upgrade by looking at the
+kubelet version for a node as reported by kubectl:
+
+```
+$ kubectl --context <project> get nodes
+```
+

--- a/README.md
+++ b/README.md
@@ -103,11 +103,14 @@ to sandbox, create PR, merge to master, tag repository. The Cloud Builds for
 this repository will generate new boot images with the updated Kubernetes
 components. In mlab-sandbox and mlab-staging, the newly built images will be
 automatically deployed to a node upon reboot. However, in production (mlab-oti)
-they will not be automatically deployed without further action.
+they will not be automatically deployed without further action. See the
+following section for more details.
 
-In order to deploy the new boot images to production you will need modify the
-`ImagesVersion` property of every ePoxy Host GCD entity to match the tag name
-of the production release for this repository. This can be done using the
+## Configure ePoxy to use a newer image version
+
+In order to deploy the new boot images to production you will need to modify
+the `ImagesVersion` property of every ePoxy Host GCD entity to match the tag
+name of the production release for this repository. This can be done using the
 `epoxy_admin` tool. If you don't already have it installed, then install it
 with:
 
@@ -123,6 +126,8 @@ static value in those projects and should always be "latest":
 ```
 $ epoxy_admin update --project mlab-oti --images-version <tag> --hostname "^mlab[1-3]"
 ```
+
+## Trigger a rolling reboot
 
 None of the nodes in any project will be running the updated images until they
 are rebooted. You can trigger a rolling reboot of all nodes in a cluster with a

--- a/config.sh
+++ b/config.sh
@@ -5,8 +5,8 @@ export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json
 
 # K8S component versions
 export K8S_VERSION=v1.19.12
-export CRI_VERSION=v1.19.0
-export CNI_VERSION=v0.9.1
+export K8S_CNI_VERSION=v0.9.1
+export K8S_CRICTL_VERSION=v1.19.0
 
 # stage3 mlxupdate
 export MFT_VERSION=4.14.0-105

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -218,7 +218,7 @@ sed -i -e 's/ENABLED=1/ENABLED=0/g' $BOOTSTRAP/etc/default/motd-news
 ################################################################################
 # Install the CNI binaries: bridge, flannel, host-local, ipvlan, loopback, etc.
 mkdir -p ${BOOTSTRAP}/opt/cni/bin
-curl --location "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" \
+curl --location "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-linux-amd64-${K8S_CNI_VERSION}.tgz" \
   | tar --directory=${BOOTSTRAP}/opt/cni/bin -xz
 
 # Make all the shims so that network plugins can be debugged.
@@ -252,9 +252,9 @@ rm -Rf ${TMPDIR}
 
 # Install crictl.
 mkdir -p ${BOOTSTRAP}/opt/bin
-wget https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRI_VERSION}/crictl-${CRI_VERSION}-linux-amd64.tar.gz
-tar zxvf crictl-${CRI_VERSION}-linux-amd64.tar.gz -C ${BOOTSTRAP}/opt/bin/
-rm -f crictl-${CRI_VERSION}-linux-amd64.tar.gz
+wget https://github.com/kubernetes-incubator/cri-tools/releases/download/${K8S_CRICTL_VERSION}/crictl-${K8S_CRICTL_VERSION}-linux-amd64.tar.gz
+tar zxvf crictl-${K8S_CRICTL_VERSION}-linux-amd64.tar.gz -C ${BOOTSTRAP}/opt/bin/
+rm -f crictl-${K8S_CRICTL_VERSION}-linux-amd64.tar.gz
 
 # Install the kube* commands.
 # Installation commands adapted from:

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -49,15 +49,18 @@ function umount_proc_and_sys() {
 # Main script
 ##############################################################################
 
-# Check k8s cluster version to be sure that it is equal to the configured k8s
-# version in this repo before continuing.
+# Make sure that the k8s version configured in K8S_VERSION in this repository
+# is not greater than the version currently running in the API cluster.
 CLUSTER_VERSION=$(
   curl --insecure --silent \
     https://api-platform-cluster.$PROJECT.measurementlab.net:6443/version \
     | jq -r '.gitVersion'
 )
-if [[ $CLUSTER_VERSION != $K8S_VERSION ]]; then
-  echo "Cluster k8s version is ${CLUSTER_VERSION}, but configured k8s version in this repo is ${K8S_VERSION}. Exiting..."
+LOWEST_VERSION=$(
+  echo -e "${CLUSTER_VERSION}\n${K8S_VERSION}" | sort --version-sort | head --lines 1
+)
+if [[ $LOWEST_VERSION != $K8S_VERSION ]]; then
+  echo "K8S_VERSION is ${K8S_VERSION}), which is greater than the cluster version of ${CLUSTER_VERSION}. Exiting..."
   exit 1
 fi
 


### PR DESCRIPTION
This PR renames the k8s component vars to match the names used for the same thing in the k8s-support repo. This should help to avoid confusion when upgrading k8s in either repo. It also adds some basic documentation on how to upgrade k8s components on platform nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/207)
<!-- Reviewable:end -->
