### PR TITLE
Adds slightly longer sleep before checking net dev carrier file

### DIFF
--- a/configs/stage3_ubuntu/opt/mlab/bin/generate_network_config.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/generate_network_config.sh
@@ -88,7 +88,7 @@ for i in /sys/class/net/eth*; do
   # bring each device up before trying to read the carrier file. Sleep briefly
   # to give the kernel time to populate the directory.
   ip link set up dev $NAME
-  sleep 1
+  sleep 2
   CARRIER=$(cat $i/carrier)
   if [[ $CARRIER == "1" ]]; then
     DEVICE=$NAME


### PR DESCRIPTION
I had previously thought that 1s was a lot of time in terms of CPU and kernel time, and it is, but there was apparently more than a 1s delay between bringing an interface up and the file /sys/class/net/eth*/carrier being populated with a value by the kernel. It seems that just changing the sleep from 1s to 2s was enough, can I can now verify that this file has the correct value when looping over interfaces.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/275)
<!-- Reviewable:end -->
