### PR TITLE
Changes epoxy-images container image version 1.0

### DIFF
--- a/cloudbuild-stage1.yaml
+++ b/cloudbuild-stage1.yaml
@@ -15,20 +15,20 @@ options:
 
 steps:
 # stage1 minimal kernel & initram using stock ubuntu kernel.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
   args: [
     '/workspace/builder.sh', 'stage1_minimal'
   ]
 
 # stage1 ROMs.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
   args: [
     '/workspace/builder.sh', 'stage1_mlxrom'
   ]
 
 # stage1 ISOs
 # NOTE: must run after stage1_minimal so that kernel & initram are available.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
   args: [
     '/workspace/builder.sh', 'stage1_isos'
   ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -20,13 +20,13 @@ availableSecrets:
 
 steps:
 # stage1 minimal kernel & initram using stock ubuntu kernel.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
   args: [
     '/workspace/builder.sh', 'stage1_minimal'
   ]
 
 # stage3_ubuntu images.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
   entrypoint: /bin/bash
   args:
   - '-c'
@@ -35,7 +35,7 @@ steps:
   - SSH_HOST_CA_KEY
 
 # stage3_update images.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.18
+- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
   args: [
     '/workspace/builder.sh', 'stage3_update'
   ]


### PR DESCRIPTION
It was previously 1.18, [but that was changed](https://github.com/m-lab/gcp-config/pull/63/files#diff-0b4a5fc26445836e6672c426692297004cfaba21997343b63e6f58b946bd2a5c) in the m-lab/gcp-config/Dockerfile.epoxy-images Dockerfile to 1.0. I mistakenly used 1.18 in a previous PR to this repo.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/225)
<!-- Reviewable:end -->
