### PR TITLE
Stop relying on /etc/default/kubelet in kubelet.service 

### DIFF
--- a/configs/virtual_ubuntu/opt/mlab/bin/join-cluster.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/join-cluster.sh
@@ -105,7 +105,7 @@ token=$(echo "$join_data" | jq -r '.token')
 #
 # Add an env variable to the kubelet drop-in file and then append that env
 # variable to the ExecStart line.
-echo "Environment=\"MLAB_EXTRA_ARGS='--node-ip=${internal_ip} --node-labels=${k8s_labels} '\"" \
+echo "Environment=\"MLAB_EXTRA_ARGS=--node-ip=${internal_ip} --node-labels=${k8s_labels} \"" \
   >> /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 sed -i '/ExecStart=\// s/$/ $MLAB_EXTRA_ARGS/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 

--- a/configs/virtual_ubuntu/opt/mlab/bin/join-cluster.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/join-cluster.sh
@@ -105,7 +105,7 @@ token=$(echo "$join_data" | jq -r '.token')
 #
 # Add an env variable to the kubelet drop-in file and then append that env
 # variable to the ExecStart line.
-echo "Environment=\"MLAB_EXTRA_ARGS='--node-ip=${internal_ip} --node-lables=${k8s_labels} '\"" \
+echo "Environment=\"MLAB_EXTRA_ARGS='--node-ip=${internal_ip} --node-labels=${k8s_labels} '\"" \
   >> /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 sed -i '/ExecStart=\// s/$/ $MLAB_EXTRA_ARGS/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 

--- a/configs/virtual_ubuntu/opt/mlab/bin/join-cluster.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/join-cluster.sh
@@ -21,14 +21,6 @@ k8s_node=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/instance/attributes/k8s_node
 api_load_balancer=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/project/attributes/api_load_balancer")
 project=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/project/project-id")
 
-# For some reason I have not figured out, on dual stack VMs the kubelet selects
-# the IPv6 address for the InternalIP field, which causes all sorts of
-# breakage. Here we pass the internal IP address of the VM as a flag to the
-# kubelet so that it assigns the right InternalIP. From what I can tell in my
-# research this has something to do with running the kubelet in a cloud
-# environment but without any cloud controller manager in the cluster.
-echo "KUBELET_EXTRA_ARGS='--node-ip=${internal_ip}'" > /etc/default/kubelet
-
 # MIG instances will have an "instance-template" attribute, other VMs will not.
 # Record the HTTP status code of the request into a variable. 200 means
 # "instance-template" exists and that this is a MIG instance. 404 means it is
@@ -103,9 +95,19 @@ api_address=$(echo "$join_data" | jq -r '.api_address')
 ca_hash=$(echo "$join_data" | jq -r '.ca_hash')
 token=$(echo "$join_data" | jq -r '.token')
 
-# Set up necessary labels for the node.
-sed -ie "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$k8s_labels |g" \
-  /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+# Regarding the --node-ip flag below, for some reason I have not figured out,
+# on dual stack VMs the kubelet selects the IPv6 address for the InternalIP
+# field, which causes all sorts of breakage. Here we pass the internal IP
+# address of the VM as a flag to the kubelet so that it assigns the right
+# InternalIP. From what I can tell in my research this has something to do with
+# running the kubelet in a cloud environment but without any cloud controller
+# manager in the cluster.
+#
+# Add an env variable to the kubelet drop-in file and then append that env
+# variable to the ExecStart line.
+echo "Environment=\"MLAB_EXTRA_ARGS='--node-ip=${internal_ip} --node-lables=${k8s_labels} '\"" \
+  >> /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sed -i '/ExecStart=\// s/$/ $MLAB_EXTRA_ARGS/' /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
 # Set the system's hostname to the node name. By default, kubeadm uses the
 # hostname for the node name. The hostname, as defined in the instance's
@@ -125,3 +127,4 @@ kubeadm join "$api_address"  --v 4  --token "$token" \
 kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate node $node_name \
   flannel.alpha.coreos.com/public-ip-overwrite=$external_ip \
   --overwrite=true
+

--- a/packer/configure_image_common.sh
+++ b/packer/configure_image_common.sh
@@ -53,15 +53,15 @@ cd /opt/bin
 curl --location --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
 chmod +x {kubeadm,kubelet,kubectl}
 
-# Install kubelet systemd service and enable it.
+# Install kubelet systemd service.
 curl --silent --show-error --location \
   "https://raw.githubusercontent.com/kubernetes/release/${K8S_TOOLING_VERSION}/cmd/krel/templates/latest/kubelet/kubelet.service" \
-  | sed "s:/usr/bin:/opt/bin:g" | sudo tee /etc/systemd/system/kubelet.service
+  > /etc/systemd/system/kubelet.service
 
 mkdir -p /etc/systemd/system/kubelet.service.d
 curl --silent --show-error --location \
   "https://raw.githubusercontent.com/kubernetes/release/${K8S_TOOLING_VERSION}/cmd/krel/templates/latest/kubeadm/10-kubeadm.conf" \
-  | sed "s:/usr/bin:/opt/bin:g" | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+  | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
 # For convenience, when an operator needs to login and inspect things with crictl.
 echo -e "\nexport CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock\n" >> /root/.bashrc


### PR DESCRIPTION
We used to download a kubelet systemd drop-in file that was particular to Debian, and which relied on 
 /etc/default/kubelet. We would write some configs to that file. At some point k8s stopped providing distro-specific drop-in files and the new generic one only references /etc/sysconfig/kubelet, which is more of a RHEL thing.

This PR downloads the generic drop-in file and then simply appends a new env variable to it, and then adds that env variable to the end of ExecStart. This should be more robust to future changes to the default kubelet drop-in file. In essence, with these changes, we do not actually modify the contents of the original drop-in file, but simply add to it.

Additionally, stop modifying the default `kubelet.service` systemd file, since the drop-in file already overrides the thing we were modifying.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/252)
<!-- Reviewable:end -->
