### PR TITLE
qSet containerd LimitNOFILE so containers inherit a high open-file limit

### DIFF
--- a/configs/stage3_ubuntu/etc/systemd/system/containerd.service.d/20-limit-nofile.conf
+++ b/configs/stage3_ubuntu/etc/systemd/system/containerd.service.d/20-limit-nofile.conf
@@ -1,0 +1,13 @@
+# containerd 2.x (which arrived on platform machines via the Ubuntu jammy
+# security update that bumped the containerd package from 1.7.x to 2.x) no
+# longer sets a high LimitNOFILE on its packaged systemd unit. As a result the
+# containerd daemon — and every container that inherits the daemon's rlimits —
+# defaults to a soft RLIMIT_NOFILE of only 1024. Services that do not raise
+# their own soft limit at startup (e.g. pusher) then exhaust it, which silently
+# stalls data uploads and loses data. Restore the previously-effective high
+# default on the daemon so all containers inherit it again.
+#
+# Note: this must set a high *soft* limit (not just hard), because the affected
+# services do not raise their own soft limit. LimitNOFILE=N sets soft=hard=N.
+[Service]
+LimitNOFILE=1048576

--- a/configs/virtual_ubuntu/etc/systemd/system/containerd.service.d/20-limit-nofile.conf
+++ b/configs/virtual_ubuntu/etc/systemd/system/containerd.service.d/20-limit-nofile.conf
@@ -1,0 +1,1 @@
+../../../../../stage3_ubuntu/etc/systemd/system/containerd.service.d/20-limit-nofile.conf


### PR DESCRIPTION
containerd 2.x (arrived via the Ubuntu jammy-security update that bumped the containerd package from 1.7.x to 2.x) no longer sets a high LimitNOFILE on its systemd unit, so the daemon and every container that inherits its rlimits default to a soft RLIMIT_NOFILE of 1024. Services that do not raise their own soft limit (e.g. pusher) then exhaust it, stalling data uploads.

Add a containerd.service.d drop-in setting LimitNOFILE=1048576 for both physical (stage3_ubuntu) and virtual (virtual_ubuntu, via symlink) images. Takes effect on image rebuild + reboot.

Co-Authored-By: Claude Opus 4.8

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/290)
<!-- Reviewable:end -->
