### PR TITLE
Add new "mlab/managed" label to physical k8s nodes

### DIFF
--- a/configs/stage3_ubuntu/opt/mlab/bin/setup_k8s.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/setup_k8s.sh
@@ -42,7 +42,7 @@ NODE_LABELS+="mlab/metro=${METRO},"
 NODE_LABELS+="mlab/type=physical,"
 NODE_LABELS+="mlab/project=${GCP_PROJECT},"
 NODE_LABELS+="mlab/ndt-version=production,"
-NODE_LABELS+="mlab/managed=$(cat /var/local/metadata/managed)"
+NODE_LABELS+="mlab/managed=$(cat /var/local/metadata/managed | tr ',' '-')"
 
 sed -ie "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS |g" \
   /etc/systemd/system/kubelet.service.d/10-kubeadm.conf

--- a/configs/stage3_ubuntu/opt/mlab/bin/setup_k8s.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/setup_k8s.sh
@@ -28,6 +28,12 @@ MACHINE=${HOSTNAME:0:5}
 SITE=${HOSTNAME:6:5}
 METRO="${SITE/[0-9]*/}"
 
+# This value will be used to populate the node label "mlab/managed", which will
+# allow operators to differentiate betweeen "full", "minimal" and "BYOS"
+# physical sites. Since k8s does not support commas in label values, any commas
+# are converted to dashes.
+MANAGED=$(cat /var/local/metadata/managed | tr ',' '-')
+
 # Adds /opt/bin (k8s binaries) and /opt/mlab/bin (mlab binaries/scripts) to PATH.
 # Also, be 100% sure /sbin and /usr/sbin are in PATH.
 export PATH=$PATH:/sbin:/usr/sbin:/opt/bin:/opt/mlab/bin
@@ -42,7 +48,7 @@ NODE_LABELS+="mlab/metro=${METRO},"
 NODE_LABELS+="mlab/type=physical,"
 NODE_LABELS+="mlab/project=${GCP_PROJECT},"
 NODE_LABELS+="mlab/ndt-version=production,"
-NODE_LABELS+="mlab/managed=$(cat /var/local/metadata/managed | tr ',' '-')"
+NODE_LABELS+="mlab/managed=${MANAGED}"
 
 sed -ie "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS |g" \
   /etc/systemd/system/kubelet.service.d/10-kubeadm.conf

--- a/configs/stage3_ubuntu/opt/mlab/bin/setup_k8s.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/setup_k8s.sh
@@ -35,7 +35,15 @@ export PATH=$PATH:/sbin:/usr/sbin:/opt/bin:/opt/mlab/bin
 # Capture K8S version for later usage.
 RELEASE=$(kubelet --version | awk '{print $2}')
 
-NODE_LABELS="mlab/machine=${MACHINE},mlab/site=${SITE},mlab/metro=${METRO},mlab/type=physical,mlab/project=${GCP_PROJECT},mlab/ndt-version=production"
+# Create a list of node labels
+NODE_LABELS="mlab/machine=${MACHINE},"
+NODE_LABELS+="mlab/site=${SITE},"
+NODE_LABELS+="mlab/metro=${METRO},"
+NODE_LABELS+="mlab/type=physical,"
+NODE_LABELS+="mlab/project=${GCP_PROJECT},"
+NODE_LABELS+="mlab/ndt-version=production,"
+NODE_LABELS+="mlab/managed=$(cat /var/local/metadata/managed)"
+
 sed -ie "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS |g" \
   /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 


### PR DESCRIPTION
Minimal sites do not have switches, yet today the Disco DaemonSet deploys to every physical machine. On minimal sites Disco crashloops because there is no switch. This commit adds a new node label named "mlab/managed", which has the
same meaning and possible values as the "managed" metadata field. Indeed, the value is taken directly from /var/local/metadata/managed.

This script gets run by epoxy_client as part of the setup-after-boot.service. This service is configured to run _after_ the write-metadata.service, which should ensure that the file is properly populated with the appropriate value.

Additionally, kubernetes does not support commas in label values, so the script changes any commas to a dash. I also decided to reformat the NODE_LABELS variable assignment to be a bit more readable, since it was getting rather long.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/261)
<!-- Reviewable:end -->
