### PR TITLE
Update k8s to v1.22.15

### DIFF
--- a/cloudbuild-stage1.yaml
+++ b/cloudbuild-stage1.yaml
@@ -28,7 +28,7 @@ steps:
 
 # stage1 ISOs
 # NOTE: must run after stage1_minimal so that kernel & initram are available.
-- name: gcr.io/$PROJECT_ID/epoxy-images1.18
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
   args: [
     '/workspace/builder.sh', 'stage1_isos'
   ]

--- a/cloudbuild-stage1.yaml
+++ b/cloudbuild-stage1.yaml
@@ -15,20 +15,20 @@ options:
 
 steps:
 # stage1 minimal kernel & initram using stock ubuntu kernel.
-- name: gcr.io/$PROJECT_ID/epoxy-images
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
   args: [
     '/workspace/builder.sh', 'stage1_minimal'
   ]
 
 # stage1 ROMs.
-- name: gcr.io/$PROJECT_ID/epoxy-images
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
   args: [
     '/workspace/builder.sh', 'stage1_mlxrom'
   ]
 
 # stage1 ISOs
 # NOTE: must run after stage1_minimal so that kernel & initram are available.
-- name: gcr.io/$PROJECT_ID/epoxy-images
+- name: gcr.io/$PROJECT_ID/epoxy-images1.18
   args: [
     '/workspace/builder.sh', 'stage1_isos'
   ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,13 +20,13 @@ availableSecrets:
 
 steps:
 # stage1 minimal kernel & initram using stock ubuntu kernel.
-- name: gcr.io/$PROJECT_ID/epoxy-images
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
   args: [
     '/workspace/builder.sh', 'stage1_minimal'
   ]
 
 # stage3_ubuntu images.
-- name: gcr.io/$PROJECT_ID/epoxy-images
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
   entrypoint: /bin/bash
   args:
   - '-c'
@@ -35,7 +35,7 @@ steps:
   - SSH_HOST_CA_KEY
 
 # stage3_update images.
-- name: gcr.io/$PROJECT_ID/epoxy-images
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
   args: [
     '/workspace/builder.sh', 'stage3_update'
   ]

--- a/config.sh
+++ b/config.sh
@@ -18,4 +18,4 @@ export MFT_VERSION=4.14.0-105
 export MLXROM_VERSION=3.4.817
 
 # multus-cni version
-export MULTUS_CNI_VERSION=3.9.1
+export MULTUS_CNI_VERSION=3.9

--- a/config.sh
+++ b/config.sh
@@ -4,9 +4,9 @@
 export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
 
 # K8S component versions
-export K8S_VERSION=v1.21.14
+export K8S_VERSION=v1.22.15
 export K8S_CNI_VERSION=v1.1.1
-export K8S_CRICTL_VERSION=v1.21.0
+export K8S_CRICTL_VERSION=v1.22.1
 # v0.9.1 of the official CNI plugins release stopped including flannel, so we
 # must now install it manually.
 export K8S_FLANNELCNI_VERSION=v1.1.0
@@ -18,4 +18,4 @@ export MFT_VERSION=4.14.0-105
 export MLXROM_VERSION=3.4.817
 
 # multus-cni version
-export MULTUS_CNI_VERSION=3.8
+export MULTUS_CNI_VERSION=3.9.1

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -243,8 +243,8 @@ curl --location "https://github.com/k8snetworkplumbingwg/multus-cni/releases/dow
   | tar -xz
 curl --location "https://github.com/flannel-io/cni-plugin/releases/download/${K8S_FLANNELCNI_VERSION}/flannel-amd64" \
   > flannel
-GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/index2ip@v1.2.0
-GOPATH=${TMPDIR} CGO_ENABLED=0 go get -u -ldflags '-w -s' github.com/m-lab/cni-plugins/netctl@v1.0.0
+GOPATH=${TMPDIR} CGO_ENABLED=0 go install -ldflags '-w -s' github.com/m-lab/index2ip@v1.2.0
+GOPATH=${TMPDIR} CGO_ENABLED=0 go install -ldflags '-w -s' github.com/m-lab/cni-plugins/netctl@v1.0.0
 cp ${TMPDIR}/multus-cni_${MULTUS_CNI_VERSION}_linux_amd64/multus-cni ${BOOTSTRAP}/opt/cni/bin/multus
 cp ${TMPDIR}/bin/index2ip ${BOOTSTRAP}/opt/cni/bin
 cp ${TMPDIR}/bin/netctl ${BOOTSTRAP}/opt/cni/bin


### PR DESCRIPTION
Updates k8s to v1.22.15, as well as updating various related components.

Also, updates explicitly use v1.18 of the epoxy-images build container image, and use `go install` instead of `go get` in couple places.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/224)
<!-- Reviewable:end -->
