### PR TITLE
Replaces dots with dashes in image names

### DIFF
--- a/packer/mlab.pkr.hcl
+++ b/packer/mlab.pkr.hcl
@@ -58,9 +58,8 @@ build {
   # should exist. I came across this documentation, which seems to be specific
   # to AWS, but maybe works for GCP too:
   # https://developer.hashicorp.com/packer/docs/debugging#issues-installing-ubuntu-packages
-  {
-    "type": "shell",
-    "inline": [
+  provisioner "shell" {
+    inline = [
       "cloud-init status --wait"
     ]
   }

--- a/packer/mlab.pkr.hcl
+++ b/packer/mlab.pkr.hcl
@@ -56,7 +56,7 @@ build {
 
   # Builds were randomly failing because apt was unable to find packages that
   # should exist. I came across this documentation, which seems to be specific
-  # to AWS, but maybe works for GCP too:
+  # to AWS, but appears to also work for GCE:
   # https://developer.hashicorp.com/packer/docs/debugging#issues-installing-ubuntu-packages
   provisioner "shell" {
     inline = [

--- a/packer/mlab.pkr.hcl
+++ b/packer/mlab.pkr.hcl
@@ -54,6 +54,17 @@ build {
     ]
   }
 
+  # Builds were randomly failing because apt was unable to find packages that
+  # should exist. I came across this documentation, which seems to be specific
+  # to AWS, but maybe works for GCP too:
+  # https://developer.hashicorp.com/packer/docs/debugging#issues-installing-ubuntu-packages
+  {
+    "type": "shell",
+    "inline": [
+      "cloud-init status --wait"
+    ]
+  }
+
   # This provisioning step gets run for all sources.
   provisioner "shell" {
     environment_vars = [

--- a/setup_packer_images.sh
+++ b/setup_packer_images.sh
@@ -15,5 +15,5 @@ cd packer
 packer init .
 packer build -force \
   -var "gcp_project=$PROJECT" \
-  -var "image_version=$IMAGES_VERSION" \
+  -var "image_version=${IMAGES_VERSION//./-}" \
   mlab.pkr.hcl


### PR DESCRIPTION
Repo version strings contain dots, but dots are not allowed in image names, apparently:

```
Starting packer_images build
Error: 1 error(s) occurred:

* Invalid image name "platform-cluster-instance-v2.2.0": The first character must be a lowercase letter, and all following characters must be a dash, lowercase letter, or digit, except the last character, which cannot be a dash

  on mlab.pkr.hcl line 17
```

This commit just substitutes dots for dashes in the version name, which will produce image names like `platform-cluster-instance-v2-2-0`, which is slightly awkward, but doable, I think.

Additionally, I noticed builds were failing in sandbox because apt was unable to find packages on one of the source builds, but never both. I found this documentation:

https://developer.hashicorp.com/packer/docs/debugging#issues-installing-ubuntu-packages

This PR adds that suggestion, which _seems_ to have worked as intended.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/231)
<!-- Reviewable:end -->
