### PR TITLE
Adds new mlab/donated node label

### DIFF
--- a/configs/stage3_ubuntu/opt/mlab/bin/setup_k8s.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/setup_k8s.sh
@@ -41,6 +41,12 @@ export PATH=$PATH:/sbin:/usr/sbin:/opt/bin:/opt/mlab/bin
 # Capture K8S version for later usage.
 RELEASE=$(kubelet --version | awk '{print $2}')
 
+# Whether the site's transit is donated or not. Will be "true" or "false".
+DONATED=$(
+  curl --silent "https://siteinfo.${GCP_PROJECT}.measurementlab.net/v2/sites/donated.json" \
+    | jq "any(. == \"${SITE}\")"
+)
+
 # Create a list of node labels
 NODE_LABELS="mlab/machine=${MACHINE},"
 NODE_LABELS+="mlab/site=${SITE},"
@@ -48,7 +54,8 @@ NODE_LABELS+="mlab/metro=${METRO},"
 NODE_LABELS+="mlab/type=physical,"
 NODE_LABELS+="mlab/project=${GCP_PROJECT},"
 NODE_LABELS+="mlab/ndt-version=production,"
-NODE_LABELS+="mlab/managed=${MANAGED}"
+NODE_LABELS+="mlab/managed=${MANAGED},"
+NODE_LABELS+="mlab/donated=${DONATED}"
 
 sed -ie "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS |g" \
   /etc/systemd/system/kubelet.service.d/10-kubeadm.conf


### PR DESCRIPTION
This can be used for any number of purposes. For example, we could choose to use it as a node selector for pods such that we only deploy certain workloads to donated or non-donated sites.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/262)
<!-- Reviewable:end -->
