### PR TITLE
Use registration.json format instead of switches.json to get uplink speed

### DIFF
--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -17,10 +17,11 @@ function write_metric_file {
   chmod 644 $METRIC_FILE
 }
 
-SITE=${HOSTNAME:6:5}
-SPEED=$(curl --silent --show-error --location \
-    https://siteinfo.mlab-oti.measurementlab.net/v1/sites/switches.json \
-    | jq -r ".${SITE}.uplink_speed")
+SPEED=$(
+  curl --silent --show-error --location \
+    https://siteinfo.mlab-oti.measurementlab.net/v2/sites/registration.json \
+    jq -r ".[\"${HOSTNAME}\"] | .Uplink"
+  )
 
 # Internally, tc stores rates as 32-bit unsigned integers in bps (bytes per
 # second).  Because of this, and to make comparisons easier later in the script,

--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -20,7 +20,7 @@ function write_metric_file {
 SPEED=$(
   curl --silent --show-error --location \
     https://siteinfo.mlab-oti.measurementlab.net/v2/sites/registration.json \
-    jq -r ".[\"${HOSTNAME}\"] | .Uplink"
+    | jq -r ".[\"${HOSTNAME}\"] | .Uplink"
   )
 
 # Internally, tc stores rates as 32-bit unsigned integers in bps (bytes per


### PR DESCRIPTION
All physical machines have a systemd service that runs on boot which configures the fq qdisc on the default network interface. In order to properly configure the `maxrate` setting the script currently relies on the switches.json format. The problem is that not every physical site has a switch any longer, now that the ISC minimal site is moving to production. This PR changes the script to get the sites uplink speed from the registration.json siteinfo format, which will have a record for every machine at every site, no matter whether it is physical, virtual, full or minimal etc.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/260)
<!-- Reviewable:end -->
