### PR TITLE
Includes IPv6 interface configs only if IPv6 exists

### DIFF
--- a/configs/stage3_ubuntu/opt/mlab/bin/generate_network_config.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/generate_network_config.sh
@@ -76,10 +76,20 @@ Address=$ADDR_IPv4
 Gateway=$GATEWAY_IPv4
 DNS=$DNS1_IPv4
 DNS=$DNS2_IPv4
+EOF
+
+# Append IPv6 configs, but only if IPv6 configs exist. If there is no IPv6
+# config, then the we would be left with "DNS=", which apparently overrides the
+# previous IPv4 DNS settings, leaving a machine with no configured nameservers,
+# and thus no name resolution.
+if [[ -n $FIELDS_IPv6 ]]; then
+  cat >> $OUTPUT <<EOF
 
 # IPv6
 Address=$ADDR_IPv6
 Gateway=$GATEWAY_IPv6
 DNS=$DNS1_IPv6
 IPv6AcceptRA=no
+
 EOF
+fi


### PR DESCRIPTION
Currently, if a site doesn't support IPv6 the systemd-networkd config for IPv6 looks like:

```
Address=
Gateway=
DNS=
IPv6AcceptRA=no
```

systemd-network emits some warnings that it is ignoring invalid values for Address and Gateway, but more significantly, I think, is that it does not apparently consider `DNS=` invalid, but simply overwrites any existing "DNS" entries that were previously set for IPv4. The end results is that no nameservers are configured and machines at sites with no IPv6 have no name resolution, which, of course, breaks everything.

This PR just breaks out the IPv6 part of the config and wraps it in a conditional that won't write it to the config file if no IPv6 config exists.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/256)
<!-- Reviewable:end -->
