### PR TITLE
Updates k8s to v1.24.15, plus related components

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -1,16 +1,21 @@
 # Common configuration for epoxy image builds. All builds source this file for
 # relevant settings.
+#
+# NOTE: these values should be kept in sync with the corresponding variables in
+# k8s-support. TODO(kinkade): we need a better way to manage these values.
+#
+# https://github.com/m-lab/k8s-support/blob/main/manage-cluster/k8s_deploy.conf#L31
 
 export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
 
 # K8S component versions
-export K8S_VERSION=v1.23.16
-export K8S_CNI_VERSION=v1.2.0
-export K8S_CRICTL_VERSION=v1.23.0
+export K8S_VERSION=v1.24.15
+export K8S_CNI_VERSION=v1.3.0
+export K8S_CRICTL_VERSION=v1.24.2
 # v0.9.1 of the official CNI plugins release stopped including flannel, so we
 # must now install it manually.
 export K8S_FLANNELCNI_VERSION=v1.1.2
-export K8S_TOOLING_VERSION=v0.15.0
+export K8S_TOOLING_VERSION=v0.15.1
 
 # stage3 mlxupdate
 export MFT_VERSION=4.22.0-96

--- a/configs/virtual_ubuntu/opt/mlab/conf/kubeadm-config.yml.template
+++ b/configs/virtual_ubuntu/opt/mlab/conf/kubeadm-config.yml.template
@@ -3,7 +3,6 @@ kind: InitConfiguration
 nodeRegistration:
   name: "{{MACHINE_NAME}}"
   kubeletExtraArgs:
-    container-runtime: "remote"
     container-runtime-endpoint: "unix:///run/containerd/containerd.sock"
   criSocket: "unix:///run/containerd/containerd.sock"
 localAPIEndpoint:
@@ -28,7 +27,6 @@ controlPlane:
 nodeRegistration:
   name: "{{MACHINE_NAME}}"
   kubeletExtraArgs:
-    container-runtime: "remote"
     container-runtime-endpoint: "unix:///run/containerd/containerd.sock"
 ---
 apiVersion: kubeadm.k8s.io/v1beta3

--- a/packer/configure_image_api.sh
+++ b/packer/configure_image_api.sh
@@ -24,6 +24,18 @@ ln -s /mnt/cluster-data/kubernetes /etc/kubernetes
 # Set the default KUBECONFIG location
 echo -e "\nexport KUBECONFIG=/etc/kubernetes/admin.conf\n" >> /root/.bashrc
 
+# Set various etcdctl configurations
+cat <<- EOF >> /root/.bashrc
+
+	export ETCDCTL_API=3
+	export ETCDCTL_DIAL_TIMEOUT=3s
+	export ETCDCTL_CACERT=/etc/kubernetes/pki/etcd/ca.crt
+	export ETCDCTL_CERT=/etc/kubernetes/pki/etcd/peer.crt
+	export ETCDCTL_KEY=/etc/kubernetes/pki/etcd/peer.key
+	export ETCDCTL_ENDPOINTS=https://127.0.0.1:2379
+	export CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
+EOF
+
 # Enable various systemd services.
 systemctl enable docker
 systemctl enable reboot-api-node.service


### PR DESCRIPTION
In addition to upgrading k8s and related components, this commit removes a deprecated config for the kubelet and sets up etcdctl env variables.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/240)
<!-- Reviewable:end -->
