### PR TITLE
Wait for "forwarded-ip[v6]s" to be available from metadata server before reading value

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/write-metadata.service
@@ -2,6 +2,11 @@
 Description=Writes metadata to a known location
 Before=setup-after-boot.service
 
+# This unit writes data to the disk which gets mounted in various containers.
+# Be sure that this unit runs before the kubelet to be sure that no k8s
+# workloads start running before this unit has completed.
+Before=kubelet.service
+
 # generate-eth0-config.service sets the hostname of the machine to the expected
 # M-Lab DNS name for the machine. Since this write-metadata unit writes the
 # hostname value to the metadata directory, then be sure this unit runs later,


### PR DESCRIPTION
I discovered this week that in some cases the metadata files /var/local/metadata/external-ip and /var/local/metadata/external-ipv6 container 404 error HTML documents instead of IP addresses. It appears that there is a race between the write-metadata.service running, and when GCP has fully populated the `forwarded-ip[v6]s` metadata fields. This PR adds a simple loop to the write-metadata.sh script, but only for the case where the instance is a MIG, since it _seems_ that the other metadata fields are ready by the time write-metadata.sh runs.

This PR also adds a small modification to the write-metadata.service unit file, telling it to run before the kubelet.service. Since some of our k8s containers mount the metadata directory and use values within it, we want to be sure that this unit is complete before the kubelet starts and begins to launch containers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/267)
<!-- Reviewable:end -->
