### PR TITLE
Signs all host ssh public keys with ssh CA private key

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -9,6 +9,11 @@ options:
     - 'PROJECT=$PROJECT_ID'
     - 'ARTIFACTS=/workspace/output'
 
+availableSecrets:
+  secretManager:
+  - versionName: projects/${PROJECT_NUMBER}/secrets/platform-ssh-host-ca-private-key/versions/latest
+    env: SSH_HOST_CA_KEY
+
 ############################################################################
 # BUILD ARTIFACTS
 ############################################################################
@@ -22,9 +27,12 @@ steps:
 
 # stage3_ubuntu images.
 - name: gcr.io/$PROJECT_ID/epoxy-images
-  args: [
-    '/workspace/builder.sh', 'stage3_ubuntu'
-  ]
+  entrypoint: /bin/bash
+  args:
+  - '-c'
+  - '/workspace/builder.sh stage3_ubuntu'
+  secretEnv:
+  - SSH_HOST_CA_KEY
 
 # stage3_update images.
 - name: gcr.io/$PROJECT_ID/epoxy-images

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -216,9 +216,12 @@ fi
 # stored in GCP Secret Manager which is made available to this script via an
 # environment variable. See cloudbuild.yaml in the root of this repo for details.
 pushd $BOOTSTRAP/etc/ssh
+# Don't log this command, since it contains sensitive private key material.
+set +x
 echo $SSH_HOST_CA_KEY > ./host_ca
+set -x
 for f in $(ls ssh_host_*_key.pub); do
-  ssh-keygen -s host_ca -I mlab -h -V forever $f
+  ssh-keygen -s host_ca -I mlab -h -V always:forever $f
   echo "HostCertificate /etc/ssh/$f" >> /etc/ssh/sshd_config
 done
 rm ./host_ca

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -218,7 +218,7 @@ fi
 pushd $BOOTSTRAP/etc/ssh
 # Don't log this command, since it contains sensitive private key material.
 set +x
-echo $SSH_HOST_CA_KEY > ./host_ca
+echo "$SSH_HOST_CA_KEY" > ./host_ca
 chmod 0600 ./host_ca
 set -x
 for f in $(ls ssh_host_*_key.pub); do

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -223,7 +223,7 @@ chmod 0600 ./host_ca
 set -x
 for f in $(ls ssh_host_*_key.pub); do
   ssh-keygen -s host_ca -I mlab -h -V always:forever $f
-  echo "HostCertificate /etc/ssh/$f" >> /etc/ssh/sshd_config
+  echo "HostCertificate /etc/ssh/$f" >> sshd_config
 done
 rm ./host_ca
 popd

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -223,7 +223,7 @@ chmod 0600 ./host_ca
 set -x
 for f in $(ls ssh_host_*_key.pub); do
   ssh-keygen -s host_ca -I mlab -h -V always:forever $f
-  echo "HostCertificate /etc/ssh/$f" >> sshd_config
+  echo "HostCertificate /etc/ssh/${f%%.pub}-cert.pub" >> sshd_config
 done
 rm ./host_ca
 popd

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -219,6 +219,7 @@ pushd $BOOTSTRAP/etc/ssh
 # Don't log this command, since it contains sensitive private key material.
 set +x
 echo $SSH_HOST_CA_KEY > ./host_ca
+chmod 0600 ./host_ca
 set -x
 for f in $(ls ssh_host_*_key.pub); do
   ssh-keygen -s host_ca -I mlab -h -V always:forever $f


### PR DESCRIPTION
This is part of the process of securing our SSH configurations generally. With this change, SSH clients will be offered a signed certificate by each M-Lab physical platform node. If they client has an appropriate entry in their known_hosts, then the client will automatically trust the public key offered by the server.  