### PR TITLE
Updates k8s to v1.23.16, plus upgrades to related resources

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -4,13 +4,13 @@
 export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
 
 # K8S component versions
-export K8S_VERSION=v1.22.15
-export K8S_CNI_VERSION=v1.1.1
-export K8S_CRICTL_VERSION=v1.22.1
+export K8S_VERSION=v1.23.16
+export K8S_CNI_VERSION=v1.2.0
+export K8S_CRICTL_VERSION=v1.23.0
 # v0.9.1 of the official CNI plugins release stopped including flannel, so we
 # must now install it manually.
-export K8S_FLANNELCNI_VERSION=v1.1.0
-export K8S_TOOLING_VERSION=v0.14.0
+export K8S_FLANNELCNI_VERSION=v1.1.2
+export K8S_TOOLING_VERSION=v0.15.0
 
 # stage3 mlxupdate
 export MFT_VERSION=4.22.0-96
@@ -19,7 +19,7 @@ export MFT_VERSION=4.22.0-96
 export MLXROM_VERSION=3.4.818
 
 # multus-cni version
-export MULTUS_CNI_VERSION=3.9
+export MULTUS_CNI_VERSION=3.9.3
 
 # etcdctl version
-export ETCDCTL_VERSION=v3.5.5
+export ETCDCTL_VERSION=v3.5.6


### PR DESCRIPTION
The control plane in sandbox and staging is already update, and now this will bring the nodes up to date.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/235)
<!-- Reviewable:end -->
