### PR TITLE
Adds loadbalanced=false to physical machines and standalone VMs

### DIFF
--- a/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -29,3 +29,7 @@ case "$PREFIX_LEN" in
     ;;
 esac
 echo -n "$MANAGED" > $METADATA_DIR/managed
+
+# Physical machines are not loadbalanced.
+echo -n "false" > $METADATA_DIR/loadbalanced
+

--- a/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -36,6 +36,7 @@ if [[ $is_mig == "200" ]]; then
   external_ip=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/network-interfaces/0/forwarded-ips/0")
   external_ipv6=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/network-interfaces/0/forwarded-ipv6s/0")
 else
+  echo -n "false" > $METADATA_DIR/loadbalanced
   external_ip=$(
     curl "${CURL_FLAGS[@]}" "${METADATA_URL}/network-interfaces/0/access-configs/0/external-ip"
   )


### PR DESCRIPTION
We have been adding the metadata file "loadbalanced" with a content/value of "true" to MIG instances. However, we have not been explicitly flagging non-loadbalanced machines as loadbalanced=false. This commit makes the declaration explicity for all machine types, which should make filtering in BigQuery using this field more intuitive and consitent with other fields.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/266)
<!-- Reviewable:end -->
