### PR TITLE
Configure Packer to ssh to VMs using IAP

### DIFF
--- a/cloudbuild-packer.yaml
+++ b/cloudbuild-packer.yaml
@@ -14,7 +14,7 @@ options:
 steps:
 
 # packer_images.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
+- name: us-central1-docker.pkg.dev/mlab-sandbox/build-images/epoxy-images:1.2
   args: [
     '/workspace/builder.sh', 'packer_images'
   ]

--- a/packer/mlab.pkr.hcl
+++ b/packer/mlab.pkr.hcl
@@ -21,36 +21,39 @@ variable "source_image" {
 }
 
 source "googlecompute" "platform-cluster-instance" {
-  disk_size              = 100
-  iap_tunnel_launch_wait = 60
-  image_name             = "platform-cluster-instance-${var.image_version}"
-  omit_external_ip       = true
-  project_id             = var.gcp_project
-  source_image           = var.source_image
-  ssh_username           = "packer"
-  use_iap                = true
-  use_internal_ip        = true
-  zone                   = "us-central1-c"
+  disk_size        = 100
+  image_name       = "platform-cluster-instance-${var.image_version}"
+  omit_external_ip = true
+  project_id       = var.gcp_project
+  source_image     = var.source_image
+  ssh_username     = "packer"
+  use_iap          = true
+  use_internal_ip  = true
+  zone             = "us-central1-c"
 }
 
 source "googlecompute" "platform-cluster-internal-instance" {
-  disk_size    = 100
-  image_name   = "platform-cluster-internal-instance-${var.image_version}"
-  project_id   = var.gcp_project
-  source_image = var.source_image
-  ssh_username = "packer"
-  use_iap      = true
-  zone         = "us-central1-c"
+  disk_size        = 100
+  image_name       = "platform-cluster-internal-instance-${var.image_version}"
+  omit_external_ip = true
+  project_id       = var.gcp_project
+  source_image     = var.source_image
+  ssh_username     = "packer"
+  use_iap          = true
+  use_internal_ip  = true
+  zone             = "us-central1-c"
 }
 
 source "googlecompute" "platform-cluster-api-instance" {
-  disk_size    = 100
-  image_name   = "platform-cluster-api-instance-${var.image_version}"
-  project_id   = var.gcp_project
-  source_image = var.source_image
-  ssh_username = "packer"
-  use_iap      = true
-  zone         = "us-central1-c"
+  disk_size        = 100
+  image_name       = "platform-cluster-api-instance-${var.image_version}"
+  omit_external_ip = true
+  project_id       = var.gcp_project
+  source_image     = var.source_image
+  ssh_username     = "packer"
+  use_iap          = true
+  use_internal_ip  = true
+  zone             = "us-central1-c"
 }
 
 build {

--- a/packer/mlab.pkr.hcl
+++ b/packer/mlab.pkr.hcl
@@ -21,33 +21,33 @@ variable "source_image" {
 }
 
 source "googlecompute" "platform-cluster-instance" {
-  project_id   = var.gcp_project
-  zone         = "us-central1-c"
-  source_image = var.source_image
-  image_name   = "platform-cluster-instance-${var.image_version}"
-  ssh_username = "packer"
   disk_size    = 100
-  tags         = ["cloud-build-packer"]
+  image_name   = "platform-cluster-instance-${var.image_version}"
+  project_id   = var.gcp_project
+  source_image = var.source_image
+  ssh_username = "packer"
+  use_iap      = true
+  zone         = "us-central1-c"
 }
 
 source "googlecompute" "platform-cluster-internal-instance" {
-  project_id   = var.gcp_project
-  zone         = "us-central1-c"
-  source_image = var.source_image
-  image_name   = "platform-cluster-internal-instance-${var.image_version}"
-  ssh_username = "packer"
   disk_size    = 100
-  tags         = ["cloud-build-packer"]
+  image_name   = "platform-cluster-internal-instance-${var.image_version}"
+  project_id   = var.gcp_project
+  source_image = var.source_image
+  ssh_username = "packer"
+  use_iap      = true
+  zone         = "us-central1-c"
 }
 
 source "googlecompute" "platform-cluster-api-instance" {
-  project_id   = var.gcp_project
-  zone         = "us-central1-c"
-  source_image = var.source_image
-  image_name   = "platform-cluster-api-instance-${var.image_version}"
-  ssh_username = "packer"
   disk_size    = 100
-  tags         = ["cloud-build-packer"]
+  image_name   = "platform-cluster-api-instance-${var.image_version}"
+  project_id   = var.gcp_project
+  source_image = var.source_image
+  ssh_username = "packer"
+  use_iap      = true
+  zone         = "us-central1-c"
 }
 
 build {

--- a/packer/mlab.pkr.hcl
+++ b/packer/mlab.pkr.hcl
@@ -23,7 +23,6 @@ variable "source_image" {
 source "googlecompute" "platform-cluster-instance" {
   disk_size        = 100
   image_name       = "platform-cluster-instance-${var.image_version}"
-  omit_external_ip = true
   project_id       = var.gcp_project
   source_image     = var.source_image
   ssh_username     = "packer"
@@ -35,7 +34,6 @@ source "googlecompute" "platform-cluster-instance" {
 source "googlecompute" "platform-cluster-internal-instance" {
   disk_size        = 100
   image_name       = "platform-cluster-internal-instance-${var.image_version}"
-  omit_external_ip = true
   project_id       = var.gcp_project
   source_image     = var.source_image
   ssh_username     = "packer"
@@ -47,7 +45,6 @@ source "googlecompute" "platform-cluster-internal-instance" {
 source "googlecompute" "platform-cluster-api-instance" {
   disk_size        = 100
   image_name       = "platform-cluster-api-instance-${var.image_version}"
-  omit_external_ip = true
   project_id       = var.gcp_project
   source_image     = var.source_image
   ssh_username     = "packer"

--- a/packer/mlab.pkr.hcl
+++ b/packer/mlab.pkr.hcl
@@ -24,10 +24,12 @@ source "googlecompute" "platform-cluster-instance" {
   disk_size              = 100
   iap_tunnel_launch_wait = 60
   image_name             = "platform-cluster-instance-${var.image_version}"
+  omit_external_ip       = true
   project_id             = var.gcp_project
   source_image           = var.source_image
   ssh_username           = "packer"
   use_iap                = true
+  use_internal_ip        = true
   zone                   = "us-central1-c"
 }
 

--- a/packer/mlab.pkr.hcl
+++ b/packer/mlab.pkr.hcl
@@ -21,13 +21,14 @@ variable "source_image" {
 }
 
 source "googlecompute" "platform-cluster-instance" {
-  disk_size    = 100
-  image_name   = "platform-cluster-instance-${var.image_version}"
-  project_id   = var.gcp_project
-  source_image = var.source_image
-  ssh_username = "packer"
-  use_iap      = true
-  zone         = "us-central1-c"
+  disk_size              = 100
+  iap_tunnel_launch_wait = 60
+  image_name             = "platform-cluster-instance-${var.image_version}"
+  project_id             = var.gcp_project
+  source_image           = var.source_image
+  ssh_username           = "packer"
+  use_iap                = true
+  zone                   = "us-central1-c"
 }
 
 source "googlecompute" "platform-cluster-internal-instance" {

--- a/setup_packer_images.sh
+++ b/setup_packer_images.sh
@@ -34,6 +34,7 @@ else
 fi
 
 cd packer
+export PACKER_LOG=1
 packer init .
 packer build -force -debug \
   -var "gcp_project=$PROJECT" \

--- a/setup_packer_images.sh
+++ b/setup_packer_images.sh
@@ -34,11 +34,10 @@ else
 fi
 
 export PATH=$PATH:/google-cloud-sdk/bin
-export PACKER_LOG=1
 
 cd packer
 packer init .
-packer build -force -debug \
+packer build -force \
   -var "gcp_project=$PROJECT" \
   -var "image_version=$version" \
   mlab.pkr.hcl

--- a/setup_packer_images.sh
+++ b/setup_packer_images.sh
@@ -35,7 +35,7 @@ fi
 
 cd packer
 packer init .
-packer build -force \
+packer build -force -debug \
   -var "gcp_project=$PROJECT" \
   -var "image_version=$version" \
   mlab.pkr.hcl

--- a/setup_packer_images.sh
+++ b/setup_packer_images.sh
@@ -33,8 +33,10 @@ else
   version=${IMAGES_VERSION//./-}
 fi
 
-cd packer
+export PATH=$PATH:/google-cloud-sdk/bin
 export PACKER_LOG=1
+
+cd packer
 packer init .
 packer build -force -debug \
   -var "gcp_project=$PROJECT" \


### PR DESCRIPTION
This PR configures Packer to ssh to VMs it creates through IAP (Google's Identity-Aware Proxy). This allows us to generally leave public access to VMs disabled, while still allowing a method to ssh to VMs when necessary.

Additionally, this updates the build image to use the Artifact Registry URL of the build image instead of the Container Registry one, since Container Registry is deprecated and will go away next year.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/264)
<!-- Reviewable:end -->
