### PR TITLE
Removes the errexit shell option from generate_network_config.sh

### DIFF
--- a/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/configure_tc_fq.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -ux
+
 # This script writes out a Prometheus metric file which will be collected by the
 # node_exporter textfile collector. Make sure that METRIC_DIR exists.
 METRIC_DIR=/cache/data/node-exporter
@@ -23,8 +25,8 @@ function write_metric_file {
 # with a link. Set the default to eth0 as a fallback.
 DEVICE="eth0"
 for i in /sys/class/net/eth*; do
-  STATE=$(cat $i/operstate)
-  if [[ $STATE == "up" ]]; then
+  CARRIER=$(cat $i/carrier)
+  if [[ $CARRIER == "1" ]]; then
     DEVICE=$(basename $i)
     break
   fi

--- a/configs/stage3_ubuntu/opt/mlab/bin/generate_network_config.sh
+++ b/configs/stage3_ubuntu/opt/mlab/bin/generate_network_config.sh
@@ -4,7 +4,7 @@
 # writes a networkd configuration file for the static IP to the named file.
 # generate_network_config also sets the machine hostname.
 
-set -euxo pipefail
+set -ux
 
 OUTPUT=${1:?Please provide the name for writing config file}
 


### PR DESCRIPTION
The script runs a loop waiting for /sys/class/netc/ethN directories to exist. With errexit enabled, the script would terminate when those directories did not exist, which is counterproductive in this case. I'm sure there is some other way to get around this while still leaving the errexit option enabled, but this seemed pretty simple. Indeed, this script never had any shell options set until I added them just a week or two ago while doing other work.

This PR also modifies the configure_tc_fq.sh script to operate on the /sys/class/net/ethN/carrier file instead of "operstate", which is generate_network_config.sh already does, and was just an oversight on my part to not change it earlier, too.

Also, add `set -ux` to generate_network_config.sh, just to make debugging easier in the future if we have any issues with the script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/276)
<!-- Reviewable:end -->
