### PR TITLE
Configure the join-cluster.service systemd unit to always restart 

### DIFF
--- a/configs/virtual_ubuntu/etc/systemd/system/join-cluster.service
+++ b/configs/virtual_ubuntu/etc/systemd/system/join-cluster.service
@@ -8,7 +8,7 @@ ConditionPathExists=!/etc/kubernetes/kubelet.conf
 ExecStart=/opt/mlab/bin/join-cluster.sh
 Restart=always
 StartLimitInterval=0
-RestartSec=10
+RestartSec=30
 
 [Install]
 WantedBy=multi-user.target

--- a/configs/virtual_ubuntu/etc/systemd/system/join-cluster.service
+++ b/configs/virtual_ubuntu/etc/systemd/system/join-cluster.service
@@ -5,8 +5,10 @@ Description=Join the M-Lab Platform Cluster
 ConditionPathExists=!/etc/kubernetes/kubelet.conf
 
 [Service]
-Type=oneshot
 ExecStart=/opt/mlab/bin/join-cluster.sh
+Restart=always
+StartLimitInterval=0
+RestartSec=10
 
 [Install]
 WantedBy=multi-user.target

--- a/configs/virtual_ubuntu/opt/mlab/bin/join-cluster.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/join-cluster.sh
@@ -120,8 +120,14 @@ sed -i '/ExecStart=\// s/$/ $MLAB_EXTRA_ARGS/' /etc/systemd/system/kubelet.servi
 # node of that name.
 hostnamectl set-hostname $node_name
 
+# This script is run by the join-cluster.service systemd unit, and it set to
+# Restart=Always. In some cases kubeadm may start to run but fail for various,
+# possibly ephemeral, reasons. When this happens, kubeadm may fail preflight
+# checks because it finds certain files already exist. For this reason we add
+# --ignore-preflight-errors=all in order to unconditionally try to join the
+# cluster as many times as this scripts gets run.
 kubeadm join "$api_address"  --v 4  --token "$token" \
-  --discovery-token-ca-cert-hash "$ca_hash"
+  --discovery-token-ca-cert-hash "$ca_hash" --ignore-preflight-errors all
 
 # https://github.com/flannel-io/flannel/blob/master/Documentation/kubernetes.md#annotations
 kubectl --kubeconfig /etc/kubernetes/kubelet.conf annotate node $node_name \


### PR DESCRIPTION
Currently, the join-cluster.service unit is a "oneshot" unit. It will try to join the VM to the cluster once. If it fails, manual intervention will be required to get the VM joined to the cluster. It is entirely possible that the unit could fail due to ephemeral reasons. This small PR modifies the unit to always restart upon failure. The unit should now try over and over again to join the VM to the cluster.

Additionally, the unit runs `kubeadm`. `kubeadm` may get partway through trying to join the VM to the cluster and then fail, leaving behind any number of files. `kubeadm`s own "preflight" checks will fail if they find some of these files in the filesystem. This PR also configures `kubeadm` to ignore preflight errors. 

These two changes in combination will make VMs much more resilient to transient errors, or if the API is temporarily unavailable, etc. Namely, these changes should resolve the terraform-support build error we have this past Friday in which all VMs failed to join the staging cluster on their first try, causing a bunch of alerts and failed services.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/254)
<!-- Reviewable:end -->
