### PR TITLE
Updates Cloud Build to use Artifact Registry container images

### DIFF
--- a/builder.sh
+++ b/builder.sh
@@ -43,7 +43,7 @@ function stage3_coreos() {
   umask 0022
   ${SOURCE_DIR}/setup_stage3_coreos.sh \
       "${SOURCE_DIR}/configs/${target}" \
-      /go/bin/epoxy_client \
+      /root/go/bin/epoxy_client \
       http://stable.release.core-os.net/amd64-usr/${version}/coreos_production_pxe.vmlinuz \
       http://stable.release.core-os.net/amd64-usr/${version}/coreos_production_pxe_image.cpio.gz \
       "${artifacts}/coreos_custom_pxe_image.cpio.gz" &> ${SOURCE_DIR}/coreos.log \
@@ -63,7 +63,7 @@ function stage3_update() {
   echo 'Starting stage3_update build'
   ${SOURCE_DIR}/setup_stage3_update.sh \
       ${builddir} ${artifacts} ${SOURCE_DIR}/configs/${target} \
-      /go/bin/epoxy_client &> ${SOURCE_DIR}/stage3_update.log \
+      /root/go/bin/epoxy_client &> ${SOURCE_DIR}/stage3_update.log \
   || (
       tail -100 ${SOURCE_DIR}/stage3_update.log && false
   )
@@ -80,7 +80,7 @@ function stage1_minimal() {
   echo 'Starting stage1_minimal build'
   ${SOURCE_DIR}/setup_stage1_minimal.sh \
       ${builddir} ${artifacts} ${SOURCE_DIR}/configs/${target} \
-      /go/bin/epoxy_client
+      /root/go/bin/epoxy_client
 
   rm -rf ${builddir}
 }
@@ -94,7 +94,7 @@ function stage3_ubuntu() {
   echo 'Starting stage3_ubuntu build'
   ${SOURCE_DIR}/setup_stage3_ubuntu.sh \
       ${builddir} ${artifacts} ${SOURCE_DIR}/configs/${target} \
-      /go/bin/epoxy_client
+      /root/go/bin/epoxy_client
 
   rm -rf ${builddir}
 }

--- a/cloudbuild-stage1.yaml
+++ b/cloudbuild-stage1.yaml
@@ -15,20 +15,20 @@ options:
 
 steps:
 # stage1 minimal kernel & initram using stock ubuntu kernel.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
+- name: us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.2
   args: [
     '/workspace/builder.sh', 'stage1_minimal'
   ]
 
 # stage1 ROMs.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
+- name: us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.2
   args: [
     '/workspace/builder.sh', 'stage1_mlxrom'
   ]
 
 # stage1 ISOs
 # NOTE: must run after stage1_minimal so that kernel & initram are available.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
+- name: us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.2
   args: [
     '/workspace/builder.sh', 'stage1_isos'
   ]

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -18,13 +18,13 @@ availableSecrets:
 
 steps:
 # stage1 minimal kernel & initram using stock ubuntu kernel.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
+- name: us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.2
   args: [
     '/workspace/builder.sh', 'stage1_minimal'
   ]
 
 # stage3_ubuntu images.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
+- name: us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.2
   entrypoint: /bin/bash
   args:
   - '-c'
@@ -33,7 +33,7 @@ steps:
   - SSH_HOST_CA_KEY
 
 # stage3_update images.
-- name: gcr.io/$PROJECT_ID/epoxy-images:1.0
+- name: us-central1-docker.pkg.dev/$PROJECT_ID/build-images/epoxy-images:1.2
   args: [
     '/workspace/builder.sh', 'stage3_update'
   ]

--- a/simpleiso
+++ b/simpleiso
@@ -92,7 +92,7 @@ set timeout=5
 set color_highlight=black/light-magenta
 
 menuentry 'linux: ${ISO_NAME}' {
-    linuxefi  /vmlinuz $boot_params
+    linux /vmlinuz $boot_params
     $initramfs_config_efi
 }
 EOF
@@ -121,7 +121,7 @@ function make_bootefi_img() {
 
   # Make the grub efi boot loader image.
   grub-mkimage -o ${tmp}/bootx64.efi -p / -O x86_64-efi fat iso9660 part_gpt \
-      part_msdos normal boot linux linuxefi efinet lsefi lsefisystab lsefimmap \
+      part_msdos normal boot linux efinet lsefi lsefisystab lsefimmap \
       configfile loopback chain efifwsetup efi_gop efi_uga ls search \
       search_label search_fs_uuid search_fs_file gfxterm gfxterm_background \
       gfxterm_menu test all_video loadenv exfat ext2 ntfs udf


### PR DESCRIPTION
Container Registry is being retired.

Additionally, this updates the build images to v1.2, which updates the base Ubuntu image, which necessitated a few other small changes.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/281)
<!-- Reviewable:end -->
