### PR TITLE
Store IATA code in /var/local/metadata/iata-code

### DIFF
--- a/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -82,3 +82,8 @@ echo -n $(uname -r) > $METADATA_DIR/kernel-version
 # For virtual machines this indicates that M-Lab manages only the machine and
 # none of the infrastructure upstream of it.
 echo -n "machine" > $METADATA_DIR/managed
+
+# Store the 3-letter IATA code. This may be used, for example, by M-Lab
+# Autojoin VMs.
+echo $HOSTNAME | sed -rn 's|.+([a-z]{3})[0-9t]{2}.+|\1|p' > $METADATA/iata-code
+

--- a/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -16,27 +16,14 @@ CURL_FLAGS=(--header "Metadata-Flavor: Google" --silent)
 
 mkdir -p $METADATA_DIR
 
-# MIG instances will have a "created-by" attribute, standalone VMs will not.
-# Record the HTTP status code of the request into a variable. 200 means
-# "created-by" exists and therefore this is a MIG instance. Any other response
-# code means it was not created by an instance group manager and is not a MIG
-# instance.  This value is used to determine whether to flag this instance as
-# loadbalanced or not. Additionally, it is used to determine which external IP
-# addresses should be recorded, those of the VM or the ones associated with a
-# load balancer.
-#
-# https://cloud.google.com/compute/docs/instance-groups/getting-info-about-migs#checking_if_a_vm_instance_is_part_of_a_mig
-is_mig=$(
-  curl "${CURL_FLAGS[@]}" --output /dev/null --write-out "%{http_code}" \
-    "${METADATA_URL}/attributes/created-by"
-)
+loadbalanced=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/attributes/loadbalanced")
+echo -n ${loadbalanced} > $METADATA_DIR/loadbalanced
 
-if [[ $is_mig == "200" ]]; then
-  # It was discovered that there is some sort of race condition between this
-  # script and GCP fully populating VM metadata, specifically the
-  # "forwarded-ip[v6]s" values, requests for which were occasionally returning a
-  # 404, other times not. This loop just makes sure that one of those values
-  # exists before trying to read the value.
+if [[ $loadbalanced == "true" ]]; then
+  # It sometimes takes a while for GCE to fully populating VM metadata,
+  # specifically the "forwarded-ip[v6]s" values, requests for which were
+  # occasionally returning a 404, other times not. This loop just makes sure
+  # that one of those values exists before trying to read the value.
   metadata_status=""
   until [[ $metadata_status == "200" ]]; do
     sleep 5

--- a/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -85,5 +85,5 @@ echo -n "machine" > $METADATA_DIR/managed
 
 # Store the 3-letter IATA code. This may be used, for example, by M-Lab
 # Autojoin VMs.
-echo $HOSTNAME | sed -rn 's|.+([a-z]{3})[0-9t]{2}.+|\1|p' > $METADATA/iata-code
+echo $HOSTNAME | sed -rn 's|.+([a-z]{3})[0-9t]{2}.+|\1|p' > $METADATA_DIR/iata-code
 


### PR DESCRIPTION
We are experimenting with having VMs leverage the Autojoin API to get a DNS name, meaning that they will no longer need to be recorded in siteinfo. Additionally, this change obviates the need to load balance VMs, since each VM in an instance group will get its own DNS name and join the cluster independently. The Autojoin system requires knowing the IATA code to register with the API. Since I could not determine any feasible way to plumb the IATA code through to the pod via k8s, this change writes the IATA code out to /var/local/metdata/iata-code, which the register container can mount and read in the value at runtime.

Additionally, since some MIGs will be loadbalanced and others not (for now), whether a machine is loadbalanced is defined in the terraform-support configs and is added to the VM's metadata on creation. Instead of trying to infer whether the VM is loadbalanced or not, there is a small change to the write-metadata.sh script to simply look at the value of the "loadbalanced" attribute of the machine's metadata. This simplifies the script and this property is now defined in terraform-support, which is more appropriate.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/277)
<!-- Reviewable:end -->
