### PR TITLE
Adds a new "leave-cluster" service and script

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system.conf.d/10-timeoutstopsec.conf
+++ b/configs/stage3_ubuntu/etc/systemd/system.conf.d/10-timeoutstopsec.conf
@@ -1,3 +1,3 @@
 [Manager]
-DefaultTimeoutStopSec=180
+DefaultTimeoutStopSec=30
 

--- a/configs/stage3_ubuntu/etc/systemd/system/leave-cluster.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/leave-cluster.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Leave cluster before shutdown
+After=multi-user.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+ExecStop=/opt/mlab/bin/leave-cluster.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/configs/stage3_ubuntu/etc/systemd/system/leave-cluster.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/leave-cluster.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Leave cluster before shutdown
-After=multi-user.target
+After=multi-user.target network.target
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/opt/mlab/bin/leave-cluster.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/leave-cluster.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+#
+# This script leverages the ePoxy boot server's "delete" extension, allowing a
+# machine to leave the k8s cluster on shutdown.
+
+set -euxo pipefail
+
+export PATH=$PATH:/opt/bin
+
+METADATA_URL="http://metadata.google.internal/computeMetadata/v1"
+CURL_FLAGS=(--header "Metadata-Flavor: Google" --silent)
+
+# Collect data necessary to proceed.
+epoxy_extension_server=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/project/attributes/epoxy_extension_server")
+k8s_node=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/instance/attributes/k8s_node")
+
+# MIG instances will have an "instance-template" attribute, other VMs will not.
+# Record the HTTP status code of the request into a variable. 200 means
+# "instance-template" exists and that this is a MIG instance. 404 means it is
+# not part of a MIG. We use this below to determine whether to attempt to
+# append the unique 4 char suffix of MIG instances to the k8s node name.
+is_mig=$(
+  curl "${CURL_FLAGS[@]}" --output /dev/null --write-out "%{http_code}" \
+    http://metadata.google.internal/computeMetadata/v1/instance/attributes/instance-template
+)
+
+# If this is a MIG instance, determine the random 4 char suffix of the instance
+# name, and then append that to the base k8s node name. The result should be a
+# typical M-Lab node/DNS name with a "-<xxxx>" string on the end. With this,
+# the node name is still unique, but we can easily just strip off the last 5
+# characters to get the name of the load balancer. Among other things, the
+# uuid-annotator can use this value as its -hostname flag so that it knows how
+# to annotate the data on this MIG instance.
+node_name="$k8s_node"
+if [[ $is_mig == "200" ]]; then
+  node_suffix="${hostname##*-}"
+  node_name="${k8s_node}-${node_suffix}"
+fi
+
+# Generate a JSON snippet suitable for the ePoxy extension server, and then
+# request a token.
+# https://github.com/m-lab/epoxy/blob/main/extension/request.go#L36
+extension_v1="{\"v1\":{\"hostname\":\"${node_name}\",\"last_boot\":\"$(date --utc +%Y-%m-%dT%T.%NZ)\"}}"
+
+# Don't bother with any error checking on this request. This is a one-shot deal
+# that will either work, or not, just before shutdown. Hopefully it will work
+# almost all the time.
+curl --data "$extension_v1" "http://${epoxy_extension_server}:8800/v1/delete_node"

--- a/configs/stage3_ubuntu/opt/mlab/bin/leave-cluster.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/leave-cluster.sh
@@ -11,6 +11,7 @@ METADATA_URL="http://metadata.google.internal/computeMetadata/v1"
 CURL_FLAGS=(--header "Metadata-Flavor: Google" --silent)
 
 # Collect data necessary to proceed.
+api_load_balancer=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/project/attributes/api_load_balancer")
 epoxy_extension_server=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/project/attributes/epoxy_extension_server")
 hostname=$(hostname)
 k8s_node=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/instance/attributes/k8s_node")

--- a/configs/stage3_ubuntu/opt/mlab/bin/leave-cluster.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/leave-cluster.sh
@@ -12,6 +12,7 @@ CURL_FLAGS=(--header "Metadata-Flavor: Google" --silent)
 
 # Collect data necessary to proceed.
 epoxy_extension_server=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/project/attributes/epoxy_extension_server")
+hostname=$(hostname)
 k8s_node=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/instance/attributes/k8s_node")
 
 # MIG instances will have an "instance-template" attribute, other VMs will not.

--- a/configs/virtual_ubuntu/etc/systemd/system/epoxy-extension-server.service
+++ b/configs/virtual_ubuntu/etc/systemd/system/epoxy-extension-server.service
@@ -13,6 +13,7 @@ Restart=always
 ExecStartPre=-/usr/bin/docker stop %N
 ExecStartPre=-/usr/bin/docker rm %N
 ExecStart=/usr/bin/docker run --publish 8800:8800 \
+                              --env KUBECONFIG=/etc/kubernetes/admin.conf \
                               --volume /etc/kubernetes:/etc/kubernetes:ro \
                               --volume /opt/bin:/opt/bin:ro \
                               --name %N -- \

--- a/configs/virtual_ubuntu/etc/systemd/system/leave-cluster.service
+++ b/configs/virtual_ubuntu/etc/systemd/system/leave-cluster.service
@@ -1,0 +1,1 @@
+../../../../stage3_ubuntu/etc/systemd/system/leave-cluster.service

--- a/configs/virtual_ubuntu/opt/mlab/bin/leave-cluster.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/leave-cluster.sh
@@ -1,0 +1,1 @@
+../../../../stage3_ubuntu/opt/mlab/bin/leave-cluster.sh

--- a/packer/configure_image.sh
+++ b/packer/configure_image.sh
@@ -25,3 +25,4 @@ systemctl enable check-reboot.timer
 systemctl enable configure-tc-fq.service
 systemctl enable write-metadata.service
 systemctl enable join-cluster.service
+systemctl enable leave-cluster.service


### PR DESCRIPTION
This PR adds a new `leave-cluster.service` systemd unit, which calls a corresponding script that will make a call to a [new epoxy-extension-server service "delete_node"](https://github.com/m-lab/epoxy-extensions/pull/9).

For now, this functionality is only enabled on virtual nodes, but we may find it useful to enable on all machines at some point.

Additionally, and unrelated to the main purpose of this PR, a change was made to the systemd `DefaultTimeoutStopSec` setting, reducing it from 180s to just 30s. It was 180s to allow for propagation of Prometheus data about service status to reach mlab-ns. However, these days the heartbeat service informs the Locate service of service health every 10s. It is reduced to 30s only to give running NDT tests time to finish when a machine is shutting down.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/241)
<!-- Reviewable:end -->
