### PR TITLE
Adds Restart=on-failure to the max-rate.service unit

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
+++ b/configs/stage3_ubuntu/etc/systemd/system/max-rate.service
@@ -6,6 +6,8 @@ Before=setup-after-boot.service
 [Service]
 Type=oneshot
 ExecStart=/opt/mlab/bin/max-rate.sh
+Restart=on-failure
+RestartSec=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Transient failures in the unit will cause ndt-server to crashloop, since it requires the output of this service. This should cause systemd to restart the service every 5 seconds until it succeeds.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/289)
<!-- Reviewable:end -->
