### PR TITLE
Removes /etc/systemd/resolved.conf

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/resolved.conf
+++ b/configs/stage3_ubuntu/etc/systemd/resolved.conf
@@ -1,4 +1,0 @@
-[Resolve]
-DNS=8.8.8.8 8.8.4.4
-Domains=~.
-


### PR DESCRIPTION
For a long time we have been getting errors in the systemd journal like:

"Nameserver limits exceeded" err="Nameserver limits were exceeded, some nameservers have been omitted, the applied nameserver line is: 8.8.8.8 8.8.4.4 8.8.8.8"

... often to the point of flooding/polluting the logs. A few months ago I identified that it appeared to be the node-exporter pod on physical machines that seemed to be responsible for these messages. Our network configs specify which DNS servers to use. Perhaps configuring DNS through the network config _and_ through /etc/systemd/resolved.conf was causing duplication.

Prior to this change, /run/systemd/resolve/resolv.conf on physical machines looked something like this:

```
nameserver 8.8.8.8
nameserver 8.8.4.4
nameserver 8.8.8.8
# Too many DNS servers configured, the following entries may be ignored.
nameserver 8.8.4.4
nameserver 2001:4860:4860::8888
search .
```

And /etc/resolv.conf in a node-exporter pod looked something like this:

```
nameserver 8.8.8.8
nameserver 8.8.4.4
nameserver 8.8.8.8
```

With this change in place, /run/systemd/resolve/resolv.conf on a physical machine looks like:

```
nameserver 8.8.8.8
nameserver 8.8.4.4
nameserver 2001:4860:4860::8888
search .
```

And /etc/resolv.conf in a node-exporter pod looks like:

```
nameserver 8.8.8.8
nameserver 8.8.4.4
nameserver 2001:4860:4860::8888
```

I believe this should clear up the warning messages in the logs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/253)
<!-- Reviewable:end -->
