### PR TITLE
Builds stage1 mrom images using iPXE sources

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ipxe"]
+	path = ipxe
+	url = https://github.com/ipxe/ipxe

--- a/builder.sh
+++ b/builder.sh
@@ -16,7 +16,6 @@ function stage1_mlxrom() {
   local target=${TARGET:?Please specify a target configuration name}
   local project=${PROJECT:?Please specify the PROJECT}
   local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
-  local version=${MLXROM_VERSION:?Please define the MLXROM_VERSION to build}
 
   local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
 
@@ -28,7 +27,7 @@ function stage1_mlxrom() {
   TRUSTED_CERTS+=",${SOURCE_DIR}/configs/${target}/gtsgiag3.pem"
 
   ${SOURCE_DIR}/setup_stage1_mlxrom.sh "${project}" "${builddir}" "${artifacts}" \
-      "${SOURCE_DIR}/configs/${target}" "${version}" "${TRUSTED_CERTS}"
+      "${SOURCE_DIR}/configs/${target}" "${TRUSTED_CERTS}"
 
   rm -rf "${builddir}"
 }

--- a/builder.sh
+++ b/builder.sh
@@ -16,6 +16,7 @@ function stage1_mlxrom() {
   local target=${TARGET:?Please specify a target configuration name}
   local project=${PROJECT:?Please specify the PROJECT}
   local artifacts=${ARTIFACTS:?Please define an ARTIFACTS output directory}
+  local version=${MLXROM_VERSION:?Please define the MLXROM_VERSION to build}
 
   local builddir=$( mktemp -d -t build-${TARGET}.XXXXXX )
 
@@ -27,7 +28,7 @@ function stage1_mlxrom() {
   TRUSTED_CERTS+=",${SOURCE_DIR}/configs/${target}/gtsgiag3.pem"
 
   ${SOURCE_DIR}/setup_stage1_mlxrom.sh "${project}" "${builddir}" "${artifacts}" \
-      "${SOURCE_DIR}/configs/${target}" "${TRUSTED_CERTS}"
+      "${SOURCE_DIR}/configs/${target}" "${version}" "${TRUSTED_CERTS}"
 
   rm -rf "${builddir}"
 }

--- a/config.sh
+++ b/config.sh
@@ -14,8 +14,5 @@ export K8S_FLANNELCNI_VERSION=v1.1.0
 # stage3 mlxupdate
 export MFT_VERSION=4.14.0-105
 
-# stage1 mlxrom
-export MLXROM_VERSION=3.4.817
-
 # multus-cni version
 export MULTUS_CNI_VERSION=3.9

--- a/config.sh
+++ b/config.sh
@@ -14,5 +14,8 @@ export K8S_FLANNELCNI_VERSION=v1.1.0
 # stage3 mlxupdate
 export MFT_VERSION=4.22.0-96
 
+# stage1 mlxrom
+export MLXROM_VERSION=3.4.818
+
 # multus-cni version
 export MULTUS_CNI_VERSION=3.9

--- a/config.sh
+++ b/config.sh
@@ -12,7 +12,7 @@ export K8S_CRICTL_VERSION=v1.22.1
 export K8S_FLANNELCNI_VERSION=v1.1.0
 
 # stage3 mlxupdate
-export MFT_VERSION=4.14.0-105
+export MFT_VERSION=4.22.0-96
 
 # multus-cni version
 export MULTUS_CNI_VERSION=3.9

--- a/configs/stage1_mlxrom/config_general.h.diff
+++ b/configs/stage1_mlxrom/config_general.h.diff
@@ -1,13 +1,27 @@
 diff --git a/src/config/general.h b/src/config/general.h
-index 52f29a7c..9dd99e80 100644
+index 2d15f500..08ca8de6 100644
 --- a/src/config/general.h
 +++ b/src/config/general.h
-@@ -62,7 +62,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
- 
- #define	DOWNLOAD_PROTO_TFTP	/* Trivial File Transfer Protocol */
- #define	DOWNLOAD_PROTO_HTTP	/* Hypertext Transfer Protocol */
--#undef	DOWNLOAD_PROTO_HTTPS	/* Secure Hypertext Transfer Protocol */
-+#define DOWNLOAD_PROTO_HTTPS	/* Secure Hypertext Transfer Protocol */
- #undef	DOWNLOAD_PROTO_FTP	/* File Transfer Protocol */
- #undef	DOWNLOAD_PROTO_SLAM	/* Scalable Local Area Multicast */
- #undef	DOWNLOAD_PROTO_NFS	/* Network File System Protocol */
+@@ -55,7 +55,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+
+ #define        DOWNLOAD_PROTO_TFTP     /* Trivial File Transfer Protocol */
+ #define        DOWNLOAD_PROTO_HTTP     /* Hypertext Transfer Protocol */
+-#undef DOWNLOAD_PROTO_HTTPS    /* Secure Hypertext Transfer Protocol */
++#define        DOWNLOAD_PROTO_HTTPS    /* Secure Hypertext Transfer Protocol */
+ #undef DOWNLOAD_PROTO_FTP      /* File Transfer Protocol */
+ #undef DOWNLOAD_PROTO_SLAM     /* Scalable Local Area Multicast */
+ #undef DOWNLOAD_PROTO_NFS      /* Network File System Protocol */
+@@ -145,11 +145,11 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
+ //#define LOTEST_CMD           /* Loopback testing commands */
+ //#define VLAN_CMD             /* VLAN commands */
+ //#define PXE_CMD              /* PXE commands */
+-//#define REBOOT_CMD           /* Reboot command */
++#define REBOOT_CMD             /* Reboot command */
+ //#define POWEROFF_CMD         /* Power off command */
+ //#define IMAGE_TRUST_CMD      /* Image trust management commands */
+ //#define PCI_CMD              /* PCI commands */
+-//#define PARAM_CMD            /* Form parameter commands */
++#define PARAM_CMD              /* Form parameter commands */
+ //#define NEIGHBOUR_CMD                /* Neighbour management commands */
+ //#define PING_CMD             /* Ping command */
+ //#define CONSOLE_CMD          /* Console command */

--- a/configs/stage1_mlxrom/config_general.h.diff
+++ b/configs/stage1_mlxrom/config_general.h.diff
@@ -3,25 +3,25 @@ index 2d15f500..08ca8de6 100644
 --- a/src/config/general.h
 +++ b/src/config/general.h
 @@ -55,7 +55,7 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
-
- #define        DOWNLOAD_PROTO_TFTP     /* Trivial File Transfer Protocol */
- #define        DOWNLOAD_PROTO_HTTP     /* Hypertext Transfer Protocol */
--#undef DOWNLOAD_PROTO_HTTPS    /* Secure Hypertext Transfer Protocol */
-+#define        DOWNLOAD_PROTO_HTTPS    /* Secure Hypertext Transfer Protocol */
- #undef DOWNLOAD_PROTO_FTP      /* File Transfer Protocol */
- #undef DOWNLOAD_PROTO_SLAM     /* Scalable Local Area Multicast */
- #undef DOWNLOAD_PROTO_NFS      /* Network File System Protocol */
+ 
+ #define	DOWNLOAD_PROTO_TFTP	/* Trivial File Transfer Protocol */
+ #define	DOWNLOAD_PROTO_HTTP	/* Hypertext Transfer Protocol */
+-#undef	DOWNLOAD_PROTO_HTTPS	/* Secure Hypertext Transfer Protocol */
++#define	DOWNLOAD_PROTO_HTTPS	/* Secure Hypertext Transfer Protocol */
+ #undef	DOWNLOAD_PROTO_FTP	/* File Transfer Protocol */
+ #undef	DOWNLOAD_PROTO_SLAM	/* Scalable Local Area Multicast */
+ #undef	DOWNLOAD_PROTO_NFS	/* Network File System Protocol */
 @@ -145,11 +145,11 @@ FILE_LICENCE ( GPL2_OR_LATER_OR_UBDL );
- //#define LOTEST_CMD           /* Loopback testing commands */
- //#define VLAN_CMD             /* VLAN commands */
- //#define PXE_CMD              /* PXE commands */
--//#define REBOOT_CMD           /* Reboot command */
-+#define REBOOT_CMD             /* Reboot command */
- //#define POWEROFF_CMD         /* Power off command */
- //#define IMAGE_TRUST_CMD      /* Image trust management commands */
- //#define PCI_CMD              /* PCI commands */
--//#define PARAM_CMD            /* Form parameter commands */
-+#define PARAM_CMD              /* Form parameter commands */
- //#define NEIGHBOUR_CMD                /* Neighbour management commands */
- //#define PING_CMD             /* Ping command */
- //#define CONSOLE_CMD          /* Console command */
+ //#define LOTEST_CMD		/* Loopback testing commands */
+ //#define VLAN_CMD		/* VLAN commands */
+ //#define PXE_CMD		/* PXE commands */
+-//#define REBOOT_CMD		/* Reboot command */
++#define REBOOT_CMD		/* Reboot command */
+ //#define POWEROFF_CMD		/* Power off command */
+ //#define IMAGE_TRUST_CMD	/* Image trust management commands */
+ //#define PCI_CMD		/* PCI commands */
+-//#define PARAM_CMD		/* Form parameter commands */
++#define PARAM_CMD		/* Form parameter commands */
+ //#define NEIGHBOUR_CMD		/* Neighbour management commands */
+ //#define PING_CMD		/* Ping command */
+ //#define CONSOLE_CMD		/* Console command */

--- a/configs/stage1_mlxrom/romprefix.S.diff
+++ b/configs/stage1_mlxrom/romprefix.S.diff
@@ -1,9 +1,9 @@
 diff --git a/src/arch/x86/prefix/romprefix.S b/src/arch/x86/prefix/romprefix.S
-index 24803a7..3287de5 100644
+index 4e8793c2..8c8034f4 100644
 --- a/src/arch/x86/prefix/romprefix.S
 +++ b/src/arch/x86/prefix/romprefix.S
-@@ -2753,3 +2753,11 @@ REQUIRING_SYMBOL ( _rom_start )
- 
+@@ -909,3 +909,11 @@ REQUIRING_SYMBOL ( _rom_start )
+
  /* Drag in ROM configuration */
  REQUIRE_OBJECT ( config_romprefix )
 +

--- a/configs/stage3_update/flashrom.sh
+++ b/configs/stage3_update/flashrom.sh
@@ -24,11 +24,11 @@ PAUSE=5
 
 
 # Backup current ROM by "reading" the ROM (rrom) from the local device.
-flint --device "${DEV}" rrom current.mrom
+flint --yes --device "${DEV}" rrom current.mrom
 
 # "Query" the new and current ROM versions (qrom).
-NEW_VERSION=$( flint --image "${ROM}" qrom )
-CUR_VERSION=$( flint --image current.mrom qrom )
+NEW_VERSION=$( flint --yes --image "${ROM}" qrom )
+CUR_VERSION=$( flint --yes --image current.mrom qrom )
 
 echo "ROM Versions:"
 echo "   Currently installed: $CUR_VERSION"
@@ -83,8 +83,8 @@ mlxconfig --dev "${DEV}" --yes --enable_verbosity set LEGACY_BOOT_PROTOCOL_P1=PX
 
 # For debugging, query the device to report current configuration.
 echo "Before update"
-flint --device "$DEV" query
-mlxconfig --dev "$DEV" query
+flint --yes --device "$DEV" query
+mlxconfig --yes --dev "$DEV" query
 sleep $PAUSE
 
 # Burn ROM to NIC.
@@ -101,17 +101,18 @@ echo "Performing update now..."
 #
 # NOTE: "Burn" the ROM (brom) to the device.
 # TODO: flip out if burning or verifying images fail.
-flint --allow_rom_change --device "$DEV" brom "$ROM"
+flint --yes --allow_rom_change --device "$DEV" brom "$ROM"
 # Verify that the device recognizes the new image.
-flint --device "$DEV" verify
+flint --yes --device "$DEV" verify
 sleep $PAUSE
 
 # For debugging, query the device to report new configuration.
 echo "After update"
-flint --device "$DEV" query
-mlxconfig --dev "$DEV" query
+flint --yes --device "$DEV" query
+mlxconfig --yes --dev "$DEV" query
 sleep $PAUSE
 
 # Perform a final verification that the new ROM matches the expected ROM.
-flint --device "$DEV" rrom latest.mrom
+flint --yes --device "$DEV" rrom latest.mrom
 diff latest.mrom "$ROM"
+

--- a/setup_stage1_mlxrom.sh
+++ b/setup_stage1_mlxrom.sh
@@ -169,8 +169,8 @@ DEBUG=
 
 SCRIPTDIR=$( mktemp -d -t stage1_scripts.XXXXXX )
 
-# Clone and patch the ipxe sources.
-git clone https://github.com/ipxe/ipxe.git
+# Patch iPXE sources (they are a git module) in this repo.
+git submodule update --recursive
 ipxe_source=/workspace/ipxe/src
 pushd ipxe
   # Patches sources and configure build options

--- a/setup_stage1_mlxrom.sh
+++ b/setup_stage1_mlxrom.sh
@@ -173,8 +173,9 @@ SCRIPTDIR=$( mktemp -d -t stage1_scripts.XXXXXX )
 git clone https://github.com/ipxe/ipxe.git
 ipxe_source=/workspace/ipxe/src
 pushd ipxe
-  # Add the 'driver_version' definition to flexboot source.
+  # Patches sources and configure build options
   git apply ${CONFIG_DIR}/romprefix.S.diff
+  git apply ${CONFIG_DIR}/config_general.h.diff
 popd
 
 generate_stage1_ipxe_scripts \

--- a/setup_stage1_mlxrom.sh
+++ b/setup_stage1_mlxrom.sh
@@ -10,58 +10,12 @@ set -e
 
 SOURCE_DIR=$( realpath $( dirname "${BASH_SOURCE[0]}" ) )
 
-USAGE="$0 <project> <builddir> <output dir> <mlxrom-config> <hostname-pattern> <rom-version> <embed-cert1,embed-cert2>"
+USAGE="$0 <project> <builddir> <output dir> <mlxrom-config> <hostname-pattern> <embed-cert1,embed-cert2>"
 PROJECT=${1:?Please specify the GCP project to contact: $USAGE}
 BUILD_DIR=${2:?Please specify a build directory: $USAGE}
 OUTPUT_DIR=${3:?Please specify an output directory: $USAGE}
 CONFIG_DIR=${4:?Please specify a configuration directory: $USAGE}
-ROM_VERSION=${5:?Please specify the ROM version as "3.4.800": $USAGE}
-CERTS=${6:?Please specify trusted certs to embed in ROM: $USAGE}
-
-# unpack checks whether the given directory exists and if it does not unpacks
-# the given tar archive (which should create the directory).
-function unpack () {
-  local dir=$1
-  local tgz=$2
-  if ! test -d $dir ; then
-    if ! test -f $tgz ; then
-      echo "error: no such file $tgz"
-      exit 1
-    fi
-    tar xvf $tgz
-  fi
-}
-
-
-function prepare_flexboot_source() {
-  local build_dir=$1
-  local config_dir=$2
-  local archive_path=$3
-  local canonical_name=$4
-
-  pushd ${build_dir}
-    if test -d ${canonical_name} ; then
-      # The following steps were already taken. Don't repeat them.
-      return
-    fi
-    version=$( basename ${archive_path} .tar.gz )
-    unpack ${version} ${archive_path}
-    pushd ${version}/
-      # Add the 'driver_version' definition to flexboot source.
-      git apply ${config_dir}/romprefix.S.diff
-
-      # Enable TLS configuration and any other non-standard options.
-      git apply ${config_dir}/config_general.h.diff
-
-      # Fixes a my-in-my perl error.
-      git apply ${config_dir}/parserom.S.diff
-    popd
-
-    # Move the working directory to the canonical name to signal we're done.
-    mv ${version} ${canonical_name}
-  popd
-}
-
+CERTS=${5:?Please specify trusted certs to embed in ROM: $USAGE}
 
 function generate_stage1_ipxe_scripts() {
   local build_dir=$1
@@ -85,90 +39,30 @@ function generate_stage1_ipxe_scripts() {
   popd
 }
 
-
-# define reads a heredoc into the named variable. The variable will be global.
-function define() {
-  local varname=$1
-  #  -r     Backslash does not act as an escape character.
-  #  -d     The first character is used to terminate the input line. We use the
-  #         empty string, so line input is not terminated until "EOF".
-  # TODO: why do we set IFS?
-  IFS='\n' read -r -d '' ${varname} || true;
-}
-
-function get_extra_flags() {
-  local target=$1
-  local version=$2
-  local device_id=
-
-  local major=${version%%.*}
-  local sub=${version%.*} ; sub=${sub#*.}
-  local minor=${version##*.}
-
-  major=$( printf "%04x" $major )
-  sub=$( printf "%04x" $sub )
-  minor=$( printf "%04x" $minor )
-
-  case $target in
-
-    ConnectX-3.mrom)
-      device_id=0x1003
-      ;;
-
-    ConnectX-3Pro.mrom)
-      device_id=0x1007
-      ;;
-
-    *)
-      echo "Error: unsupported target name: $target" 1>&2
-      exit 1
-      ;;
-  esac
-
-  define extra_flags <<EOM
-    -Wno-error=strict-aliasing
-    -Wno-error=address
-    -Wno-pointer-to-int-cast
-    -Wno-error=maybe-uninitialized
-    -DMLX_BUILD
-    -DDEVICE_CX3
-    -DFLASH_CONFIGURATION
-    -D__MLX_0001_MAJOR_VER_=0x0010${major}
-    -D__MLX_MIN_SUB_MIN_VER_=0x${sub}${minor}
-    -D__MLX_DEV_ID_00ff=${device_id}00ff
-    -D__BUILD_VERSION__=\"$version\"
-    -Idrivers/infiniband/mlx_utils_flexboot/include/
-    -Idrivers/infiniband/mlx_utils/include/
-    -Idrivers/infiniband/mlx_utils/include/public/
-    -Idrivers/infiniband/mlx_utils/include/private/
-    -Idrivers/infiniband/mlx_nodnic/include/
-    -Idrivers/infiniband/mlx_nodnic/include/public/
-    -Idrivers/infiniband/mlx_nodnic/include/private/
-    -Idrivers/infiniband/mlx_utils_flexboot/tests/include/
-    -Idrivers/infiniband/mlx_utils/mlx_lib/mlx_reg_access/
-    -Idrivers/infiniband/mlx_utils/mlx_lib/mlx_nvconfig/
-    -Idrivers/infiniband/mlx_utils/mlx_lib/mlx_vmac/
-    -fno-PIE
-EOM
-  echo $extra_flags
-}
-
-
 function build_roms() {
-  local flexboot_src=$1
+  local ipxe_src=$1
   local stage1_config_dir=$2
-  local version=$3
-  local debug=$4
-  local certs=$5
-  local rom_output_dir=$6
+  local debug=$3
+  local certs=$4
+  local rom_output_dir=$5
 
   local extra_cflags=
   local procs=`getconf _NPROCESSORS_ONLN`
 
-  for device in ConnectX-3.mrom ConnectX-3Pro.mrom ; do
+  # 15b3 is the vendor ID for Mellanox Technologies
+  # 1003 is the device ID for the ConnectX-3
+  # 1007 is the device ID for the ConnectX-3Pro
+  for device in 15b31003 15b31007; do
+    pushd ${ipxe_src}
+      # Use the git short commit of HEAD as the version string for the images.
+      version=$(git rev-parse --short HEAD)
 
-    extra_cflags="$( get_extra_flags $device $version )"
-    pushd ${flexboot_src}
+      if [[ $device == "15b31003" ]]; then
+        device_name="ConnectX-3"
+      else
+        device_name="ConnectX-3Pro"
+      fi
+
       # NOTE: clean the build environment between devices. Without resetting,
       # ROMs for the ConnectX-3Pro have the wrong device ID.
       make clean
@@ -180,8 +74,8 @@ function build_roms() {
         hostname=${hostname%%.ipxe}
 
         # The generated ROM file is the device name.
-        make -j ${procs} bin/${device} \
-            EXTRA_CFLAGS="${extra_cflags}" \
+        make -j ${procs} bin/${device}.mrom \
+            EXTRA_CFLAGS="-D__BUILD_VERSION__=$version" \
             DEBUG=${debug} \
             TRUST=${certs} \
             EMBED=${stage1} \
@@ -189,8 +83,8 @@ function build_roms() {
 
         # Copy it to a structured location.
         # Note: the update image depends on this structure to locate an image.
-        mkdir -p ${rom_output_dir}/${version}/${device%%.mrom}/
-        cp bin/${device} ${rom_output_dir}/${version}/${device%%.mrom}/${hostname}.mrom
+        mkdir -p ${rom_output_dir}/${version}/${device_name}/
+        cp bin/${device}.mrom ${rom_output_dir}/${version}/${device_name}/${hostname}.mrom
       done
     popd
   done
@@ -223,14 +117,11 @@ function copy_roms_to_output() {
 # I started with these: DEBUG=tls,x509,certstore
 DEBUG=
 
-FLEXDIR=$( mktemp -d -t flexboot.XXXXXX )
 SCRIPTDIR=$( mktemp -d -t stage1_scripts.XXXXXX )
 
-prepare_flexboot_source \
-    ${FLEXDIR} \
-    ${CONFIG_DIR} \
-    ${SOURCE_DIR}/vendor/flexboot-20160705.tar.gz \
-    flexboot
+# Clone the ipxe sources.
+git clone https://github.com/ipxe/ipxe.git
+ipxe_source=/workspace/ipxe/src
 
 generate_stage1_ipxe_scripts \
     ${BUILD_DIR} \
@@ -238,15 +129,14 @@ generate_stage1_ipxe_scripts \
     "${SCRIPTDIR}"
 
 build_roms \
-    ${FLEXDIR}/flexboot/src \
+    "${ipxe_source}" \
     "${SCRIPTDIR}" \
-    "${ROM_VERSION}" \
     "${DEBUG}" \
     "${CERTS}" \
     "${BUILD_DIR}/stage1_mlxrom"
 
 rm -rf "${SCRIPTDIR}"
-rm -rf "${FLEXDIR}"
+rm -rf "${ipxe_source}"
 
 copy_roms_to_output \
     ${BUILD_DIR}/stage1_mlxrom/ \

--- a/setup_stage1_mlxrom.sh
+++ b/setup_stage1_mlxrom.sh
@@ -169,11 +169,11 @@ DEBUG=
 
 SCRIPTDIR=$( mktemp -d -t stage1_scripts.XXXXXX )
 
-# Patch iPXE sources (they are a git module) in this repo.
-git submodule update --recursive
+# Patch iPXE sources (they are a git submodule) in this repo.
+git submodule update --init --recursive
 ipxe_source=/workspace/ipxe/src
 pushd ipxe
-  # Patches sources and configure build options
+  # Patches sources and configures build options
   git apply ${CONFIG_DIR}/romprefix.S.diff
   git apply ${CONFIG_DIR}/config_general.h.diff
 popd


### PR DESCRIPTION
There was a bug in the old, unmaintained "flexboot" code from Mellanox that manifest itself with an error of "Out of space". The machine would usually be able to get past that bug by simply trying the operation multiple times. However, we finally encountered one machine, mlab1-tun01, that failed to boot permanently due to this error.

This PR makes the necessary changes to cause stage1_mlxrom builds to use current, official iPXE sources to build the mrom images to be flashed to the R630 NICs. Moving the iPXE sources also allows us to remove some amount of cruft that was associated with building the flexboot code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/228)
<!-- Reviewable:end -->
