### PR TITLE
Installs specific versions of CNI plugins

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -15,4 +15,4 @@ export MFT_VERSION=4.14.0-105
 export MLXROM_VERSION=3.4.817
 
 # multus-cni version
-export MULTUS_CNI_VERSION=3.7.2
+export MULTUS_CNI_VERSION=3.6

--- a/config.sh
+++ b/config.sh
@@ -13,3 +13,6 @@ export MFT_VERSION=4.14.0-105
 
 # stage1 mlxrom
 export MLXROM_VERSION=3.4.817
+
+# multus-cni version
+export MULTUS_CNI_VERSION=3.7.2

--- a/configs/stage3_ubuntu/opt/mlab/bin/setup_after_boot.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/setup_after_boot.sh
@@ -9,14 +9,6 @@ exec 2> /var/log/setup_after_boot.log 1>&2
 # Stop on any failure.
 set -euxo pipefail
 
-# Create a state directory for the IPAM host-local plugin (which is the IPAM
-# plugin used by flannel). And create two symlinks to is named after the
-# names of our two flannel networks. This causes both flannel networks to use
-# a common state directory to avoid IP assignment conflics for pods.
-mkdir -p /var/lib/cni/networks/flannel
-ln -s flannel /var/lib/cni/networks/flannel-conf
-ln -s flannel /var/lib/cni/networks/flannel-experiment-conf
-
 echo "Running epoxy client"
 /usr/bin/epoxy_client -action epoxy.stage3
 

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -227,19 +227,11 @@ curl --location "https://github.com/containernetworking/plugins/releases/downloa
 # Install multus, index2ip and netctl.
 TMPDIR=$(mktemp -d)
 pushd ${TMPDIR}
-mkdir -p src/github.com/intel
-pushd src/github.com/intel
-    git clone https://github.com/intel/multus-cni.git
-    pushd multus-cni
-        git checkout v3.2
-    popd
-  popd
-popd
-# TODO: restore `-u` flag. Removed so `go get` works on detached head.
-GOPATH=${TMPDIR} CGO_ENABLED=0 go get -ldflags '-w -s' github.com/intel/multus-cni/multus
+curl --location "https://github.com/k8snetworkplumbingwg/multus-cni/releases/download/v${MULTUS_CNI_VERSION}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64.tar.gz" \
+  | tar -xz
 GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/index2ip
 GOPATH=${TMPDIR} CGO_ENABLED=0 GO111MODULE=on go get -u -ldflags '-w -s' github.com/m-lab/cni-plugins/netctl
-cp ${TMPDIR}/bin/multus ${BOOTSTRAP}/opt/cni/bin
+cp ${TMPDIR}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64/multus-cni ${BOOTSTRAP}/opt/cni/bin/multus
 cp ${TMPDIR}/bin/index2ip ${BOOTSTRAP}/opt/cni/bin
 cp ${TMPDIR}/bin/netctl ${BOOTSTRAP}/opt/cni/bin
 chmod 755 ${BOOTSTRAP}/opt/cni/bin/*

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -230,7 +230,7 @@ pushd ${TMPDIR}
 curl --location "https://github.com/k8snetworkplumbingwg/multus-cni/releases/download/v${MULTUS_CNI_VERSION}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64.tar.gz" \
   | tar -xz
 GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/index2ip@v1.2.0
-GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/cni-plugins/netctl@v1.0.0/
+GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/cni-plugins/netctl@v1.0.0
 cp ${TMPDIR}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64/multus-cni ${BOOTSTRAP}/opt/cni/bin/multus
 cp ${TMPDIR}/bin/index2ip ${BOOTSTRAP}/opt/cni/bin
 cp ${TMPDIR}/bin/netctl ${BOOTSTRAP}/opt/cni/bin

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -229,8 +229,8 @@ TMPDIR=$(mktemp -d)
 pushd ${TMPDIR}
 curl --location "https://github.com/k8snetworkplumbingwg/multus-cni/releases/download/v${MULTUS_CNI_VERSION}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64.tar.gz" \
   | tar -xz
-GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/index2ip
-GOPATH=${TMPDIR} CGO_ENABLED=0 GO111MODULE=on go get -u -ldflags '-w -s' github.com/m-lab/cni-plugins/netctl
+GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/index2ip@v1.2.0
+GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/cni-plugins/netctl@v1.0.0/
 cp ${TMPDIR}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64/multus-cni ${BOOTSTRAP}/opt/cni/bin/multus
 cp ${TMPDIR}/bin/index2ip ${BOOTSTRAP}/opt/cni/bin
 cp ${TMPDIR}/bin/netctl ${BOOTSTRAP}/opt/cni/bin

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -244,7 +244,6 @@ for i in ${BOOTSTRAP}/opt/cni/bin/*; do
     # the symlink should reference in the final image filesystem.
     ln --symbolic --force /opt/shimcni/bin/shim.sh $(basename "$i")
 done
-popd
 
 # Install crictl.
 mkdir -p ${BOOTSTRAP}/opt/bin


### PR DESCRIPTION
This PR install these versions of these CNI plugins:

* multus-cni: v3.6 (up from previous v3.2)
* index2ip: v1.2.0 (not versioned previously)
* netctl: v1.0.0 (not versioned previously)

Additionally, this PR changes the way that multus-cni gets installed. Currently, the build process uses some rather convoluted method of cloning the git repo, checking out the desired branch, and manually building the version we want. However, the multus-cni repo publishes build artifacts with every release. With this PR, we simply download the correct archive and extract the binary we want.

One other small change is removal of the "flannel-conf" and "flannel-experiment-conf" symlinks in /var/lib/cni/networks. The internal IP leak issue was resolved (and was actually caused by these symlinks), obviating the need for these symlinks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/211)
<!-- Reviewable:end -->
