### PR TITLE
Causes shim.sh to exit with exit code of plugin

### DIFF
--- a/configs/stage3_ubuntu/opt/shimcni/bin/shim.sh
+++ b/configs/stage3_ubuntu/opt/shimcni/bin/shim.sh
@@ -40,3 +40,5 @@ cat \
   > summary
 chmod a+rx "${OUTPUT}"
 chmod a+r "${OUTPUT}"/*
+exit $(cat "${OUTPUT}/exitcode")
+


### PR DESCRIPTION
Previously, shim.sh would always exit with status code 0. In this
scenario, if the plugin that shim.sh called exited with a non-zero
status, indicating failure, shim.sh would still exit with 0, causing the
caller (the container runtime) to think everything succeeded, when it
really didn't. This commit simply causes shim.sh to explicitly exit
with the same exit code of the called plugin.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/212)
<!-- Reviewable:end -->
