### PR TITLE
Add small improvements to auto detection of network and disk devices

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/format-cache.service
@@ -1,8 +1,7 @@
 [Unit]
 # We want this unit to run before we mount to be sure that disk gets formatted first.
 Before=cache-data.mount cache-containerd.mount
-BindsTo=dev-sda.device
-After=dev-sda.device
+After=dev-sda.device sysinit.target
 ConditionPathExists=!/cache/data
 ConditionPathExists=!/cache/containerd
 DefaultDependencies=no

--- a/configs/stage3_ubuntu/etc/systemd/system/generate-network-config.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/generate-network-config.service
@@ -1,6 +1,5 @@
 [Unit]
 Before=network-pre.target
-After=sysinit.target
 Wants=network-pre.target
 
 [Service]

--- a/configs/stage3_ubuntu/etc/systemd/system/generate-network-config.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/generate-network-config.service
@@ -1,5 +1,6 @@
 [Unit]
 Before=network-pre.target
+After=sysinit.target
 Wants=network-pre.target
 
 [Service]

--- a/configs/stage3_ubuntu/opt/mlab/bin/generate_network_config.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/generate_network_config.sh
@@ -66,6 +66,16 @@ DNS2_IPv6=$( echo $FIELDS_IPv6 | awk -F, '{print $4}' )
 # Note, we cannot set the hostname via networkd. Use hostnamectl instead.
 hostnamectl set-hostname ${HOSTNAME}
 
+# Don't continue until ethN devices exist in /sys/class/net.
+ETH_DEVICES=""
+until [[ $ETH_DEVICES == "true" ]]; do
+  sleep 1
+  ls /sys/class/net/eth* &> /dev/null
+  if [[ $? == 0 ]]; then
+    ETH_DEVICES="true"
+  fi
+done
+
 # For network cards with multiple interfaces, the kernel may not assign eth*
 # device names in the same order between boots. Determine which eth* interface
 # has a layer 2 link, and use it as our interface. There should only be one


### PR DESCRIPTION
I found that on the Ziply machine in staging the previous changes to auto detect the network and disk devices was failing because /sys/class/net/eth* did not exist when the script was being run, and for disk devices `lsblk` was not returning anything, probably because the disks device did not yet exist in /dev. 

This PR makes the format-cache.service depend on the sysinit.target, which should help ensure that the disks have all be recognized and added to /dev. Even though we don't specifically depend on /dev/sda, I left the `After=dev-sda.device` just to add some assurance that at least that device existed, even if we end up using a different one.

For generate-network-config.sh, I found that adding a dependency on sysinit.target was not enough, so I just added a small loop to wait for eth* directories to end up /sys/class/net. Additionally, I found that the kernel does not, apparently, populate values for many of the files in /sys/class/net/eth*/ until _after_ the interface is UP. So I added an extra line to unconditionally attempt to bring every interface up before trying to read files in /sys/class/net/eth*/. I also changed from using the file "operstate" to using "carrier", which I think is more appropriate because we don't particularly care whether the interface is UP, but more whether there is a carrier/medium attached to the interface.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/273)
<!-- Reviewable:end -->
