### PR TITLE
Creates new systemd write-metadata.service and script

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Writes metadata to a known location
+Before=setup-after-boot.service
+
+[Service]
+Type=oneshot
+ExecStart=/opt/mlab/bin/write-metadata.sh
+
+[Install]
+WantedBy=multi-user.target
+

--- a/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+#
+# This script writes various pieces of metadata to files in a known location.
+# This directory can be mounted into experiment pods so that the experiment can
+# have some awareness of its environment. The experiment may optionally include
+# this metadata in its test results.
+
+$METADATA_DIR=/var/local/metadata
+
+mkdir -p /var/local/metadata
+
+# Write the kernel version
+uname -r | tr -d '\n' > $METADATA_DIR/kernel-version
+

--- a/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -5,9 +5,8 @@
 # have some awareness of its environment. The experiment may optionally include
 # this metadata in its test results.
 
-$METADATA_DIR=/var/local/metadata
-
-mkdir -p /var/local/metadata
+METADATA_DIR=/var/local/metadata
+mkdir -p $METADATA_DIR
 
 # Write the kernel version
 uname -r | tr -d '\n' > $METADATA_DIR/kernel-version

--- a/setup_stage3_ubuntu.sh
+++ b/setup_stage3_ubuntu.sh
@@ -165,10 +165,6 @@ echo -e "\nexport CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.s
 # Don't go beyond multi-user.target as these are headless systems.
 chroot $BOOTSTRAP bash -c 'systemctl set-default multi-user.target'
 
-for unit in $(find $CONFIG_DIR/etc/systemd/system -maxdepth 1 -type f -printf "%f\n"); do
-  chroot $BOOTSTRAP bash -c "systemctl enable $unit"
-done
-
 # Install the kubelet.service unit file.
 curl --silent --show-error --location \
     "https://raw.githubusercontent.com/kubernetes/release/v0.7.0/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service" \
@@ -179,6 +175,10 @@ mkdir --parents $BOOTSTRAP/etc/systemd/system/kubelet.service.d
 curl --silent --show-error --location \
     "https://raw.githubusercontent.com/kubernetes/release/v0.7.0/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" \
      > $BOOTSTRAP/etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+
+for unit in $(find $CONFIG_DIR/etc/systemd/system -maxdepth 1 -type f -printf "%f\n"); do
+  chroot $BOOTSTRAP bash -c "systemctl enable $unit"
+done
 
 # Enable various services.
 chroot $BOOTSTRAP systemctl enable ssh.service


### PR DESCRIPTION
This PR creates a generic and very simple shell script and accompanying systemd service unit file which can be leveraged to write out arbitrary metadata to a standardized location in the filesystem (`/var/local/metadata`). This directory can be mounted inside experiments (and already is for ndt), where the experiment can leverage the data to gain some insight into its operating environment, and possibly include some of the metadata into its test results.

As a start the script does nothing more than write the current kernel version to the file `/var/local/metadata/kernel-version`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/227)
<!-- Reviewable:end -->
