### PR TITLE
Adds new systemd service to write NDT max-rate to a file

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Determines ndt-server max-rate for this node
+After=network.target
+Before=configure-tc-fq.service setup-after-boot.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/mlab/bin/max-rate.sh

--- a/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Determines ndt-server max-rate for this node
 After=nss-lookup.target
-Before=configure-tc-fq.service setup-after-boot.service
+Before=setup-after-boot.service
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
@@ -1,7 +1,8 @@
 [Unit]
 Description=Determines ndt-server max-rate for this node
-After=network-online.target
+After=systemd-networkd-wait-online.service
 Before=configure-tc-fq.service setup-after-boot.service
+Wants=systemd-networkd-wait-online.service
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Determines ndt-server max-rate for this node
-After=network.target
+After=network-online.target
 Before=configure-tc-fq.service setup-after-boot.service
 
 [Service]

--- a/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
@@ -6,3 +6,6 @@ Before=configure-tc-fq.service setup-after-boot.service
 [Service]
 Type=oneshot
 ExecStart=/opt/mlab/bin/max-rate.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
@@ -1,12 +1,8 @@
 [Unit]
 Description=Determines ndt-server max-rate for this node
-After=systemd-networkd-wait-online.service
+After=nss-lookup.target
 Before=configure-tc-fq.service setup-after-boot.service
-Wants=systemd-networkd-wait-online.service
 
 [Service]
 Type=oneshot
 ExecStart=/opt/mlab/bin/max-rate.sh
-
-[Install]
-WantedBy=multi-user.target

--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -1,16 +1,9 @@
 #!/bin/bash
 
-SITE=${HOSTNAME:6:5}
-SPEED=$(curl --silent --show-error --location \
-    https://siteinfo.mlab-oti.measurementlab.net/v1/sites/switches.json \
-    | jq -r ".${SITE}.uplink_speed")
-
-if [[ "${SPEED}" == "10g" ]]; then
-  MAXRATE="10gbit"
-elif [[ "${SPEED}" == "1g" ]]; then
-  MAXRATE="1gbit"
-else
-  echo "Unknown uplink speed '${SPEED}'. Not configuring default qdisc for eth0."
+MAX_RATE=$(cat /etc/ndt-max-rate)
+if [[ -z $MAX_RATE ]]; then
+  echo "ERROR: NDT max-rate not found in /etc/ndt-max-rate."
+  echo "Not configuring default qdisc for eth0."
   exit 1
 fi
 

--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -1,17 +1,24 @@
 #!/bin/bash
 
-MAX_RATE=$(cat /etc/ndt-max-rate)
-if [[ -z $MAX_RATE ]]; then
-  echo "ERROR: NDT max-rate not found in /etc/ndt-max-rate."
-  echo "Not configuring default qdisc for eth0."
+SITE=${HOSTNAME:6:5}
+SPEED=$(curl --silent --show-error --location \
+    https://siteinfo.mlab-oti.measurementlab.net/v1/sites/switches.json \
+    | jq -r ".${SITE}.uplink_speed")
+
+if [[ "${SPEED}" == "10g" ]]; then
+  MAXRATE="10gbit"
+elif [[ "${SPEED}" == "1g" ]]; then
+  MAXRATE="1gbit"
+else
+  echo "Unknown uplink speed '${SPEED}'. Not configuring default qdisc for eth0."
   exit 1
 fi
 
-/sbin/tc qdisc replace dev eth0 root fq maxrate "${MAX_RATE}"
+/sbin/tc qdisc replace dev eth0 root fq maxrate "${MAXRATE}"
 
 if [[ $? -ne 0 ]]; then
-  echo "Failed to configure qdisc fq on dev eth0 with max rate of: ${MAX_RATE}"
+  echo "Failed to configure qdisc fq on dev eth0 with max rate of: ${MAXRATE}"
   exit 1
 fi
 
-echo "Set maxrate for qdisc fq on dev eth0 to: ${MAX_RATE}"
+echo "Set maxrate for qdisc fq on dev eth0 to: ${MAXRATE}"

--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -7,6 +7,11 @@ if [[ -z $MAX_RATE ]]; then
   exit 1
 fi
 
-/sbin/tc qdisc replace dev eth0 root fq maxrate "${MAXRATE}"
+/sbin/tc qdisc replace dev eth0 root fq maxrate "${MAX_RATE}"
 
-echo "Set maxrate for qdisc fq on dev eth0 to: ${MAXRATE}"
+if [[ $? -ne 0 ]]; then
+  echo "Failed to configure qdisc fq on dev eth0 with max rate of: ${MAX_RATE}"
+  exit 1
+fi
+
+echo "Set maxrate for qdisc fq on dev eth0 to: ${MAX_RATE}"

--- a/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
@@ -8,8 +8,8 @@ SITEINFO_URL=siteinfo.${PROJECT}.measurementlab.net
 # configured to run _After_ the nss-lookup.target, for some reason DNS
 # resolution, at least for external hosts, is still not functional at this
 # point. Run a loop waiting for name resolution to start working before moving on.
-while busybox nslookup ${SITEINFO_URL} | grep SERVFAIL; do
-  echo "Name resolution failed."
+while busybox nslookup ${SITEINFO_URL} | grep SERVFAIL &> /dev/null; do
+  :
 done
 
 MAX_RATE=$(curl --silent --show-error --location \

--- a/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+SITE=${HOSTNAME:6:5}
+PROJECT=$(echo $HOSTNAME | cut -d. -f2)
+MAX_RATE=$(curl --silent --show-error --location \
+    https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/max-rates.json \
+    | jq -r ".${SITE}")
+
+if [[ -z $MAX_RATE ]]; then
+  echo "ERROR: Unable to determine NDT max-rate for site ${SITE}"
+  exit 1
+fi
+
+echo -n $MAX_RATE > /etc/ndt-max-rate

--- a/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+#
+# max-rate.sh downloads the siteinfo format max-rates.json, determines the
+# NDT max-rate for the current site, and then writes that value to a file in the
+# local filesystem. ndt-server will read this value in order to properly set its
+# -txcontroller.max-rate flag. This script takes no arguments, and the only
+# input it uses is the $HOSTNAME environment variable to determine the node's
+# site name and GCP project.
 
 SITE=${HOSTNAME:6:5}
 PROJECT=$(echo $HOSTNAME | cut -d. -f2)
@@ -10,7 +17,7 @@ METADATA_DIR=/var/local/metadata
 # resolution, at least for external hosts, is still not functional at this
 # point. Run a loop waiting for name resolution to start working before moving on.
 while busybox nslookup ${SITEINFO_URL} | grep SERVFAIL &> /dev/null; do
-  :
+  sleep .1
 done
 
 MAX_RATE=$(curl --silent --show-error --location \

--- a/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
@@ -2,14 +2,14 @@
 
 SITE=${HOSTNAME:6:5}
 PROJECT=$(echo $HOSTNAME | cut -d. -f2)
+SITEINFO_URL=siteinfo.${PROJECT}.measurementlab.net
 
-# Wait for DNS resolution to work before continuing
-while busybox nslookup siteinfo.${PROJECT}.measurementlab.net | grep NXDOMAIN; do
+while ! busybox nslookup ${SITEINFO_URL}; do
   echo "Name resolution failed."
 done
 
 MAX_RATE=$(curl --silent --show-error --location \
-    https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/max-rates.json \
+    https://${SITEINFO_URL}/v2/sites/max-rates.json \
     | jq -r ".${SITE}")
 
 if [[ -z $MAX_RATE ]]; then

--- a/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
@@ -2,6 +2,12 @@
 
 SITE=${HOSTNAME:6:5}
 PROJECT=$(echo $HOSTNAME | cut -d. -f2)
+
+# Wait for DNS resolution to work before continuing
+while busybox nslookup siteinfo.${PROJECT}.measurementlab.net | grep NXDOMAIN; do
+  echo "Name resolution failed."
+done
+
 MAX_RATE=$(curl --silent --show-error --location \
     https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/max-rates.json \
     | jq -r ".${SITE}")

--- a/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
@@ -4,7 +4,11 @@ SITE=${HOSTNAME:6:5}
 PROJECT=$(echo $HOSTNAME | cut -d. -f2)
 SITEINFO_URL=siteinfo.${PROJECT}.measurementlab.net
 
-while ! busybox nslookup ${SITEINFO_URL}; do
+# Even though the systemd service (max-rate.service) which calls this script is
+# configured to run _After_ the nss-lookup.target, for some reason DNS
+# resolution, at least for external hosts, is still not functional at this
+# point. Run a loop waiting for name resolution to start working before moving on.
+while busybox nslookup ${SITEINFO_URL} | grep SERVFAIL; do
   echo "Name resolution failed."
 done
 

--- a/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/max-rate.sh
@@ -3,6 +3,7 @@
 SITE=${HOSTNAME:6:5}
 PROJECT=$(echo $HOSTNAME | cut -d. -f2)
 SITEINFO_URL=siteinfo.${PROJECT}.measurementlab.net
+METADATA_DIR=/var/local/metadata
 
 # Even though the systemd service (max-rate.service) which calls this script is
 # configured to run _After_ the nss-lookup.target, for some reason DNS
@@ -21,4 +22,6 @@ if [[ -z $MAX_RATE ]]; then
   exit 1
 fi
 
-echo -n $MAX_RATE > /etc/ndt-max-rate
+mkdir -p ${METADATA_DIR}
+
+echo -n $MAX_RATE > $METADATA_DIR/iface-max-rate


### PR DESCRIPTION
Currently, the value for the ndt-server flag `-txcontroller.max-rate` makes it to ndt-server through a ConfigMap and some back bending both during k8s-support builds and at runtime. As I was thinking of a way to more gracefully plumb the max-rate to ndt-server, I noticed/remembered that the existing systemd service `configure-tc-fq.service` also needs this max-rate value, and currently downloads a file from siteinfo to figure out what value to use.

This PR introduces a new systemd service that will fetch the new siteinfo format "max-rates.json", extract the max bit rate for the site, and then write the value to a file at /etc/ndt-max-rate. The script for configuring the fq qdisc on boot can now use the value from this file. Additionally, this file can be mounted into ndt pods and supply the max-rate value for it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/219)
<!-- Reviewable:end -->
