### PR TITLE
Update k8s to v1.27.12

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -9,13 +9,13 @@
 export SITES="https://siteinfo.${PROJECT}.measurementlab.net/v2/sites/sites.json"
 
 # K8S component versions
-export K8S_VERSION=v1.26.12
-export K8S_CNI_VERSION=v1.4.0
-export K8S_CRICTL_VERSION=v1.26.1
+export K8S_VERSION=v1.27.12
+export K8S_CNI_VERSION=v1.4.1
+export K8S_CRICTL_VERSION=v1.27.1
 # v0.9.1 of the official CNI plugins release stopped including flannel, so we
 # must now install it manually.
-export K8S_FLANNELCNI_VERSION=v1.2.0
-export K8S_TOOLING_VERSION=v0.16.4
+export K8S_FLANNELCNI_VERSION=v1.4.0-flannel1
+export K8S_TOOLING_VERSION=v0.16.7
 
 # stage3 mlxupdate
 export MFT_VERSION=4.22.0-96
@@ -27,4 +27,4 @@ export MLXROM_VERSION=3.4.818
 export MULTUS_CNI_VERSION=3.9.3
 
 # etcdctl version
-export ETCDCTL_VERSION=v3.5.9
+export ETCDCTL_VERSION=v3.5.12

--- a/configs/virtual_ubuntu/opt/mlab/conf/kubeadm-config.yml.template
+++ b/configs/virtual_ubuntu/opt/mlab/conf/kubeadm-config.yml.template
@@ -42,7 +42,6 @@ controllerManager:
     node-cidr-mask-size: "26"
     # https://github.com/kubernetes-sigs/kubespray/blob/master/docs/kubernetes-reliability.md#medium-update-and-average-reaction
     node-monitor-grace-period: 2m
-    pod-eviction-timeout: 1m
 etcd:
   local:
     dataDir: "/mnt/cluster-data/etcd"


### PR DESCRIPTION
See https://github.com/m-lab/k8s-support/pull/874. This also removes the deprecated `-pod-eviction-timeout` flag.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/259)
<!-- Reviewable:end -->
