### PR TITLE
Increases build timeout for stage1 images to 10h

### DIFF
--- a/cloudbuild-stage1.yaml
+++ b/cloudbuild-stage1.yaml
@@ -1,5 +1,5 @@
-# Timeout for complete build: 5h. Default is 10m.
-timeout: 18000s
+# Timeout for complete build: 10h. Default is 10m.
+timeout: 36000s
 
 # The default disk size is 100GB. However, the stage1 ISOs are pretty big these
 # days. 600GB  should give us some breathing room.


### PR DESCRIPTION
For a long time the build timeout was 4h. Looking back at the build history, stage1 build times were hovering around 3h30m, give or take. In the past few months [stage1 builds started timing out at 4h](https://console.cloud.google.com/cloud-build/builds?project=mlab-oti&pageState=(%22builds%22:(%22f%22:%22%255B%257B_22k_22_3A_22Trigger%2520Name_22_2C_22t_22_3A10_2C_22v_22_3A_22_5C_22epoxy-images-stage1_5C_22_22_2C_22s_22_3Atrue_2C_22i_22_3A_22triggerName_22%257D%255D%22))), but we didn't notice because we weren't receiving build failure alerts to the oti-alerts Slack channel. But now we do get alerts there and noticed. I raised the timeout to 5h, but even that timed out on the most recent production build. I don't know why things are taking so much longer, but this commit raises the timeout to 10h, which should be plenty by 4 to 5 hours.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/233)
<!-- Reviewable:end -->
