### PR TITLE
Adds cert_key to project metadata 

### DIFF
--- a/configs/virtual_ubuntu/opt/mlab/bin/create-control-plane.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/create-control-plane.sh
@@ -137,7 +137,7 @@ function initialize_cluster() {
       until [[ -n $instance_exists ]]; do
         sleep 5
         instance_exists=$(
-          gcloud compute instances describe "api-platform-cluster-${z}" \
+          gcloud compute instances list --filter "name:api-platform-cluster-${z}" \
             --project $project --zone $z --format "value(name)"
         )
       done

--- a/configs/virtual_ubuntu/opt/mlab/bin/create-control-plane.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/create-control-plane.sh
@@ -137,8 +137,8 @@ function initialize_cluster() {
       until [[ -n $instance_exists ]]; do
         sleep 5
         instance_exists=$(
-          gcloud compute instances list --filter "name:api-platform-cluster-${z}" \
-            --project $project --zone $z --format "value(name)"
+          gcloud compute instances list --filter "name=('api-platform-cluster-${z}')" \
+            --project $project --format "value(name)"
         )
       done
 

--- a/configs/virtual_ubuntu/opt/mlab/bin/create-control-plane.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/create-control-plane.sh
@@ -137,7 +137,7 @@ function initialize_cluster() {
       until [[ -n $instance_exists ]]; do
         sleep 5
         instance_exists=$(
-          gcloud compute instances list --filter "name=('api-platform-cluster-${z}')" \
+          gcloud compute instances list --filter "name=api-platform-cluster-${z}" \
             --project $project --format "value(name)"
         )
       done

--- a/configs/virtual_ubuntu/opt/mlab/bin/create-control-plane.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/create-control-plane.sh
@@ -116,8 +116,8 @@ function initialize_cluster() {
   # is the encryption key for the cluster certificate data that is uploaded to
   # the secret kubeadm-certs in the 'kubeadm init' call below. However, the
   # secret is automatically deleted after 2 hours. For an attacker to take
-  # advantage of this, they would have to already have access the project in a
-  # way that would allow them to read project metadata, as well as cluster
+  # advantage of this, they would have to already have access to the project in
+  # a way that would allow them to read project metadata, as well as cluster
   # access to secrets in the kube-system namespace. Additionally, they would
   # need to have this access and excercise it during a 2h window that cannot be
   # known in advance.
@@ -279,9 +279,9 @@ function main() {
 
   # Add various cluster environment variables to root's .profile and .bashrc
   # files so that etcdctl and kubectl operate as expected without additional
-  # flags. This is done here because we don't want to overwrite the default
-  # .bashcrc and .profile files from the base distribution. We only want to
-  # append this to the existing files.
+  # flags. This is done here, rather than baking it into the image, because we
+  # don't want to overwrite the default .bashrc and .profile files from the
+  # base distribution. We only want to append this to the existing files.
   bash -c "(cat <<-EOF
   export CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
   export ETCDCTL_API=3


### PR DESCRIPTION
See the comment in the change set for details about why I chose to do this. Doing this possibly adds some small security risk, but greatly simplifies the script, and means that booting of the "init" control plane node is no longer dependent on the other control plane nodes existing.

The commits about fixing the gcloud request are no longer relevant, because the node doesn't need to run gcloud operations to figure out whether the other control planes actually exist.

Additionally, I have now configured Terraform to add the project metadata for `api_load_balancer` and `epoxy_extension_server`, so the script no longer needs to set these.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/243)
<!-- Reviewable:end -->
