### PR TITLE
Upgrade k8s to v1.20.13 and install flannel CNI plugin

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -7,7 +7,7 @@ export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json
 export K8S_VERSION=v1.20.13
 export K8S_CNI_VERSION=v1.0.1
 export K8S_CRICTL_VERSION=v1.20.0
-# v1.0.0 of the official CNI plugins release stopped including flannel, so we
+# v0.9.1 of the official CNI plugins release stopped including flannel, so we
 # must now install it manually.
 export K8S_FLANNELCNI_VERSION=v1.0.0
 

--- a/config.sh
+++ b/config.sh
@@ -7,6 +7,9 @@ export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json
 export K8S_VERSION=v1.20.13
 export K8S_CNI_VERSION=v1.0.1
 export K8S_CRICTL_VERSION=v1.20.0
+# v1.0.0 of the official CNI plugins release stopped including flannel, so we
+# must now install it manually.
+export K8S_FLANNELCNI_VERSION=v1.0.0
 
 # stage3 mlxupdate
 export MFT_VERSION=4.14.0-105

--- a/config.sh
+++ b/config.sh
@@ -4,9 +4,9 @@
 export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
 
 # K8S component versions
-export K8S_VERSION=v1.19.12
-export K8S_CNI_VERSION=v0.9.1
-export K8S_CRICTL_VERSION=v1.19.0
+export K8S_VERSION=v1.20.13
+export K8S_CNI_VERSION=v1.0.1
+export K8S_CRICTL_VERSION=v1.20.0
 
 # stage3 mlxupdate
 export MFT_VERSION=4.14.0-105
@@ -15,4 +15,4 @@ export MFT_VERSION=4.14.0-105
 export MLXROM_VERSION=3.4.817
 
 # multus-cni version
-export MULTUS_CNI_VERSION=3.6
+export MULTUS_CNI_VERSION=3.8

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -225,13 +225,14 @@ TMPDIR=$(mktemp -d)
 pushd ${TMPDIR}
 curl --location "https://github.com/k8snetworkplumbingwg/multus-cni/releases/download/v${MULTUS_CNI_VERSION}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64.tar.gz" \
   | tar -xz
-curl --location "https://github.com/flannel-io/cni-plugin/releases/download/${K8S_FLANNELCNI_VERSION}/flannel-amd64"
+curl --location "https://github.com/flannel-io/cni-plugin/releases/download/${K8S_FLANNELCNI_VERSION}/flannel-amd64" \
+  > flannel
 GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/index2ip@v1.2.0
 GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/cni-plugins/netctl@v1.0.0
 cp ${TMPDIR}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64/multus-cni ${BOOTSTRAP}/opt/cni/bin/multus
 cp ${TMPDIR}/bin/index2ip ${BOOTSTRAP}/opt/cni/bin
 cp ${TMPDIR}/bin/netctl ${BOOTSTRAP}/opt/cni/bin
-cp ${TMPDIR}/flannel-amd64 ${BOOTSTRAP}/opt/cni/bin/flannel
+cp ${TMPDIR}/flannel ${BOOTSTRAP}/opt/cni/bin
 chmod 755 ${BOOTSTRAP}/opt/cni/bin/*
 rm -Rf ${TMPDIR}
 

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -215,7 +215,7 @@ fi
 ################################################################################
 # Kubernetes / CNI / crictl
 ################################################################################
-# Install the CNI binaries: bridge, flannel, host-local, ipvlan, loopback, etc.
+# Install the CNI binaries.
 mkdir -p ${BOOTSTRAP}/opt/cni/bin
 curl --location "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-linux-amd64-${K8S_CNI_VERSION}.tgz" \
   | tar --directory=${BOOTSTRAP}/opt/cni/bin -xz

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -220,16 +220,18 @@ mkdir -p ${BOOTSTRAP}/opt/cni/bin
 curl --location "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-linux-amd64-${K8S_CNI_VERSION}.tgz" \
   | tar --directory=${BOOTSTRAP}/opt/cni/bin -xz
 
-# Install multus, index2ip and netctl.
+# Install multus, index2ip, netctl and flannel.
 TMPDIR=$(mktemp -d)
 pushd ${TMPDIR}
 curl --location "https://github.com/k8snetworkplumbingwg/multus-cni/releases/download/v${MULTUS_CNI_VERSION}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64.tar.gz" \
   | tar -xz
+curl --location "https://github.com/flannel-io/cni-plugin/releases/download/${K8S_FLANNELCNI_VERSION}/flannel-amd64"
 GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/index2ip@v1.2.0
 GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/cni-plugins/netctl@v1.0.0
 cp ${TMPDIR}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64/multus-cni ${BOOTSTRAP}/opt/cni/bin/multus
 cp ${TMPDIR}/bin/index2ip ${BOOTSTRAP}/opt/cni/bin
 cp ${TMPDIR}/bin/netctl ${BOOTSTRAP}/opt/cni/bin
+cp ${TMPDIR}/flannel-amd64 ${BOOTSTRAP}/opt/cni/bin/flannel
 chmod 755 ${BOOTSTRAP}/opt/cni/bin/*
 rm -Rf ${TMPDIR}
 


### PR DESCRIPTION
This PR upgrades k8s components to v1.20.13, along with upgrades to any supporting resources. It also installs the flannel CNI plugin to /opt/cni/bin, since the official CNI plugins package stopped including flannel as of v1.0.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/215)
<!-- Reviewable:end -->
