### PR TITLE
Updates k8s to v1.21.14 + exports new metric about fq qdisc config status

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -4,12 +4,12 @@
 export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
 
 # K8S component versions
-export K8S_VERSION=v1.20.13
-export K8S_CNI_VERSION=v1.0.1
-export K8S_CRICTL_VERSION=v1.20.0
+export K8S_VERSION=v1.21.14
+export K8S_CNI_VERSION=v1.1.1
+export K8S_CRICTL_VERSION=v1.21.0
 # v0.9.1 of the official CNI plugins release stopped including flannel, so we
 # must now install it manually.
-export K8S_FLANNELCNI_VERSION=v1.0.0
+export K8S_FLANNELCNI_VERSION=v1.1.0
 
 # stage3 mlxupdate
 export MFT_VERSION=4.14.0-105

--- a/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/configure-tc-fq.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Configures TCP pacing properly depending on the site's uplink speed
-After=multi-user.target
+After=cache-data.mount multi-user.target
 
 [Service]
 Type=oneshot
@@ -8,4 +8,3 @@ ExecStart=/opt/mlab/bin/configure_tc_fq.sh
 
 [Install]
 WantedBy=multi-user.target
-

--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -31,7 +31,7 @@ elif [[ "${SPEED}" == "1g" ]]; then
   MAXRATE="125000000"
 else
   echo "Unknown uplink speed '${SPEED}'. Not configuring default qdisc for eth0."
-  overwrite_metric_file 0
+  write_metric_file 0
   exit 1
 fi
 
@@ -39,7 +39,7 @@ fi
 
 if [[ $? -ne 0 ]]; then
   echo "Failed to configure qdisc fq on dev eth0 with max rate of: ${MAXRATE}"
-  overwrite_metric_file 0
+  write_metric_file 0
   exit 1
 fi
 
@@ -48,9 +48,9 @@ fi
 configured_maxrate=$(tc -json qdisc show dev eth0 | jq -r '.[0].options.maxrate')
 if [[ $configured_maxrate != $MAXRATE ]]; then
   echo "maxrate of qdisc fq on eth0 is ${configured_maxrate}, but should be ${MAXRATE}"
-  overwrite_metric_file 0
+  write_metric_file 0
   exit 1
 fi
 
-overwrite_metric_file 1
+write_metric_file 1
 echo "Set maxrate for qdisc fq on dev eth0 to: ${MAXRATE}"

--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -8,9 +8,9 @@ METRIC_FILE_TEMP=$(mktemp)
 mkdir -p $METRIC_DIR
 echo -n "node_configure_qdisc_success " > $METRIC_FILE_TEMP
 
-# Append the passed status code to the temporary metric file, overwrite the
-# metric file with the temp metric file, and make the metric file world readable.
-function overwrite_metric_file {
+# Append the passed status code to the temporary metric file, then move the temp
+# metric file to the proper location, making it world readable.
+function write_metric_file {
   local status=$1
   echo "$status" >> $METRIC_FILE_TEMP
   mv $METRIC_FILE_TEMP $METRIC_FILE

--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 # This script writes out a Prometheus metric file which will be collected by the
-# node_exporter textfile collector.
-METRIC_FILE=/cache/data/node-exporter/configure_tc_fq.prom
+# node_exporter textfile collector. Make sure that METRIC_DIR exists.
+METRIC_DIR=/cache/data/node-exporter
+METRIC_FILE=$METRIC_DIR/configure_tc_fq.prom
 METRIC_FILE_TEMP=$(mktemp)
+mkdir -p $METRIC_DIR
 echo -n "node_configure_qdisc_success " > $METRIC_FILE_TEMP
 
 # Append the passed status code to the temporary metric file, overwrite the

--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -1,5 +1,14 @@
 #!/bin/bash
 
+# This script writes out a Prometheus metric file which will be collected by the
+# node_exporter textfile collector. Make sure that the textfile collector
+# directory exists. And write out the stub metric file.
+METRIC_DIR=/var/spool/node_exporter
+METRIC_FILE=$METRIC_DIR/configure_tc_fq.prom
+METRIC_FILE_TEMP=$(mktemp)
+mkdir -p $METRIC_DIR
+echo -n "node_configure_qdisc_success " > $METRIC_FILE_TEMP
+
 SITE=${HOSTNAME:6:5}
 SPEED=$(curl --silent --show-error --location \
     https://siteinfo.mlab-oti.measurementlab.net/v1/sites/switches.json \
@@ -11,6 +20,7 @@ elif [[ "${SPEED}" == "1g" ]]; then
   MAXRATE="1gbit"
 else
   echo "Unknown uplink speed '${SPEED}'. Not configuring default qdisc for eth0."
+  echo -n "0" >> $METRIC_FILE_TEMP
   exit 1
 fi
 
@@ -18,7 +28,19 @@ fi
 
 if [[ $? -ne 0 ]]; then
   echo "Failed to configure qdisc fq on dev eth0 with max rate of: ${MAXRATE}"
+  echo -n "0" >> $METRIC_FILE_TEMP
   exit 1
 fi
 
+# Even though tc's exit code was 0, be 100% sure that the configured value for
+# maxrate is what we expect.
+configured_maxrate=$(tc -json qdisc show dev eth0 | jq -r '.[0].options.maxrate')
+if [[ $configured_maxrate != $MAXRATE ]]; then
+  echo "maxrate of qdisc fq on eth0 is ${configured_maxrate}, but should be ${MAXRATE}"
+  echo -n "0" >> $METRIC_FILE_TEMP
+  exit 1
+fi
+
+echo -n "1" >> $METRIC_FILE_TEMP
+mv $METRIC_FILE_TEMP $METRIC_FILE
 echo "Set maxrate for qdisc fq on dev eth0 to: ${MAXRATE}"


### PR DESCRIPTION
This PR does two things:

* Updates k8s to v1.21.14, along with updates to related components.
* Updates the configure-tc-fq.sh script to write out a metric file which will be ingested by nodes_exporter's textfile collector. The metric will give us insight into whether the fq qdisc was properly configured on each machine at boot.

https://prometheus-platform-cluster.mlab-sandbox.measurementlab.net/graph?g0.expr=node_configure_qdisc_success&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=2h

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/222)
<!-- Reviewable:end -->
