### PR TITLE
Reorders the last two commits of master

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -4,9 +4,12 @@
 export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
 
 # K8S component versions
-export K8S_VERSION=v1.19.12
-export K8S_CNI_VERSION=v0.9.1
-export K8S_CRICTL_VERSION=v1.19.0
+export K8S_VERSION=v1.20.13
+export K8S_CNI_VERSION=v1.0.1
+export K8S_CRICTL_VERSION=v1.20.0
+# v0.9.1 of the official CNI plugins release stopped including flannel, so we
+# must now install it manually.
+export K8S_FLANNELCNI_VERSION=v1.0.0
 
 # stage3 mlxupdate
 export MFT_VERSION=4.14.0-105
@@ -15,4 +18,4 @@ export MFT_VERSION=4.14.0-105
 export MLXROM_VERSION=3.4.817
 
 # multus-cni version
-export MULTUS_CNI_VERSION=3.6
+export MULTUS_CNI_VERSION=3.8

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -219,21 +219,24 @@ sed -i -e 's/ENABLED=1/ENABLED=0/g' $BOOTSTRAP/etc/default/motd-news
 ################################################################################
 # Kubernetes / CNI / crictl
 ################################################################################
-# Install the CNI binaries: bridge, flannel, host-local, ipvlan, loopback, etc.
+# Install the CNI binaries.
 mkdir -p ${BOOTSTRAP}/opt/cni/bin
 curl --location "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-linux-amd64-${K8S_CNI_VERSION}.tgz" \
   | tar --directory=${BOOTSTRAP}/opt/cni/bin -xz
 
-# Install multus, index2ip and netctl.
+# Install multus, index2ip, netctl and flannel.
 TMPDIR=$(mktemp -d)
 pushd ${TMPDIR}
 curl --location "https://github.com/k8snetworkplumbingwg/multus-cni/releases/download/v${MULTUS_CNI_VERSION}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64.tar.gz" \
   | tar -xz
+curl --location "https://github.com/flannel-io/cni-plugin/releases/download/${K8S_FLANNELCNI_VERSION}/flannel-amd64" \
+  > flannel
 GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/index2ip@v1.2.0
 GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/cni-plugins/netctl@v1.0.0
 cp ${TMPDIR}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64/multus-cni ${BOOTSTRAP}/opt/cni/bin/multus
 cp ${TMPDIR}/bin/index2ip ${BOOTSTRAP}/opt/cni/bin
 cp ${TMPDIR}/bin/netctl ${BOOTSTRAP}/opt/cni/bin
+cp ${TMPDIR}/flannel ${BOOTSTRAP}/opt/cni/bin
 chmod 755 ${BOOTSTRAP}/opt/cni/bin/*
 rm -Rf ${TMPDIR}
 


### PR DESCRIPTION
This PR is a rewrite of the git history which reorders that last two commits of the master branch. The master branch currently looks like:

2e24673 -> 6241792 <- HEAD

This PR reverses those two commits, such that the commit history will look like:

6241792 -> 2e24673 <- HEAD

The reason for wanting to reverse these is that 6241792 (upgrade k8s) is a change that I want to rollout now, and 2e24673 (updates packages in rootfs) is change we want to canary and rollout more slowly, probably not until the new year. Reversing these commits will allow me to make a new release (v2.0.4) of this repo at commit 6241792, and then immediately make a second release (v2.0.5) against commit 2e24673 (effectively the HEAD of master). With this I can release v2.0.4 to every node, and then subsequently selectively release v2.0.5 to small subset of nodes for the canary.

This PR does rewrite the git history, but epoxy-images is a repo only used internally by M-Lab (that I know of), and mostly nobody but myself ever makes changes to it, so I don't believe it will cause any issues.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/216)
<!-- Reviewable:end -->
