### PR TITLE
Add GCP zone fallback for Packer image builds

### DIFF
--- a/packer/google-oim.pkr.hcl
+++ b/packer/google-oim.pkr.hcl
@@ -26,6 +26,12 @@ variable "api_key" {
   type = string
 }
 
+variable "zone" {
+  default = "us-central1-c"
+  description = "GCE zone for the temporary Packer builder VM. Overridden per-attempt by the zone-fallback loop in setup_packer_google_oim_images.sh (see packer/zone_fallback.sh), which retries other zones on ZONE_RESOURCE_POOL_EXHAUSTED."
+  type = string
+}
+
 source "googlecompute" "google-oim-instance" {
   disk_size        = 100
   image_name       = "google-oim-instance-${var.version}"
@@ -34,7 +40,7 @@ source "googlecompute" "google-oim-instance" {
   ssh_username     = "packer"
   use_iap          = true
   use_internal_ip  = true
-  zone             = "us-central1-f"
+  zone             = var.zone
 }
 
 build {

--- a/packer/mlab.pkr.hcl
+++ b/packer/mlab.pkr.hcl
@@ -20,6 +20,12 @@ variable "source_image" {
   type = string
 }
 
+variable "zone" {
+  default = "us-central1-c"
+  description = "GCE zone for the temporary Packer builder VM. Overridden per-attempt by the zone-fallback loop in setup_packer_images.sh (see packer/zone_fallback.sh), which retries other zones on ZONE_RESOURCE_POOL_EXHAUSTED."
+  type = string
+}
+
 source "googlecompute" "platform-cluster-instance" {
   disk_size        = 100
   image_name       = "platform-cluster-instance-${var.image_version}"
@@ -28,7 +34,7 @@ source "googlecompute" "platform-cluster-instance" {
   ssh_username     = "packer"
   use_iap          = true
   use_internal_ip  = true
-  zone             = "us-central1-c"
+  zone             = var.zone
 }
 
 source "googlecompute" "platform-cluster-internal-instance" {
@@ -39,7 +45,7 @@ source "googlecompute" "platform-cluster-internal-instance" {
   ssh_username     = "packer"
   use_iap          = true
   use_internal_ip  = true
-  zone             = "us-central1-c"
+  zone             = var.zone
 }
 
 source "googlecompute" "platform-cluster-api-instance" {
@@ -50,7 +56,7 @@ source "googlecompute" "platform-cluster-api-instance" {
   ssh_username     = "packer"
   use_iap          = true
   use_internal_ip  = true
-  zone             = "us-central1-c"
+  zone             = var.zone
 }
 
 build {

--- a/packer/zone_fallback.sh
+++ b/packer/zone_fallback.sh
@@ -36,8 +36,11 @@ packer_build_with_zone_fallback() {
       return 0
     fi
 
-    if grep -q "ZONE_RESOURCE_POOL_EXHAUSTED" "${build_log}"; then
-      echo "=== Zone ${zone} has no capacity (ZONE_RESOURCE_POOL_EXHAUSTED); trying the next zone ==="
+    # Packer surfaces zone capacity exhaustion as the human-readable GCE message
+    # "does not have enough resources available", not the raw
+    # ZONE_RESOURCE_POOL_EXHAUSTED error code. Match either, case-insensitively.
+    if grep -qiE "does not have enough resources|ZONE_RESOURCE_POOL_EXHAUSTED" "${build_log}"; then
+      echo "=== Zone ${zone} has no capacity; trying the next zone ==="
       rm -f "${build_log}"
       continue
     fi

--- a/packer/zone_fallback.sh
+++ b/packer/zone_fallback.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+#
+# Shared helper for running `packer build` with automatic GCP zone fallback.
+#
+# Packer must create a temporary builder VM to produce each image, and lately we
+# frequently hit ZONE_RESOURCE_POOL_EXHAUSTED when a single GCP zone is out of
+# capacity for the builder's machine type. This helper tries a list of candidate
+# zones (spread across several US regions, all reachable on the default
+# auto-mode network) until one succeeds. It only advances to the next zone on a
+# capacity error; any other failure is a real build error and aborts
+# immediately, so genuine bugs are not masked by silently cycling through zones.
+#
+# Override the candidate list by exporting $PACKER_ZONES (space-separated).
+#
+# Usage (from within the packer/ directory):
+#   source ./zone_fallback.sh
+#   packer_build_with_zone_fallback <template.pkr.hcl> [extra packer build args...]
+
+PACKER_ZONES="${PACKER_ZONES:-us-central1-c us-central1-a us-central1-b us-central1-f us-east1-b us-east1-c us-east1-d us-east4-a us-east4-b us-east4-c us-west1-a us-west1-b us-west1-c}"
+
+packer_build_with_zone_fallback() {
+  local template="$1"; shift
+  local zone build_log pstatus
+
+  for zone in $PACKER_ZONES; do
+    echo "=== Attempting Packer build of ${template} in zone: ${zone} ==="
+    build_log="$(mktemp)"
+
+    # Use PIPESTATUS to read packer's exit code rather than tee's.
+    packer build -force -var "zone=${zone}" "$@" "${template}" 2>&1 | tee "${build_log}"
+    pstatus="${PIPESTATUS[0]}"
+
+    if [[ "${pstatus}" -eq 0 ]]; then
+      echo "=== Packer build of ${template} succeeded in zone: ${zone} ==="
+      rm -f "${build_log}"
+      return 0
+    fi
+
+    if grep -q "ZONE_RESOURCE_POOL_EXHAUSTED" "${build_log}"; then
+      echo "=== Zone ${zone} has no capacity (ZONE_RESOURCE_POOL_EXHAUSTED); trying the next zone ==="
+      rm -f "${build_log}"
+      continue
+    fi
+
+    echo "=== Packer build of ${template} failed in zone ${zone} for a non-capacity reason (exit ${pstatus}); aborting ==="
+    rm -f "${build_log}"
+    return "${pstatus}"
+  done
+
+  echo "=== ERROR: Packer build of ${template} did not succeed in any candidate zone ==="
+  return 1
+}

--- a/setup_packer_google_oim_images.sh
+++ b/setup_packer_google_oim_images.sh
@@ -6,8 +6,11 @@ export PATH=$PATH:/google-cloud-sdk/bin
 
 cd packer
 packer init .
-packer build -force \
+# Build the image, retrying across candidate zones when one is out of capacity.
+# See packer/zone_fallback.sh.
+# shellcheck source=packer/zone_fallback.sh
+source ./zone_fallback.sh
+packer_build_with_zone_fallback google-oim.pkr.hcl \
   -var "gcp_project=$PROJECT" \
   -var "version=$version" \
-  -var "api_key=$GOOGLE_OIM_AUTOJOIN_API_KEY" \
-  google-oim.pkr.hcl
+  -var "api_key=$GOOGLE_OIM_AUTOJOIN_API_KEY"

--- a/setup_packer_images.sh
+++ b/setup_packer_images.sh
@@ -37,7 +37,10 @@ export PATH=$PATH:/google-cloud-sdk/bin
 
 cd packer
 packer init .
-packer build -force \
+# Build the image, retrying across candidate zones when one is out of capacity.
+# See packer/zone_fallback.sh.
+# shellcheck source=packer/zone_fallback.sh
+source ./zone_fallback.sh
+packer_build_with_zone_fallback mlab.pkr.hcl \
   -var "gcp_project=$PROJECT" \
-  -var "image_version=$version" \
-  mlab.pkr.hcl
+  -var "image_version=$version"


### PR DESCRIPTION
Packer image builds (platform-cluster and google-oim) have been failing
intermittently with ZONE_RESOURCE_POOL_EXHAUSTED when a single GCP zone is out
of capacity for the builder VM's machine type. There is no API to pre-check
zone capacity, so add packer/zone_fallback.sh: a shared helper that runs
`packer build` across a list of candidate zones (spread across several US
regions, all on the default auto-mode network) until one succeeds. It advances
to the next zone only on a capacity error; any other failure aborts immediately
so real build errors are not masked. Override the list with $PACKER_ZONES.

The zone is now a Packer variable (var.zone) in both templates, set per attempt
by the helper.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/epoxy-images/291)
<!-- Reviewable:end -->
