### PR TITLE
Fixes var capitalization bug in reboot-api script

### DIFF
--- a/configs/virtual_ubuntu/opt/mlab/bin/reboot-api-node.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/reboot-api-node.sh
@@ -8,7 +8,7 @@ METADATA_URL="http://metadata.google.internal/computeMetadata/v1"
 CURL_FLAGS=(--header "Metadata-Flavor: Google" --silent)
 
 ZONE_PATH=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/instance/zone")
-ZONE=${zone_path##*/}
+ZONE=${ZONE_PATH##*/}
 REBOOT_DAY=$(
   curl "${CURL_FLAGS[@]}" "${METADATA_URL}/instance/attributes/cluster_data" \
     | jq -r ".zones[\"${ZONE}\"].reboot_day"


### PR DESCRIPTION
This small bug was causing the `reboot-api-node.sh` script from working properly, since the reboot_day was always null, and never matched the current day.

I only happened to notice this bug today while investigating why two of the API nodes in production were running kernel version 5.19.x, and one was still on 5.15.x. 5.19.x is installed on the machine running 5.15, but it needs a reboot to pick up the new version, which didn't happen automatically like it should, due to this bug.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/239)
<!-- Reviewable:end -->
