### PR TITLE
Removes any conditional checks for correct netmask

### DIFF
--- a/configs/stage1_isos/create-stage1-iso-template.sh
+++ b/configs/stage1_isos/create-stage1-iso-template.sh
@@ -15,20 +15,6 @@ SOURCE_DIR=${1:?Please provide the source directory root: $USAGE}
 IMAGE_DIR=${2:?Error: specify input vmlinuz: $USAGE}
 OUTPUT_DIR=${3:?Error: specify directory for output ISO: $USAGE}
 
-# For the purposes of testing smaller IPv4 prefixes, allow CIDRs other than
-# /26, but only in mlab-sandbox for now.
-#
-# TODO(kinkade): implement actual support for prefixes smaller than /26. Our
-# goal is to be able to explicitly support prefixes smaller than /26, and the
-# conditional below doesn't actually do this, but simply doesn't prevent the
-# build from happening, which may have unexpected results.
-if [[ $PROJECT != "mlab-sandbox" ]]; then
-  if [[ "{{ipv4_netmask}}" != "255.255.255.192" ]] ; then
-    echo 'Error: Sorry, unsupported netmask: {{ipv4_netmask}}'
-    exit 1
-  fi
-fi
-
 if [[ ! -f "${IMAGE_DIR}/stage1_kernel.vmlinuz" ]] ; then
     echo 'Error: vmlinuz image not found!'
     echo "Expected: ${IMAGE_DIR}/stage1_kernel.vmlinuz."

--- a/configs/stage1_usbs/create-stage1-usb-template.sh
+++ b/configs/stage1_usbs/create-stage1-usb-template.sh
@@ -14,11 +14,6 @@ SOURCE_DIR=${1:?Please provide the source directory root: $USAGE}
 IMAGE_DIR=${2:?Error: specify input vmlinuz: $USAGE}
 OUTPUT_DIR=${3:?Error: specify directory for output USB: $USAGE}
 
-if [[ "{{ipv4_netmask}}" != "255.255.255.192" ]] ; then
-  echo 'Error: Sorry, unsupported netmask: {{ipv4_netmask}}'
-  exit 1
-fi
-
 if [[ ! -f "${IMAGE_DIR}/stage1_kernel.vmlinuz" ]] ; then
     echo 'Error: vmlinuz image not found!'
     echo "Expected: ${IMAGE_DIR}/stage1_kernel.vmlinuz"


### PR DESCRIPTION
We will soon no longer just support /26 prefixes, but also /28 and /29. While we do want to validate netmasks, we no longer want or need to do that here, as it is already done in siteinfo, so sites shouldn't be able to be added without a supported prefix in the first place:

https://github.com/m-lab/siteinfo/blob/main/lib/site.jsonnet#L213

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/258)
<!-- Reviewable:end -->
