### PR TITLE
Tell udev to ignore /dev/sr0 + removes trailing newline from IATA code file

### DIFF
--- a/configs/stage3_ubuntu/etc/udev/rules.d/90-ignore.rules
+++ b/configs/stage3_ubuntu/etc/udev/rules.d/90-ignore.rules
@@ -1,2 +1,2 @@
-KERNEL=="sr0",SUBSYSTEM=="block",OPTIONS==”ignore_device”
+KERNEL=="sr0", SUBSYSTEM=="block", ENV{UDISKS_IGNORE}="1"
 

--- a/configs/stage3_ubuntu/etc/udev/rules.d/90-ignore.rules
+++ b/configs/stage3_ubuntu/etc/udev/rules.d/90-ignore.rules
@@ -1,0 +1,2 @@
+KERNEL=="sr0",SUBSYSTEM=="block",OPTIONS==”ignore_device”
+

--- a/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
+++ b/configs/virtual_ubuntu/opt/mlab/bin/write-metadata.sh
@@ -75,5 +75,5 @@ echo -n "machine" > $METADATA_DIR/managed
 
 # Store the 3-letter IATA code. This may be used, for example, by M-Lab
 # Autojoin VMs.
-echo $HOSTNAME | sed -rn 's|.+([a-z]{3})[0-9t]{2}.+|\1|p' > $METADATA_DIR/iata-code
+echo -n $HOSTNAME | sed -rn 's|.+([a-z]{3})[0-9t]{2}.+|\1|p' > $METADATA_DIR/iata-code
 


### PR DESCRIPTION
This is an attempt to workaround this: https://github.com/m-lab/ops-tracker/issues/2046

We are seeing this issue with mlab4-ath03. Fortunately, I rebooted mlab4-ath03 and the same problem occurred again, so we should know whether this resolves the issue in staging.

Also, removes a trailing newline from the /var/local/metadata/iata-code file on VMs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/279)
<!-- Reviewable:end -->
