### PR TITLE
Add network tags to VMs created by Packer for firewalling

### DIFF
--- a/packer/mlab.pkr.hcl
+++ b/packer/mlab.pkr.hcl
@@ -21,30 +21,36 @@ variable "source_image" {
 }
 
 source "googlecompute" "platform-cluster-instance" {
-  project_id   = var.gcp_project
-  zone         = "us-central1-c"
-  source_image = var.source_image
-  image_name   = "platform-cluster-instance-${var.image_version}"
-  ssh_username = "packer"
-  disk_size    = 100
+  project_id       = var.gcp_project
+  zone             = "us-central1-c"
+  source_image     = var.source_image
+  image_name       = "platform-cluster-instance-${var.image_version}"
+  ssh_username     = "packer"
+  disk_size        = 100
+  use_internal_ip  = true
+  omit_external_ip = true
 }
 
 source "googlecompute" "platform-cluster-internal-instance" {
-  project_id   = var.gcp_project
-  zone         = "us-central1-c"
-  source_image = var.source_image
-  image_name   = "platform-cluster-internal-instance-${var.image_version}"
-  ssh_username = "packer"
-  disk_size    = 100
+  project_id       = var.gcp_project
+  zone             = "us-central1-c"
+  source_image     = var.source_image
+  image_name       = "platform-cluster-internal-instance-${var.image_version}"
+  ssh_username     = "packer"
+  disk_size        = 100
+  use_internal_ip  = true
+  omit_external_ip = true
 }
 
 source "googlecompute" "platform-cluster-api-instance" {
-  project_id   = var.gcp_project
-  zone         = "us-central1-c"
-  source_image = var.source_image
-  image_name   = "platform-cluster-api-instance-${var.image_version}"
-  ssh_username = "packer"
-  disk_size    = 100
+  project_id       = var.gcp_project
+  zone             = "us-central1-c"
+  source_image     = var.source_image
+  image_name       = "platform-cluster-api-instance-${var.image_version}"
+  ssh_username     = "packer"
+  disk_size        = 100
+  use_internal_ip  = true
+  omit_external_ip = true
 }
 
 build {

--- a/packer/mlab.pkr.hcl
+++ b/packer/mlab.pkr.hcl
@@ -21,36 +21,33 @@ variable "source_image" {
 }
 
 source "googlecompute" "platform-cluster-instance" {
-  project_id       = var.gcp_project
-  zone             = "us-central1-c"
-  source_image     = var.source_image
-  image_name       = "platform-cluster-instance-${var.image_version}"
-  ssh_username     = "packer"
-  disk_size        = 100
-  use_internal_ip  = true
-  omit_external_ip = true
+  project_id   = var.gcp_project
+  zone         = "us-central1-c"
+  source_image = var.source_image
+  image_name   = "platform-cluster-instance-${var.image_version}"
+  ssh_username = "packer"
+  disk_size    = 100
+  tags         = ["cloud-build-packer"]
 }
 
 source "googlecompute" "platform-cluster-internal-instance" {
-  project_id       = var.gcp_project
-  zone             = "us-central1-c"
-  source_image     = var.source_image
-  image_name       = "platform-cluster-internal-instance-${var.image_version}"
-  ssh_username     = "packer"
-  disk_size        = 100
-  use_internal_ip  = true
-  omit_external_ip = true
+  project_id   = var.gcp_project
+  zone         = "us-central1-c"
+  source_image = var.source_image
+  image_name   = "platform-cluster-internal-instance-${var.image_version}"
+  ssh_username = "packer"
+  disk_size    = 100
+  tags         = ["cloud-build-packer"]
 }
 
 source "googlecompute" "platform-cluster-api-instance" {
-  project_id       = var.gcp_project
-  zone             = "us-central1-c"
-  source_image     = var.source_image
-  image_name       = "platform-cluster-api-instance-${var.image_version}"
-  ssh_username     = "packer"
-  disk_size        = 100
-  use_internal_ip  = true
-  omit_external_ip = true
+  project_id   = var.gcp_project
+  zone         = "us-central1-c"
+  source_image = var.source_image
+  image_name   = "platform-cluster-api-instance-${var.image_version}"
+  ssh_username = "packer"
+  disk_size    = 100
+  tags         = ["cloud-build-packer"]
 }
 
 build {


### PR DESCRIPTION
We lately disabled SSH access to project VMs in most VPCs, notwithstanding the mlab-platform-network. We don't SSH into those nodes, and they don't need to be publicly exposed in that way. However, doing this broke epoxy-images builds for
Packer, because, by default, Packer will SSH into the VM that is created using the public address.

This PR causes Packer to add a special network tag to the VMs it creates, and this tag can be used to create a firewall rule that will explicitly allow public SSH access to VMs it creates, while still disallowing public SSH access to all other VMs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/263)
<!-- Reviewable:end -->
