### PR TITLE
Update k8s, crictl and cni plugin versions

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -4,9 +4,9 @@
 export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
 
 # K8S component versions
-export K8S_VERSION=v1.18.15
-export CRI_VERSION=v1.18.0
-export CNI_VERSION=v0.9.0
+export K8S_VERSION=v1.19.12
+export CRI_VERSION=v1.19.0
+export CNI_VERSION=v0.9.1
 
 # stage3 mlxupdate
 export MFT_VERSION=4.14.0-105


### PR DESCRIPTION
This PR updates the versions in config.sh for the following components:
- Kubernetes
- crictl
- CNI plugin

So that they match https://github.com/m-lab/k8s-support/blob/master/manage-cluster/k8s_deploy.conf#L31, in preparation for the platform cluster upgrade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/208)
<!-- Reviewable:end -->
