### PR TITLE
Update extension-server, change URL of leave-cluster script

### DIFF
--- a/configs/stage3_ubuntu/opt/mlab/bin/leave-cluster.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/leave-cluster.sh
@@ -55,4 +55,4 @@ extension_v1="{\"v1\":{\"hostname\":\"${node_name}\",\"last_boot\":\"$(date --ut
 # Don't bother with any error checking on this request. This is a one-shot deal
 # that will either work, or not, just before shutdown. Hopefully it will work
 # almost all the time.
-curl --data "$extension_v1" "http://${epoxy_extension_server}:8800/v1/delete_node"
+curl --data "$extension_v1" "http://${epoxy_extension_server}:8800/v1/node/delete"

--- a/configs/virtual_ubuntu/etc/systemd/system/epoxy-extension-server.service
+++ b/configs/virtual_ubuntu/etc/systemd/system/epoxy-extension-server.service
@@ -17,7 +17,7 @@ ExecStart=/usr/bin/docker run --publish 8800:8800 \
                               --volume /etc/kubernetes:/etc/kubernetes:ro \
                               --volume /opt/bin:/opt/bin:ro \
                               --name %N -- \
-                              measurementlab/epoxy-extensions:v0.4.0 \
+                              measurementlab/epoxy-extensions:v0.5.0 \
                               -bin-dir /opt/bin
 ExecStop=/usr/bin/docker stop %N
 


### PR DESCRIPTION
This commit updates the extension-server container image to v0.5.0, which implements the new functionality to allow machines to request to be removed from the cluster when they are rebooting or being shutdown.

This new extension has a new URL of /v1/node/delete, and this commit also updates the leave-cluster.sh script to use this new path.