### PR TITLE
Writes LB IPs to metadata directory if VM is a MIG instance

### DIFF
--- a/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -16,16 +16,37 @@ CURL_FLAGS=(--header "Metadata-Flavor: Google" --silent)
 
 mkdir -p $METADATA_DIR
 
+# MIG instances will have a "created-by" attribute, standalone VMs will not.
+# Record the HTTP status code of the request into a variable. 200 means
+# "created-by" exists and therefore this is a MIG instance. Any other response
+# code means it was not created by an instance group manager and is not a MIG
+# instance.  This value is used to determine whether to flag this instance as
+# loadbalanced or not. Additionally, it is used to determine which external IP
+# addresses should be recorded, those of the VM or the ones associated with a
+# load balancer.
+#
+# https://cloud.google.com/compute/docs/instance-groups/getting-info-about-migs#checking_if_a_vm_instance_is_part_of_a_mig
+is_mig=$(
+  curl "${CURL_FLAGS[@]}" --output /dev/null --write-out "%{http_code}" \
+    "${METADATA_URL}/attributes/created-by"
+)
+
+if [[ $is_mig == "200" ]]; then
+  echo -n "true" > $METADATA_DIR/loadbalanced
+  external_ip=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/network-interfaces/0/forwarded-ips/0")
+  external_ipv6=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/network-interfaces/0/forwarded-ipv6s/0")
+else
+  external_ip=$(
+    curl "${CURL_FLAGS[@]}" "${METADATA_URL}/network-interfaces/0/access-configs/0/external-ip"
+  )
+  external_ipv6=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/network-interfaces/0/ipv6s")
+fi
+
+echo -n $external_ip > $METADATA_DIR/external-ip
+echo -n $external_ipv6 > $METADATA_DIR/external-ipv6
+
 zone=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/zone")
 echo -n ${zone##*/} > $METADATA_DIR/zone
-
-external_ip=$(
-  curl "${CURL_FLAGS[@]}" "${METADATA_URL}/network-interfaces/0/access-configs/0/external-ip"
-)
-echo -n $external_ip > $METADATA_DIR/external-ip
-
-external_ipv6=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/network-interfaces/0/ipv6s")
-echo -n $external_ipv6 > $METADATA_DIR/external-ipv6
 
 machine_type=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/machine-type")
 echo -n ${machine_type##*/} > $METADATA_DIR/machine-type
@@ -35,25 +56,10 @@ echo -n ${machine_type##*/} > $METADATA_DIR/machine-type
 #
 # networkInterfaces[0].accessConfigs[0].networkTier
 #
-# So, for now, just statically set the network tier to PREMIUM. This is the
-# default, and anything less isn't even available in all regions. We are
-# unlikely to change this.
+# For now, just statically set the network tier to PREMIUM. This is the default,
+# and STANDARD isn't even available in all regions. However, we do want to do
+# some testing with STANDARD tier networking, and ideally we could/should be
+# able to set this to the correct value in every case.
 echo -n "PREMIUM" > $METADATA_DIR/network-tier
-
-# MIG instances will have a "created-by" attribute, standalone VMs will not.
-# Record the HTTP status code of the request into a variable. 200 means
-# "created-by" exists and therefore this is a MIG instance. Any other response
-# code means it was not created by an instance group manager and is not a MIG
-# instance.  We use this to determine whether to flag this instance as
-# loadbalanced.
-#
-# https://cloud.google.com/compute/docs/instance-groups/getting-info-about-migs#checking_if_a_vm_instance_is_part_of_a_mig
-is_mig=$(
-  curl "${CURL_FLAGS[@]}" --output /dev/null --write-out "%{http_code}" \
-    "${METADATA_URL}/attributes/created-by"
-)
-if [[ $is_mig == "200" ]]; then
-  echo -n "true" > $METADATA_DIR/loadbalanced
-fi
 
 echo -n $(uname -r) > $METADATA_DIR/kernel-version


### PR DESCRIPTION
Depending on whether the VM is standalone or part of a MIG, we need to write different values to /var/local/metadata/external_ip[v6]. For standalone VMs we can write the same values that we have been writing before, which are the external IPs associated with the machine. For MIG instances, we want to write the external IPs associated with the loadbalancer instead.

Less has changed in this file than the diff would make it seem. I had to rearrange some elements of the script. The main change is to move the MIG detection logic to the top, and then assign `external_ip` and `external_ipv6` appropriately depending on whether the VM is a MIG.

I updated the disk image for this build in sandbox and verified that this is work as intended.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/255)
<!-- Reviewable:end -->
