### PR TITLE
Writes out new "managed" metadata file with appropriate value

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
@@ -7,7 +7,7 @@ Before=setup-after-boot.service
 # hostname value to the metadata directory, then be sure this unit runs later,
 # otherwise we get some randomish looking string for the hostname. Additionally,
 # wait until the eth0 interface exists and the machine network is online.
-After=generate-eth0-config.service sys-subsystem-net-devices-eth0.device network-online.target
+After=generate-eth0-config.service
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
@@ -5,8 +5,7 @@ Before=setup-after-boot.service
 # generate-eth0-config.service sets the hostname of the machine to the expected
 # M-Lab DNS name for the machine. Since this write-metadata unit writes the
 # hostname value to the metadata directory, then be sure this unit runs later,
-# otherwise we get some randomish looking string for the hostname. Additionally,
-# wait until the eth0 interface exists and the machine network is online.
+# otherwise we get some randomish looking string for the hostname.
 After=generate-eth0-config.service
 
 [Service]

--- a/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
@@ -5,8 +5,9 @@ Before=setup-after-boot.service
 # generate-eth0-config.service sets the hostname of the machine to the expected
 # M-Lab DNS name for the machine. Since this write-metadata unit writes the
 # hostname value to the metadata directory, then be sure this unit runs later,
-# otherwise we get some randomish looking string for the hostname.
-After=generate-eth0-config.service systemd-networkd-wait-online.service
+# otherwise we get some randomish looking string for the hostname. Additionally,
+# wait until the eth0 interface exists and the machine network is online.
+After=generate-eth0-config.service sys-subsystem-net-devices-eth0.device network-online.target
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
@@ -6,7 +6,7 @@ Before=setup-after-boot.service
 # M-Lab DNS name for the machine. Since this write-metadata unit writes the
 # hostname value to the metadata directory, then be sure this unit runs later,
 # otherwise we get some randomish looking string for the hostname.
-After=generate-eth0-config.service network.target
+After=generate-eth0-config.service systemd-networkd-wait-online.service
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
@@ -6,7 +6,7 @@ Before=setup-after-boot.service
 # M-Lab DNS name for the machine. Since this write-metadata unit writes the
 # hostname value to the metadata directory, then be sure this unit runs later,
 # otherwise we get some randomish looking string for the hostname.
-After=generate-eth0-config.service
+After=generate-eth0-config.service network.target
 
 [Service]
 Type=oneshot

--- a/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -14,10 +14,7 @@ uname -r | tr -d '\n' > $METADATA_DIR/kernel-version
 # Write out the metadata value for "managed". This will allow data users to know
 # what environment the test was run. For a "full" site M-Lab manages both the
 # machine and an upstream switch. For "minimal" deployments M-Lab only manages
-# the machine, and nothing upstream. For bring-your-own-server (BYOS) M-Lab
-# manages nothing. The /32 case is supposed to represent BYOS, though as this is
-# written it's not clear whether this script in this repository will even be
-# present in those container images.
+# the machine, and nothing upstream.
 PREFIX_LEN=$(egrep -o 'epoxy.ipv4=[^ ]+' /proc/cmdline | cut -d= -f2 | cut -d, -f1 | cut -d/ -f 2)
 case "$PREFIX_LEN" in
   26)
@@ -25,9 +22,6 @@ case "$PREFIX_LEN" in
     ;;
   28|29)
     MANAGED="machine"
-    ;;
-  32)
-    MANAGED="none"
     ;;
   *)
     echo "ERROR: cannot set MANAGED. Unknown prefix length ${PREFIX_LEN}"

--- a/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -18,7 +18,7 @@ uname -r | tr -d '\n' > $METADATA_DIR/kernel-version
 # manages nothing. The /32 case is supposed to represent BYOS, though as this is
 # written it's not clear whether this script in this repository will even be
 # present in those container images.
-PREFIX_LEN=$(ip -family inet -json addr show dev eth0 | jq '.[0].addr_info[0].prefixlen')
+PREFIX_LEN=$(egrep -o 'epoxy.ipv4=[^ ]+' /proc/cmdline | cut -d= -f2 | cut -d, -f1 | cut -d/ -f 2)
 case "$PREFIX_LEN" in
   26)
     MANAGED="switch,machine"

--- a/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -10,3 +10,28 @@ mkdir -p $METADATA_DIR
 
 # Write the kernel version
 uname -r | tr -d '\n' > $METADATA_DIR/kernel-version
+
+# Write out the metadata value for "managed". This will allow data users to know
+# what environment the test was run. For a "full" site M-Lab manages both the
+# machine and an upstream switch. For "minimal" deployments M-Lab only manages
+# the machine, and nothing upstream. For bring-your-own-server (BYOS) M-Lab
+# manages nothing. The /32 case is supposed to represent BYOS, though as this is
+# written it's not clear whether this script in this repository will even be
+# present in those container images.
+PREFIX_LEN=$(ip -family inet -json addr show dev eth0 | jq '.[0].addr_info[0].prefixlen')
+case "$PREFIX_LEN" in
+  26)
+    MANAGED="switch,machine"
+    ;;
+  28|29)
+    MANAGED="machine"
+    ;;
+  32)
+    MANAGED="none"
+    ;;
+  *)
+    echo "ERROR: cannot set MANAGED. Unknown prefix length ${PREFIX_LEN}"
+    MANAGED="unknown"
+    ;;
+esac
+echo -n "$MANAGED" > $METADATA_DIR/managed

--- a/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -63,3 +63,7 @@ echo -n ${machine_type##*/} > $METADATA_DIR/machine-type
 echo -n "PREMIUM" > $METADATA_DIR/network-tier
 
 echo -n $(uname -r) > $METADATA_DIR/kernel-version
+
+# For virtual machines this indicates that M-Lab manages only the machine and
+# none of the infrastructure upstream of it.
+echo -n "machine" > $METADATA_DIR/managed


### PR DESCRIPTION
As we begin to deploy M-Lab sites that are not the typical "full" deployment (4 servers, 1 switch), we want a way to flag in the data the deployment type.

This PR modifies the write-metadata.sh scripts to include a new metadata file: `/var/local/metadata/managed`. This new file can have three values:

* switch,machine
* machine
* none

The first is for typical full deployments, indicating that M-Lab manages both the machine and an upstream switch. The second is for "minimal" sites, in which M-Lab manages the machine and nothing else. The third is for BYOS, in which case M-Lab manages nothing.

For virtual machines we statically populate the file with "machine", since M-Lab manages the virtual machines, at least today.

On mlab2-lga0t this produces:

```
root@mlab2-lga0t:~# cat /var/local/metadata/managed 
switch,machine
```

On the ISC machine in sandbox this produces:

```
mlab@mlab1-nuq0t:~$ cat /var/local/metadata/managed 
machine
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/257)
<!-- Reviewable:end -->
