### PR TITLE
Make configure-tc-fq.sh agnostic to the speed of the uplink

### DIFF
--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -23,15 +23,12 @@ SPEED=$(
     | jq -r ".[\"${HOSTNAME}\"] | .Uplink"
   )
 
-# Internally, tc stores rates as 32-bit unsigned integers in bps (bytes per
+# Internally, tc stores rates as 32-bit unsigned integers in bps (*bytes* per
 # second).  Because of this, and to make comparisons easier later in the script,
-# we convert the "g" value to a bps value.
-if [[ "${SPEED}" == "40g" ]]; then
-  MAXRATE="5000000000"
-elif [[ "${SPEED}" == "10g" ]]; then
-  MAXRATE="1250000000"
-elif [[ "${SPEED}" == "1g" ]]; then
-  MAXRATE="125000000"
+# convert the "g" value to bytes/sec. The conditional assumes that $SPEED is
+# always some multiple of a gigabit.
+if [[ "${SPEED}" =~ ([0-9]+)g ]]; then
+  MAXRATE=$((${BASH_REMATCH[1]} * 1000000000 / 8))
 else
   echo "Unknown uplink speed '${SPEED}'. Not configuring default qdisc for eth0."
   write_metric_file 0

--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -26,7 +26,9 @@ SPEED=$(
 # Internally, tc stores rates as 32-bit unsigned integers in bps (bytes per
 # second).  Because of this, and to make comparisons easier later in the script,
 # we convert the "g" value to a bps value.
-if [[ "${SPEED}" == "10g" ]]; then
+if [[ "${SPEED}" == "40g" ]]; then
+  MAXRATE="5000000000"
+elif [[ "${SPEED}" == "10g" ]]; then
   MAXRATE="1250000000"
 elif [[ "${SPEED}" == "1g" ]]; then
   MAXRATE="125000000"


### PR DESCRIPTION
Having this script enforce possible uplink speed values makes it brittle. It also introduces a second place where uplink speeds must be configured, in addition to siteinfo, which is not ideal. Instead, this script shouldn't care what the uplink value is, as long as it looks like a valid speed specification.