### PR TITLE
pushd-s to flexboot root, not root/src

### DIFF
--- a/setup_stage1_mlxrom.sh
+++ b/setup_stage1_mlxrom.sh
@@ -46,7 +46,7 @@ function prepare_flexboot_source() {
     fi
     version=$( basename ${archive_path} .tar.gz )
     unpack ${version} ${archive_path}
-    pushd ${version}/src
+    pushd ${version}/
       # Add the 'driver_version' definition to flexboot source.
       git apply ${config_dir}/romprefix.S.diff
 


### PR DESCRIPTION
I noticed that stage1 builds of epoxy-images were failing in all 3 projects with this error in step 1:

```
+ pushd flexboot-20160705/src
/tmp/flexboot.mnN86s/flexboot-20160705/src /tmp/flexboot.mnN86s /workspace
+ git apply /workspace/configs/stage1_mlxrom/romprefix.S.diff
error: src/arch/x86/prefix/romprefix.S: No such file or directory
```

The shell scripts that run all this have not changed in a long time, nor has the flexboot source code (it is a static tgz in this repo). Something else must have changed about the environment in the meantime. I noticed that the failed diff has a file prefix of `a/src/arch/x86/prefix/romprefix.S`, yet we `pushd` into the `src/` subdirectory. Looking at the documentation for `git apply`, the default value for the `-p` flag is 1, which seems like it should have caused that command to fail in past too, yet it didn't. 

In any case, this PR simply changes to `pushd flexboot-20160705/` (minus `src/`), which seems to have fixed the build. I have no idea why this ever worked. Maybe Cloud Build is using some newer version of `git` which doesn't help users by figuring things out for them? In any case, builds seem to work now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/220)
<!-- Reviewable:end -->
