### PR TITLE
Adds CNI config files to root fs of all machine images

### DIFF
--- a/configs/stage3_ubuntu/etc/cni/net.d/00-multus.conf
+++ b/configs/stage3_ubuntu/etc/cni/net.d/00-multus.conf
@@ -1,0 +1,9 @@
+{
+  "clusterNetwork": "flannel-conf",
+  "cniVersion": "0.3.1",
+  "kubeconfig": "/etc/kubernetes/kubelet.conf",
+  "multusNamespace": "default",
+  "name": "multus-network",
+  "type": "multus"
+}
+

--- a/configs/virtual_ubuntu/etc/cni/net.d/00-flannel.conf
+++ b/configs/virtual_ubuntu/etc/cni/net.d/00-flannel.conf
@@ -1,0 +1,20 @@
+{
+  "name": "cbr0",
+  "cniVersion": "0.3.1",
+  "plugins": [
+    {
+      "type": "flannel",
+      "delegate": {
+        "hairpinMode": true,
+        "isDefaultGateway": true
+      }
+    },
+    {
+      "type": "portmap",
+      "capabilities": {
+        "portMappings": true
+      }
+    }
+  ]
+}
+


### PR DESCRIPTION
Previously, we had a weird configuration in the k8s platform cluster with two separate flannel DaemonSets, one for physical machines and one for virtual machines. The whole point of that was writing out different CNI config files depending on the machine type. This commit just bakes those CNI configs into the filesystem to avoid that extra complexity in the cluster. Those files haven't changed in years.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/268)
<!-- Reviewable:end -->
