### PR TITLE
Writes out VM Locate probability to metadata file

### DIFF
--- a/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -16,6 +16,9 @@ CURL_FLAGS=(--header "Metadata-Flavor: Google" --silent)
 
 mkdir -p $METADATA_DIR
 
+probability=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/attributes/probability")
+echo -n ${probability} > $METADATA_DIR/probability
+
 loadbalanced=$(curl "${CURL_FLAGS[@]}" "${METADATA_URL}/attributes/loadbalanced")
 echo -n ${loadbalanced} > $METADATA_DIR/loadbalanced
 


### PR DESCRIPTION
This allows autojoined VMs to have a configurable probability in terraform-support which gets plumbed through to the autonode-register container.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/278)
<!-- Reviewable:end -->
