### PR TITLE
Add new "instance-type" metadata file to virtual machines

### DIFF
--- a/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -47,7 +47,7 @@ echo -n "PREMIUM" > $METADATA_DIR/network-tier
 # append the unique 4 char suffix of MIG instances to the k8s node name.
 is_mig=$(
   curl "${CURL_FLAGS[@]}" --output /dev/null --write-out "%{http_code}" \
-    "${METADATA_URL}/instance/attributes/instance-template"
+    "${METADATA_URL}/attributes/instance-template"
 )
 if [[ $is_mig == "200" ]]; then
   instance_type="mig"

--- a/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -43,17 +43,15 @@ echo -n "PREMIUM" > $METADATA_DIR/network-tier
 # MIG instances will have an "instance-template" attribute, other VMs will not.
 # Record the HTTP status code of the request into a variable. 200 means
 # "instance-template" exists and that this is a MIG instance. 404 means it is
-# not part of a MIG. We use this below to determine whether to attempt to
-# append the unique 4 char suffix of MIG instances to the k8s node name.
+# not part of a MIG. We use this below to determine whether to flag this
+# instance as loadbalanced.
 is_mig=$(
   curl "${CURL_FLAGS[@]}" --output /dev/null --write-out "%{http_code}" \
     "${METADATA_URL}/attributes/instance-template"
 )
 if [[ $is_mig == "200" ]]; then
-  instance_type="loadbalanced"
-else
-  instance_type="standalone"
+  echo -n "true" > $METADATA_DIR/loadbalanced
 fi
-echo -n "$instance_type" > $METADATA_DIR/instance-type
 
 echo -n $(uname -r) > $METADATA_DIR/kernel-version
+

--- a/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -50,9 +50,9 @@ is_mig=$(
     "${METADATA_URL}/attributes/instance-template"
 )
 if [[ $is_mig == "200" ]]; then
-  instance_type="mig"
+  instance_type="loadbalanced"
 else
-  instance_type="standard"
+  instance_type="standalone"
 fi
 echo -n "$instance_type" > $METADATA_DIR/instance-type
 


### PR DESCRIPTION
This PR adds a bit of new shell code to the `write-metadata.sh` script which gets run on boot on all virtual machines. It creates a new file at /var/local/metadata/instance-type, with a value of either "mig" or "standard".  This positions us to be able to add a new `-label` flag to ndt-server in the ndt-virtual DaemonSet, which will allow us to differentiate tests in BigQuery that are from regular, standalone VM, or ones that are part of a MIG. This will be important as we begin to test whether the performance of MIGs is comparable to standalone VMs.

I have tested this in sandbox:

```
mlab1-chs0t-mlab-sandbox-measurement-lab-org-n3qf:~$ cat /var/local/metadata/instance-type 
mig
```

```
mlab2-chs0t:~$ cat /var/local/metadata/instance-type 
standard
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/246)
<!-- Reviewable:end -->
