### PR TITLE
Increases stage1 build timeout from 4h to 5h

### DIFF
--- a/cloudbuild-stage1.yaml
+++ b/cloudbuild-stage1.yaml
@@ -1,5 +1,5 @@
-# Timeout for complete build: 4h. Default is 10m.
-timeout: 14400s
+# Timeout for complete build: 5h. Default is 10m.
+timeout: 18000s
 
 # The default disk size is 100GB. However, the stage1 ISOs are pretty big these
 # days. 600GB  should give us some breathing room.


### PR DESCRIPTION
Production stage1 builds [started timing out](https://console.cloud.google.com/cloud-build/builds;region=global/e5819f94-a7a1-439f-b806-ee32ffa336ec?project=mlab-oti) at the previous 4h limit, so this commit increases the build time to 5h.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/232)
<!-- Reviewable:end -->
