### PR TITLE
Yet more improvements to auto device detection on boot

### DIFF
--- a/configs/stage3_ubuntu/opt/mlab/bin/format-cache.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/format-cache.sh
@@ -8,6 +8,14 @@ mkdir -p /cache
 # Clear any remaining LVM configs from prior installations.
 dmsetup remove_all --force
 
+# From the lsblk man page:
+#     Note that lsblk might be executed in time when udev does not have
+#     all information about recently added or modified devices yet. In
+#     this case it is recommended to use udevadm settle before lsblk to
+#     synchronize with udev.
+# https://man7.org/linux/man-pages/man8/lsblk.8.html
+udevadm settle
+
 # Determine which sd* device we should use. Eliminate all hotplug device types,
 # and then select the first disk that is greater than 250GB.
 DEVICE=$(

--- a/configs/stage3_ubuntu/opt/mlab/bin/generate_network_config.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/generate_network_config.sh
@@ -85,8 +85,10 @@ for i in /sys/class/net/eth*; do
   NAME=$(basename $i)
   # The kernel does not populate many of the files in /sys/class/net/<device>
   # with values until _after_ the device is up. Unconditionally attempt to
-  # bring each device up before trying to read the carrier file.
+  # bring each device up before trying to read the carrier file. Sleep briefly
+  # to give the kernel time to populate the directory.
   ip link set up dev $NAME
+  sleep 1
   CARRIER=$(cat $i/carrier)
   if [[ $CARRIER == "1" ]]; then
     DEVICE=$NAME


### PR DESCRIPTION
The previous changes for automatically detecting network and disk devices by various boot script worked fine in sandbox, but failed on mlab4-geg01. These are yet more changes that try to help that process complete successfully.

If this doesn't work for the staging GEG01 machine, then I may resort to manually building stage3 images for testing, rather than making changes I think will help in sandbox, and which work in sandbox, only to find that they don't, for some reason, work on the GEG01 machine in staging.